### PR TITLE
chore(deps): Remove graphql types stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/aws-lambda": "8.10.13",
     "@types/cors": "^2.8.4",
     "@types/express": "^4.11.1",
-    "@types/graphql": "^14.0.0",
     "@types/graphql-deduplicator": "^2.0.0",
     "@types/zen-observable": "^0.5.3",
     "apollo-server-express": "^1.3.6",


### PR DESCRIPTION
The `graphql` package has had its own types for quite some time now. You can see [here](https://www.npmjs.com/package/@types/graphql) that `@types/graphql` is deprecated.

This is causing a type mismatch (namely `GraphQLSchema`) for me trying to use `type-graphql` with `graphql-yoga` which is the reason for submitting this PR.