### PR TITLE
fix: node 13 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "graphql-playground-middleware-lambda": "1.7.12",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^4.0.0",
-    "graphql-upload": "^8.0.0",
+    "graphql-upload": "^10.0.0",
     "subscriptions-transport-ws": "^0.9.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi there,

The file upload doesn't work on Node 13 and produces this error:
```
RangeError: Maximum call stack size exceeded
```
The source is on the old `graphql-upload` which is fixed in the new version:
https://github.com/jaydenseric/graphql-upload/issues/170