### PR TITLE
fix: scoped resource subscriptions

### DIFF
--- a/.changeset/funny-flies-boil.md
+++ b/.changeset/funny-flies-boil.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/subscription': patch
+---
+
+fix publishing values when using the id argument for granular resource based subscriptions

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -57,8 +57,6 @@
   "devDependencies": {
     "@types/eventsource": "^1",
     "@types/node": "^16.11.7",
-    "@ungap/event": "^0.2.2",
-    "@ungap/event-target": "^0.2.3",
     "bob-the-bundler": "^1.5.1",
     "eventsource": "^1.1.0",
     "graphql": "^16.0.1",

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -47,8 +47,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@ungap/event-target": "0.2.3",
-    "@ungap/event": "0.2.2",
+    "event-target-polyfill": "0.0.3",
     "bob-the-bundler": "^1.5.1"
   }
 }

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -47,6 +47,8 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@ungap/event-target": "0.2.3",
+    "@ungap/event": "0.2.2",
     "bob-the-bundler": "^1.5.1"
   }
 }

--- a/packages/subscription/src/createPubSub.spec.ts
+++ b/packages/subscription/src/createPubSub.spec.ts
@@ -1,0 +1,118 @@
+import { createPubSub } from './createPubSub'
+
+async function collectAsyncIterableValues<TType>(
+  asyncIterable: AsyncIterable<TType>,
+): Promise<Array<TType>> {
+  const values: Array<TType> = []
+  for await (const value of asyncIterable) {
+    values.push(value)
+  }
+  return values
+}
+
+if (!globalThis.Event) {
+  global.Event = require('@ungap/event')
+}
+
+if (!globalThis.EventTarget) {
+  global.EventTarget = require('@ungap/event-target')
+}
+
+describe('createPubSub', () => {
+  it('create', () => {
+    createPubSub()
+  })
+  it('subscribe to topic', async () => {
+    const pubSub = createPubSub<{
+      a: [number]
+    }>()
+
+    const sub = pubSub.subscribe('a')
+    const allValues = collectAsyncIterableValues(sub)
+    pubSub.publish('a', 1)
+    pubSub.publish('a', 2)
+    pubSub.publish('a', 3)
+
+    setImmediate(() => {
+      sub.return()
+    })
+
+    const result = await allValues
+    expect(result).toEqual([1, 2, 3])
+  })
+  it('subscribe to multiple topics', async () => {
+    const pubSub = createPubSub<{
+      a: [number]
+      b: [string]
+    }>()
+
+    const sub1 = pubSub.subscribe('a')
+    const sub2 = pubSub.subscribe('b')
+    const allValues1 = collectAsyncIterableValues(sub1)
+    const allValues2 = collectAsyncIterableValues(sub2)
+
+    pubSub.publish('a', 1)
+    pubSub.publish('b', '1')
+    pubSub.publish('a', 2)
+    pubSub.publish('b', '2')
+    pubSub.publish('a', 3)
+    pubSub.publish('b', '3')
+
+    setImmediate(() => {
+      sub1.return()
+      sub2.return()
+    })
+
+    const result1 = await allValues1
+    const result2 = await allValues2
+    expect(result1).toEqual([1, 2, 3])
+    expect(result2).toEqual(['1', '2', '3'])
+  })
+  it('subscribe to fine-grained topic', async () => {
+    const pubSub = createPubSub<{
+      a: [id: string, payload: number]
+    }>()
+    const id1 = '1'
+    const sub1 = pubSub.subscribe('a', id1)
+    const allValues1 = collectAsyncIterableValues(sub1)
+    pubSub.publish('a', id1, 1)
+    pubSub.publish('a', id1, 2)
+    pubSub.publish('a', id1, 3)
+    setImmediate(() => {
+      sub1.return()
+    })
+
+    const result1 = await allValues1
+    expect(result1).toEqual([1, 2, 3])
+  })
+  it('subscribe to multiple fine-grained topics', async () => {
+    const pubSub = createPubSub<{
+      a: [id: string, payload: number]
+      b: [id: string, payload: string]
+    }>()
+    const id1 = '1'
+    const id2 = '1'
+
+    const sub1 = pubSub.subscribe('a', id1)
+    const sub2 = pubSub.subscribe('b', id2)
+
+    const allValues1 = collectAsyncIterableValues(sub1)
+    const allValues2 = collectAsyncIterableValues(sub2)
+
+    pubSub.publish('a', id1, 1)
+    pubSub.publish('b', id1, '1')
+    pubSub.publish('a', id1, 2)
+    pubSub.publish('b', id1, '2')
+    pubSub.publish('a', id1, 3)
+    pubSub.publish('b', id1, '3')
+    setImmediate(() => {
+      sub1.return()
+      sub2.return()
+    })
+
+    const result1 = await allValues1
+    const result2 = await allValues2
+    expect(result1).toEqual([1, 2, 3])
+    expect(result2).toEqual(['1', '2', '3'])
+  })
+})

--- a/packages/subscription/src/createPubSub.spec.ts
+++ b/packages/subscription/src/createPubSub.spec.ts
@@ -10,12 +10,8 @@ async function collectAsyncIterableValues<TType>(
   return values
 }
 
-if (!globalThis.Event) {
-  global.Event = require('@ungap/event')
-}
-
-if (!globalThis.EventTarget) {
-  global.EventTarget = require('@ungap/event-target')
+if (!globalThis.EventTarget || !globalThis.Event) {
+  require('event-target-polyfill')
 }
 
 describe('createPubSub', () => {

--- a/packages/subscription/src/createPubSub.ts
+++ b/packages/subscription/src/createPubSub.ts
@@ -110,10 +110,14 @@ export const createPubSub = <
       routingKey: TKey,
       ...args: TPubSubPublishArgsByKey[TKey]
     ) {
-      const event: PubSubEvent<TPubSubPublishArgsByKey, TKey> = new Event(
-        routingKey,
-      )
-      event.data = args[0]
+      const payload = args[1] ?? args[0]
+      const topic =
+        args[1] === undefined
+          ? routingKey
+          : `${routingKey}:${args[0] as number}`
+
+      const event: PubSubEvent<TPubSubPublishArgsByKey, TKey> = new Event(topic)
+      event.data = payload
       target.dispatchEvent(event)
     },
     subscribe<TKey extends Extract<keyof TPubSubPublishArgsByKey, string>>(

--- a/packages/subscription/src/createPubSub.ts
+++ b/packages/subscription/src/createPubSub.ts
@@ -76,15 +76,20 @@ In modern JavaScript environments those are part of the global scope. However, i
 You can provide polyfills to the 'createPubSub' function:
 
 \`\`\`
-// yarn install @ungap/event @ungap/event-target
-import Event from '@ungap/event'
-import EventTarget from '@ungap/event-target'
+// yarn install --exact event-target-polyfill@0.0.3
+import 'event-target-polyfill'
 
+const pubSub = createPubSub()
+\`\`\`
+
+Alternatively, you can provide your own custom implementation.
+
+\`\`\`
 const pubSub = createPubSub({
-event: {
+  event: {
     Event,
     EventTarget,
-}
+  }
 })
 \`\`\`
 `)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3939,12 +3939,12 @@
     "@typescript-eslint/types" "5.12.0"
     eslint-visitor-keys "^3.0.0"
 
-"@ungap/event-target@0.2.3", "@ungap/event-target@^0.2.3":
+"@ungap/event-target@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@ungap/event-target/-/event-target-0.2.3.tgz#be682c681126dca2371c4e1a1721f8e8bb400905"
   integrity sha512-7Bz0qdvxNGV9n0f+xcMKU7wsEfK6PNzo8IdAcOiBgMNyCuU0Mk9dv0Hbd/Kgr+MFFfn4xLHFbuOt820egT5qEA==
 
-"@ungap/event@0.2.2", "@ungap/event@^0.2.2":
+"@ungap/event@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@ungap/event/-/event-0.2.2.tgz#69d76a1e2c6c1cd4ec63455ee3f91082eb0c6f5e"
   integrity sha512-31PwUE7asaFeXdRatnlsNYyfmO8xSEhsRAP+v7lm77hnn/oOjlpt7pJgc7C76LGlZjiEH9nGSx9vTc/5MZ6W7A==
@@ -6794,6 +6794,11 @@ etag@1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-target-polyfill@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
+  integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
 
 event-target-shim@^5.0.0:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3939,12 +3939,12 @@
     "@typescript-eslint/types" "5.12.0"
     eslint-visitor-keys "^3.0.0"
 
-"@ungap/event-target@^0.2.3":
+"@ungap/event-target@0.2.3", "@ungap/event-target@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@ungap/event-target/-/event-target-0.2.3.tgz#be682c681126dca2371c4e1a1721f8e8bb400905"
   integrity sha512-7Bz0qdvxNGV9n0f+xcMKU7wsEfK6PNzo8IdAcOiBgMNyCuU0Mk9dv0Hbd/Kgr+MFFfn4xLHFbuOt820egT5qEA==
 
-"@ungap/event@^0.2.2":
+"@ungap/event@0.2.2", "@ungap/event@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@ungap/event/-/event-0.2.2.tgz#69d76a1e2c6c1cd4ec63455ee3f91082eb0c6f5e"
   integrity sha512-31PwUE7asaFeXdRatnlsNYyfmO8xSEhsRAP+v7lm77hnn/oOjlpt7pJgc7C76LGlZjiEH9nGSx9vTc/5MZ6W7A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3939,16 +3939,6 @@
     "@typescript-eslint/types" "5.12.0"
     eslint-visitor-keys "^3.0.0"
 
-"@ungap/event-target@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@ungap/event-target/-/event-target-0.2.3.tgz#be682c681126dca2371c4e1a1721f8e8bb400905"
-  integrity sha512-7Bz0qdvxNGV9n0f+xcMKU7wsEfK6PNzo8IdAcOiBgMNyCuU0Mk9dv0Hbd/Kgr+MFFfn4xLHFbuOt820egT5qEA==
-
-"@ungap/event@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@ungap/event/-/event-0.2.2.tgz#69d76a1e2c6c1cd4ec63455ee3f91082eb0c6f5e"
-  integrity sha512-31PwUE7asaFeXdRatnlsNYyfmO8xSEhsRAP+v7lm77hnn/oOjlpt7pJgc7C76LGlZjiEH9nGSx9vTc/5MZ6W7A==
-
 "@vercel/ncc@0.31.1":
   version "0.31.1"
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.31.1.tgz#9346c7e59326f5eeac75c0286e47df94c2d6d8f7"


### PR DESCRIPTION
The following was broken.

```typescript
   const pubSub = createPubSub<{
      a: [id: string, payload: number]
    }>()
    const id1 = '1'
    const sub1 = pubSub.subscribe('a', id1)
    const allValues1 = collectAsyncIterableValues(sub1)
    pubSub.publish('a', id1, 1)
    pubSub.publish('a', id1, 2)
    pubSub.publish('a', id1, 3)
    setImmediate(() => {
      sub1.return()
    })

    const result1 = await allValues1
    expect(result1).toEqual([1, 2, 3])
```

I added a test suite for the `createPubSub`.

Also I replaced the `@ungap/event` and `@ungap/event-target` polyfill recommendations with `event-target-polyfill` as the former dd only work in browser environments.
