### PR TITLE
Fix authentication error on wrangler publish

### DIFF
--- a/examples/service-worker/wrangler.toml
+++ b/examples/service-worker/wrangler.toml
@@ -1,6 +1,6 @@
 compatibility_date = "2022-02-21"
 type = "webpack"
 name = "my-worker-dev"
-account_id = "12345678901234567890"
+account_id = ""
 workers_dev = true
 webpack_config = "webpack.config.js"


### PR DESCRIPTION
Right now there's an account ID hardcoded into the `wrangler.toml` which causes the `wrangler publish` command to fail if the user's authentication does not match that specific account id.

If we make it an empty string instead then the Wrangler CLI will manage deploying to the right account as long as you have configured your credentials already.