### PR TITLE
fix modular example

### DIFF
--- a/examples/modular-resolvers/resolvers/index.ts
+++ b/examples/modular-resolvers/resolvers/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { fileLoader } from 'merge-graphql-schemas'
+import { fileLoader, mergeResolvers } from 'merge-graphql-schemas'
 
 /* MANUAL APPROACH: Update this file manually with each resolver file */
 // import userResolvers from "./user.resolvers";
@@ -10,4 +10,4 @@ import { fileLoader } from 'merge-graphql-schemas'
     with ".resolvers.[js/ts]" naming convention */
 const resolvers = fileLoader(path.join(__dirname, './**/*.resolvers.*'))
 
-export default resolvers
+export default mergeResolvers(resolvers)


### PR DESCRIPTION
Small fix to make the modular example work. Currently it fails with error `Error: "0" defined in resolvers, but not in schema`