### PR TITLE
cross platform events

### DIFF
--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -20,9 +20,11 @@ yarn start   # or npm start
 
 ## Testing
 
-Open your browser at [http://localhost:4000](http://localhost:4000) and start a subscription.
+### Counter
 
-Paste the following subscription in the editor (left side) of the Playground:
+Open your browser at [http://localhost:4000](http://localhost:4000).
+
+Paste the following subscription in the editor (left side) of GraphiQL:
 
 ```graphql
 subscription {
@@ -30,7 +32,9 @@ subscription {
 }
 ```
 
-The counter will increment every two seconds and the corresponding data is received in the Playground:
+Press the Play (Execute Query) button.
+
+The counter will increment every second and the corresponding data is received in the Playground:
 
 ```json
 {
@@ -52,3 +56,59 @@ The counter will increment every two seconds and the corresponding data is recei
 }
 // ...
 ```
+
+### Global counter
+
+Open your browser at [http://localhost:4000](http://localhost:4000)n.
+
+Paste the following subscription in the editor (left side) of GraphiQL:
+
+```graphql
+subscription {
+  globalCounter
+}
+```
+
+Press the Play (Execute Query) button.
+
+You will receive this initial result:
+
+```json
+{
+  "data": {
+    "globalCounter": 0,
+  }
+}
+```
+
+Open another browser window and execute the following mutation:
+
+```graphql
+mutation {
+  incrementGlobalCounter
+}
+```
+
+Press the Play (Execute Query) button.
+
+You will receive this result:
+
+```json
+{
+  "data": {
+    "incrementGlobalCounter": 1,
+  }
+}
+```
+
+On the other window that is executing the subscription, you will receive a new result.
+
+```json
+{
+  "data": {
+    "globalCounter": 1,
+  }
+}
+```
+
+As you re-execute the mutation the global counter will be further incremented.

--- a/examples/subscriptions/src/index.ts
+++ b/examples/subscriptions/src/index.ts
@@ -1,3 +1,4 @@
+import { useErrorHandler } from "@envelop/core";
 import { GraphQLServer, useExtendContext, createChannelPubSub } from "graphql-yoga";
 
 const typeDefs = `
@@ -30,10 +31,12 @@ const resolvers = {
   },
 };
 
+const pubSub = createChannelPubSub()
+
 const server = new GraphQLServer({
   typeDefs,
   resolvers,
-  plugins: [useExtendContext(() => ({ pubSub: createChannelPubSub() }))],
+  plugins: [useExtendContext(() => ({ pubSub }))],
 });
 
 server.start();

--- a/examples/subscriptions/src/index.ts
+++ b/examples/subscriptions/src/index.ts
@@ -1,33 +1,69 @@
-import { useErrorHandler } from "@envelop/core";
 import { GraphQLServer, useExtendContext, createChannelPubSub } from "graphql-yoga";
 
-const typeDefs = `
+const wait = (time: number) => new Promise((resolve) => setTimeout(resolve, time))
+
+const typeDefs = /* GraphQL */ `
   type Query {
+    """
+    Simple field that return a "Hello world!" string.
+    """
     hello: String!
   }
 
   type Subscription {
+    """
+    Count up from 0 to Infinity.
+    """
     counter: Int!
+    """
+    Subscribe to the global counter that can be incremented with the 'incrementGlobalCounter' mutation.
+    """
+    globalCounter: Int!
+  }
+
+  type Mutation {
+    """
+    Increment the global counter by one. Returns the current global counter value after incrementing.
+    """
+    incrementGlobalCounter: Int!
   }
 `;
 
+let globalCounter = 0
+
 const resolvers = {
   Query: {
-    hello: () => `Hello`,
+    hello: () => `Hello world!`,
   },
   Subscription: {
     counter: {
-      subscribe: (_, __, { pubSub, logger }) => {
-        // Create a random channel so each request gets its own subscription.
-        // In real life, this can be dependent on the user's session.
-        const channelName = `counter:${(Math.random() * 2).toString()}`;
-        let count = 0;
-        logger.info(`Subscribing to ${channelName}`);
-        setInterval(() => pubSub.publish(channelName, count++), 1000);
-        return pubSub.subscribe(channelName);
+      subscribe: async function* () {
+        let counter = 0;
+
+        // count up until the subscription is terminated
+        while (true) {
+          yield counter++
+          await wait(1000)
+        }
       },
       resolve: (payload) => payload,
     },
+    globalCounter: {
+      subscribe: async function * (_source, _args, context) {
+        // as soon as a client subscribes to this field we want to send him the latest value.
+        yield globalCounter
+        // after the initial value has been sent, we send new values to the client as the counter has been incremented.
+        yield* context.pubSub.subscribe("global:counter")
+      },
+      resolve: (payload) => payload,
+    },
+  },
+  Mutation: {
+    incrementGlobalCounter: (_source, _args, context) => {
+      globalCounter++
+      context.pubSub.publish("global:counter", globalCounter)
+      return globalCounter
+    }
   },
 };
 

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -47,6 +47,7 @@
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-yoga/core": "0.2.0-alpha.1",
     "@graphql-yoga/handler": "0.2.0-alpha.0",
+    "@n1ru4l/push-pull-async-iterable-iterator": "^3.1.0",
     "light-my-request": "^4.7.0",
     "pino": "^7.2.0",
     "pino-pretty": "^7.2.0"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -47,8 +47,6 @@
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-yoga/core": "0.2.0-alpha.1",
     "@graphql-yoga/handler": "0.2.0-alpha.0",
-    "@ungap/event": "^0.2.2",
-    "@ungap/event-target": "^0.2.3",
     "light-my-request": "^4.7.0",
     "pino": "^7.2.0",
     "pino-pretty": "^7.2.0"
@@ -56,6 +54,8 @@
   "devDependencies": {
     "@types/eventsource": "^1",
     "@types/node": "^16.11.7",
+    "@ungap/event": "^0.2.2",
+    "@ungap/event-target": "^0.2.3",
     "bob-the-bundler": "^1.5.1",
     "eventsource": "^1.1.0",
     "graphql": "^16.0.1"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -47,6 +47,8 @@
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-yoga/core": "0.2.0-alpha.1",
     "@graphql-yoga/handler": "0.2.0-alpha.0",
+    "@ungap/event": "^0.2.2",
+    "@ungap/event-target": "^0.2.3",
     "light-my-request": "^4.7.0",
     "pino": "^7.2.0",
     "pino-pretty": "^7.2.0"

--- a/packages/graphql-yoga/src/events.d.ts
+++ b/packages/graphql-yoga/src/events.d.ts
@@ -1,0 +1,3 @@
+declare module '@ungap/event' {
+  export default Event
+}

--- a/packages/graphql-yoga/src/events.d.ts
+++ b/packages/graphql-yoga/src/events.d.ts
@@ -1,3 +1,0 @@
-declare module '@ungap/event' {
-  export default Event
-}

--- a/packages/graphql-yoga/src/pubsub.ts
+++ b/packages/graphql-yoga/src/pubsub.ts
@@ -1,8 +1,44 @@
-import EventTarget from '@ungap/event-target'
-import Event from '@ungap/event'
-
 type PubSubPublishArgsByKey = {
   [key: string]: [any] | [number | string, any]
+}
+
+type EventAPI = {
+  Event: typeof Event
+  EventTarget: typeof EventTarget
+}
+
+type ChannelPubSubConfig = {
+  /**
+   * Event and EventTarget implementation.
+   * Providing this is mandatory for a Node.js version below 14.
+   */
+  event?: EventAPI
+}
+
+const resolveGlobalConfig = (api: EventAPI = globalThis): EventAPI => {
+  if (!api.Event || !api.EventTarget) {
+    throw new Error(`
+      [graphql-yoga] 'createChannelPubSub' uses the Event and EventTarget APIs.
+
+In modern JavaScript environments those are part of the global scope. However, if you are using an older version of Node.js (<= 16.x.x), those APIs must be polyfilled.
+You can provide polyfills to the 'createChannelPubSub' function:
+
+\`\`\`
+// yarn install @ungap/event @ungap/event-target
+import Event from '@ungap/event'
+import EventTarget from '@ungap/event-target'
+
+const pubSub = createChannelPubSub({
+  event: {
+    Event,
+    EventTarget,
+  }
+})
+\`\`\`
+`)
+  }
+
+  return globalThis
 }
 
 /**
@@ -10,7 +46,11 @@ type PubSubPublishArgsByKey = {
  */
 export const createChannelPubSub = <
   TPubSubPublishArgsByKey extends PubSubPublishArgsByKey,
->() => {
+>(
+  config?: ChannelPubSubConfig,
+) => {
+  const { Event, EventTarget } = resolveGlobalConfig(config?.event)
+
   const target = new EventTarget()
 
   return {
@@ -22,9 +62,7 @@ export const createChannelPubSub = <
       ;(event as any).data = args[0]
       target.dispatchEvent(event)
     },
-    subscribe: async function* <
-      TKey extends Extract<keyof TPubSubPublishArgsByKey, string>,
-    >(
+    subscribe<TKey extends Extract<keyof TPubSubPublishArgsByKey, string>>(
       ...[routingKey, id]: TPubSubPublishArgsByKey[TKey][1] extends undefined
         ? [TKey]
         : [TKey, TPubSubPublishArgsByKey[TKey][0]]
@@ -36,32 +74,36 @@ export const createChannelPubSub = <
       const topic =
         id === undefined ? routingKey : `${routingKey}:${id as number}`
 
-      const pushQueue: Array<Event> = []
-      const pullQueue: Array<(event: Event) => void> = []
-      const handler = (event: Event) => {
-        const nextResolve = pullQueue.shift()
-        if (nextResolve) {
-          nextResolve(event)
-        } else {
-          pushQueue.push(event)
-        }
-      }
-      target.addEventListener(topic, handler)
-
-      const pullValue = (): Promise<Event> =>
-        new Promise((resolve) => {
-          const nextEvent = pushQueue.shift()
-          if (nextEvent) {
-            resolve(nextEvent)
+      const source = (async function* () {
+        const pushQueue: Array<Event> = []
+        const pullQueue: Array<(event: Event) => void> = []
+        const handler = (event: Event) => {
+          const nextResolve = pullQueue.shift()
+          if (nextResolve) {
+            nextResolve(event)
           } else {
-            pullQueue.push(resolve)
+            pushQueue.push(event)
           }
-        })
+        }
+        target.addEventListener(topic, handler)
 
-      while (true) {
-        const event = await pullValue()
-        yield (event as any).data
-      }
+        const pullValue = (): Promise<Event> =>
+          new Promise((resolve) => {
+            const nextEvent = pushQueue.shift()
+            if (nextEvent) {
+              resolve(nextEvent)
+            } else {
+              pullQueue.push(resolve)
+            }
+          })
+
+        while (true) {
+          const event = await pullValue()
+          yield (event as any).data
+        }
+      })()
+
+      return source
     },
   }
 }

--- a/packages/graphql-yoga/src/pubsub.ts
+++ b/packages/graphql-yoga/src/pubsub.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, on } from 'events'
+import EventTarget from '@ungap/event-target'
+import Event from '@ungap/event'
 
 type PubSubPublishArgsByKey = {
   [key: string]: [any] | [number | string, any]
@@ -10,18 +11,16 @@ type PubSubPublishArgsByKey = {
 export const createChannelPubSub = <
   TPubSubPublishArgsByKey extends PubSubPublishArgsByKey,
 >() => {
-  const emitter = new EventEmitter()
+  const target = new EventTarget()
 
   return {
     publish: <TKey extends Extract<keyof TPubSubPublishArgsByKey, string>>(
       routingKey: TKey,
       ...args: TPubSubPublishArgsByKey[TKey]
     ) => {
-      if (args[1] !== undefined) {
-        emitter.emit(`${routingKey}:${args[0] as number}`, args[1])
-      }
-
-      emitter.emit(routingKey, args[0])
+      const event = new Event(routingKey)
+      ;(event as any).data = args[0]
+      target.dispatchEvent(event)
     },
     subscribe: async function* <
       TKey extends Extract<keyof TPubSubPublishArgsByKey, string>,
@@ -34,12 +33,34 @@ export const createChannelPubSub = <
         ? TPubSubPublishArgsByKey[TKey][0]
         : TPubSubPublishArgsByKey[TKey][1]
     > {
-      const asyncIterator = on(
-        emitter,
-        id === undefined ? routingKey : `${routingKey}:${id as number}`,
-      )
-      for await (const [value] of asyncIterator) {
-        yield value as any
+      const topic =
+        id === undefined ? routingKey : `${routingKey}:${id as number}`
+
+      const pushQueue: Array<Event> = []
+      const pullQueue: Array<(event: Event) => void> = []
+      const handler = (event: Event) => {
+        const nextResolve = pullQueue.shift()
+        if (nextResolve) {
+          nextResolve(event)
+        } else {
+          pushQueue.push(event)
+        }
+      }
+      target.addEventListener(topic, handler)
+
+      const pullValue = (): Promise<Event> =>
+        new Promise((resolve) => {
+          const nextEvent = pushQueue.shift()
+          if (nextEvent) {
+            resolve(nextEvent)
+          } else {
+            pullQueue.push(resolve)
+          }
+        })
+
+      while (true) {
+        const event = await pullValue()
+        yield (event as any).data
       }
     },
   }

--- a/packages/graphql-yoga/src/pubsub.ts
+++ b/packages/graphql-yoga/src/pubsub.ts
@@ -10,7 +10,7 @@ type EventAPI = {
 type ChannelPubSubConfig = {
   /**
    * Event and EventTarget implementation.
-   * Providing this is mandatory for a Node.js version below 14.
+   * Providing this is mandatory for a Node.js versions below 16.
    */
   event?: EventAPI
 }

--- a/website/docs/quick-start.mdx
+++ b/website/docs/quick-start.mdx
@@ -4,10 +4,11 @@ title: Quick Start
 sidebar_label: Quick Start
 ---
 
-GraphQL Yoga is a batteries-included cross-platform [GraphQL over HTTP spec-compliant](https://github.com/graphql/graphql-over-http) GraphQL Server.
-It builds a GraphQL Server using [GraphQL Helix](https://www.graphql-helix.com/), [Envelop](https://envelop.dev) and [GraphQL Tools](https://graphql-tools.com).
+GraphQL Yoga is a batteries-included cross-platform [GraphQL over HTTP spec-compliant](https://github.com/graphql/graphql-over-http) GraphQL Server using [GraphQL Helix](https://www.graphql-helix.com/), [Envelop](https://envelop.dev) and [GraphQL Tools](https://graphql-tools.com).
 
 ## Installation
+
+> When using Node.js we recommend at least using version **16**. Using an older LTS version (such as 14) is still possible, but requires polyfilling APIs when using some features of GraphQL Yoga. You will receive user-friendly error messages that guide you on installing those polyfills.
 
 <PackageInstall packages={['graphql', 'graphql-yoga@alpha']} />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,6 +3462,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@n1ru4l/push-pull-async-iterable-iterator@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@n1ru4l/push-pull-async-iterable-iterator@npm:3.1.0"
+  checksum: 1762a3c9b8c131e575c375450a408360551ae47b7c481c8115a73e2533ded134cc1d365e02c8c058c281b8b91764041568a0525250346c64fe57825877d4d5ab
+  languageName: node
+  linkType: hard
+
 "@napi-rs/triples@npm:1.0.3":
   version: 1.0.3
   resolution: "@napi-rs/triples@npm:1.0.3"
@@ -8001,6 +8008,7 @@ fsevents@~2.1.2:
     "@graphql-typed-document-node/core": ^3.1.1
     "@graphql-yoga/core": 0.2.0-alpha.1
     "@graphql-yoga/handler": 0.2.0-alpha.0
+    "@n1ru4l/push-pull-async-iterable-iterator": ^3.1.0
     "@types/eventsource": ^1
     "@types/node": ^16.11.7
     "@ungap/event": ^0.2.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,6 +4282,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ungap/event-target@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@ungap/event-target@npm:0.2.3"
+  checksum: 7d17c624ea3f96b7a294802267d1a574b71b05e4bbf191a26f8e5ab5b2db3e07d589223cf3af953016b38eb10f3d4306e2b6174bf4405e73d25664a26a12c1c3
+  languageName: node
+  linkType: hard
+
+"@ungap/event@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@ungap/event@npm:0.2.2"
+  checksum: 0bce8fc737c069c72203014b1f40ea473497fe40dba6f55415c2b668ba49d4a87860dd4f36c4ccf10504addacc69bfc5acca7f3370e76cc0fae012e6ce904adc
+  languageName: node
+  linkType: hard
+
 "@vercel/ncc@npm:0.28.3":
   version: 0.28.3
   resolution: "@vercel/ncc@npm:0.28.3"
@@ -7989,6 +8003,8 @@ fsevents@~2.1.2:
     "@graphql-yoga/handler": 0.2.0-alpha.0
     "@types/eventsource": ^1
     "@types/node": ^16.11.7
+    "@ungap/event": ^0.2.2
+    "@ungap/event-target": ^0.2.3
     bob-the-bundler: ^1.5.1
     eventsource: ^1.1.0
     graphql: ^16.0.1


### PR DESCRIPTION
Event and EventTarget are not available as globals within Node.js 14, but starting Node.js 16.

```ts
import EventTarget from '@ungap/event-target'
import Event from '@ungap/event'
```