### PR TITLE
Use File interface in resolvers, Blob as scalar name and Response as a return type of inject

### DIFF
--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -47,6 +47,7 @@
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-yoga/core": "workspace:*",
     "@graphql-yoga/handler": "workspace:*",
+    "cross-undici-fetch": "^0.1.4",
     "fastify": "^3.24.0",
     "fastify-cors": "^6.0.2",
     "pino": "^7.2.0",

--- a/packages/graphql-yoga/src/types.ts
+++ b/packages/graphql-yoga/src/types.ts
@@ -20,13 +20,17 @@ export type GraphQLServerOptions = BaseNodeGraphQLServerOptions & {
 export type GraphQLServerInject<
   TData = any,
   TVariables = Record<string, any>,
-> = {
-  /** GraphQL Operation to execute */
-  document: string | DocumentNode | TypedDocumentNode<TData, TVariables>
-  /** Variables for GraphQL Operation */
-  variables?: TVariables
-  /** Name for GraphQL Operation */
-  operationName?: string
-  /** Set any headers for the GraphQL request */
-  headers?: IncomingHttpHeaders | OutgoingHttpHeaders
+  > = {
+    /** GraphQL Operation to execute */
+    document: string | TypedDocumentNode<TData, TVariables>
+    /** Variables for GraphQL Operation */
+    variables?: TVariables
+    /** Name for GraphQL Operation */
+    operationName?: string
+    /** Set any headers for the GraphQL request */
+    headers?: IncomingHttpHeaders | OutgoingHttpHeaders
+  }
+
+export type TypedResponse<TBody = any> = Omit<Response, 'json'> & {
+  json: () => Promise<TBody>
 }

--- a/packages/graphql-yoga/test-utils/schema.ts
+++ b/packages/graphql-yoga/test-utils/schema.ts
@@ -4,7 +4,7 @@ import {
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql'
-import { GraphQLUpload } from 'graphql-yoga'
+import { GraphQLBlob } from 'graphql-yoga'
 
 export const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -32,13 +32,12 @@ export const schema = new GraphQLSchema({
         args: {
           image: {
             description: 'Image file to upload',
-            type: GraphQLUpload,
+            type: GraphQLBlob,
           },
         },
-        resolve: async (_, { image }, { logger }) => {
-          const img = await image
-          logger.debug(img)
-          return !!img.filename
+        resolve: async (_, { image }: { image: File }, { logger }) => {
+          logger.debug(image)
+          return !!image.name
         },
       },
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,7 +3187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-undici-fetch@npm:0.1.4":
+"cross-undici-fetch@npm:0.1.4, cross-undici-fetch@npm:^0.1.4":
   version: 0.1.4
   resolution: "cross-undici-fetch@npm:0.1.4"
   dependencies:
@@ -4146,6 +4146,7 @@ fsevents@~2.1.2:
     "@graphql-yoga/handler": "workspace:*"
     "@types/node": ^16.11.7
     bob-the-bundler: ^1.5.1
+    cross-undici-fetch: ^0.1.4
     fastify: ^3.24.0
     fastify-cors: ^6.0.2
     graphql: ^16.0.1


### PR DESCRIPTION
Not sure about W3 Response there but W3 Response there might be future proof for `defer/stream` and subscriptions. Also a flag for `multipart` might be good in case of file upload/multipart request