### PR TITLE
 GraphQLServer should support resolvers array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,10 +109,9 @@ export class GraphQLServer {
         directiveResolvers,
         schemaDirectives,
         typeDefs: typeDefsString,
-        resolvers: {
-          ...uploadMixin,
-          ...resolvers,
-        },
+        resolvers: Array.isArray(resolvers)
+          ? resolvers.concat(uploadMixin)
+          : {...uploadMixin, ...resolvers},
         resolverValidationOptions,
       })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class GraphQLServer {
         schemaDirectives,
         typeDefs: typeDefsString,
         resolvers: Array.isArray(resolvers)
-          ? resolvers.concat(uploadMixin)
+          ? [uploadMixin].concat(resolvers)
           : {...uploadMixin, ...resolvers},
         resolverValidationOptions,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,7 @@ export interface Props {
     [name: string]: typeof SchemaDirectiveVisitor
   }
   typeDefs?: ITypeDefinitions
-  resolvers?: IResolvers
+  resolvers?: IResolvers | Array<IResolvers>
   resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
   context?: Context | ContextCallback
@@ -127,7 +127,7 @@ export interface LambdaProps {
     [name: string]: typeof SchemaDirectiveVisitor
   }
   typeDefs?: string
-  resolvers?: IResolvers
+  resolvers?: IResolvers | Array<IResolvers>
   schema?: GraphQLSchema
   context?: Context | ContextCallback
   options?: LambdaOptions


### PR DESCRIPTION
The `makeExecutableSchema` supports array of resolvers object. See here: https://github.com/apollographql/graphql-tools/commit/4a01e320af2baafaa5061468259a851cdf0a121c#diff-53c166a92b2ab6f8eb06f41410bd4860

Although, GraphQLServer breaks this feature. One can't pass an array, the `makeExecutableSchema` throws `Error: "0" defined in resolvers, but not in schema`.