### PR TITLE
fix(node): remove port identifier from host header if used as hostname to build Request

### DIFF
--- a/.changeset/cool-ads-divide.md
+++ b/.changeset/cool-ads-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/node': patch
+---
+
+fix(node): remove port identifier from host header if used as hostname to build Request

--- a/packages/node/src/http-utils.ts
+++ b/packages/node/src/http-utils.ts
@@ -27,7 +27,7 @@ function getRequestAddressInfo(
       ?.join('')
       ?.split(':')
       ?.join('') ||
-    nodeRequest.headers.host ||
+    nodeRequest.headers?.host?.split(':')[0] ||
     defaultAddressInfo.hostname ||
     'localhost'
 


### PR DESCRIPTION
Related #966 