### PR TITLE
fix(node): resolve sendNodeResponse correctly when stream has been finished

### DIFF
--- a/.changeset/thick-cooks-run.md
+++ b/.changeset/thick-cooks-run.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/node': patch
+---
+
+fix(node): resolve sendNodeResponse correctly when stream has been finished

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -14,7 +14,7 @@ class YogaNodeServer<
   TServerContext extends Record<string, any>,
   TUserContext extends Record<string, any>,
   TRootValue,
-  > extends YogaServer<TServerContext, TUserContext, TRootValue> {
+> extends YogaServer<TServerContext, TUserContext, TRootValue> {
   /**
    * Address Information for Server
    */
@@ -98,7 +98,7 @@ class YogaNodeServer<
   requestListener = async (req: IncomingMessage, res: ServerResponse) => {
     const response = await this.handleIncomingMessage(req, { req, res } as any)
     this.logger.debug('Sending response to Node Server')
-    sendNodeResponse(response, res)
+    return sendNodeResponse(response, res)
   }
 
   start() {
@@ -166,7 +166,7 @@ export function createServer<
   },
   TUserContext extends Record<string, any> = {},
   TRootValue = {},
-  >(options?: YogaNodeServerOptions<TServerContext, TUserContext, TRootValue>) {
+>(options?: YogaNodeServerOptions<TServerContext, TUserContext, TRootValue>) {
   return new YogaNodeServer<TServerContext, TUserContext, TRootValue>(options)
 }
 


### PR DESCRIPTION
Needed to block the promise for the server frameworks that are relying on promise resolution like Express's AsyncRouter and Serverless Express