### PR TITLE
Add missing content-type and data property for error responses

### DIFF
--- a/.changeset/clever-mugs-hug.md
+++ b/.changeset/clever-mugs-hug.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+fix(common): error responses should also have data: null per spec

--- a/.changeset/two-knives-behave.md
+++ b/.changeset/two-knives-behave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+fix(common): correct content-type for error responses

--- a/examples/nextjs-auth/pages/api/graphql.ts
+++ b/examples/nextjs-auth/pages/api/graphql.ts
@@ -1,12 +1,18 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { createServer } from '@graphql-yoga/node'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { Session } from 'next-auth'
 import { getSession } from 'next-auth/react'
 
-const server = createServer<{
-  req: NextApiRequest
-  res: NextApiResponse
-}>({
+const server = createServer<
+  {
+    req: NextApiRequest
+    res: NextApiResponse
+  },
+  {
+    session: Session
+  }
+>({
   cors: false,
   endpoint: '/api/graphql',
   context: async ({ req }) => {

--- a/packages/common/src/getResponse.ts
+++ b/packages/common/src/getResponse.ts
@@ -139,6 +139,9 @@ export function getErrorResponse({
   }
   return new Response(JSON.stringify(payload), {
     status,
-    headers,
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json',
+    },
   })
 }

--- a/packages/common/src/getResponse.ts
+++ b/packages/common/src/getResponse.ts
@@ -132,6 +132,7 @@ export function getErrorResponse({
   isEventStream,
 }: ErrorResponseParams): Response {
   const payload: ExecutionResult = {
+    data: null,
     errors,
   }
   if (isEventStream) {

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -32,6 +32,7 @@ describe('Disable Introspection with plugin', () => {
     })
 
     expect(response.statusCode).toBe(400)
+    expect(response.headers['content-type']).toBe('application/json')
     const body = JSON.parse(response.text)
     expect(body.data).toBeUndefined()
     expect(body.errors![0]).toMatchInlineSnapshot(`

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -33,7 +33,7 @@ describe('Disable Introspection with plugin', () => {
 
     expect(response.statusCode).toBe(400)
     expect(response.headers['content-type']).toBe('application/json')
-    expect(response.body.data).toBeUndefined()
+    expect(response.body.data).toBeNull()
     expect(response.body.errors![0]).toMatchInlineSnapshot(`
       Object {
         "locations": Array [
@@ -197,6 +197,7 @@ describe('Context error', () => {
     const body = JSON.parse(response.text)
     expect(body).toMatchInlineSnapshot(`
       Object {
+        "data": null,
         "errors": Array [
           Object {
             "message": "I like turtles",
@@ -220,6 +221,7 @@ describe('Context error', () => {
     const body = JSON.parse(response.text)
     expect(body).toMatchInlineSnapshot(`
       Object {
+        "data": null,
         "errors": Array [
           Object {
             "message": "Unexpected error.",
@@ -243,6 +245,7 @@ describe('Context error', () => {
     const body = JSON.parse(response.text)
     expect(body).toMatchInlineSnapshot(`
       Object {
+        "data": null,
         "errors": Array [
           Object {
             "message": "I like turtles",
@@ -321,7 +324,7 @@ describe('Requests', () => {
 
     const body = JSON.parse(response.text)
     expect(body.errors).toBeDefined()
-    expect(body.data).toBeUndefined()
+    expect(body.data).toBeNull()
   })
 
   it('should error missing query', async () => {
@@ -332,7 +335,7 @@ describe('Requests', () => {
       } as any)
 
     const body = JSON.parse(response.text)
-    expect(body.data).toBeUndefined()
+    expect(body.data).toBeNull()
     expect(body.errors?.[0].message).toBe('Must provide query string.')
   })
 })

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -33,9 +33,8 @@ describe('Disable Introspection with plugin', () => {
 
     expect(response.statusCode).toBe(400)
     expect(response.headers['content-type']).toBe('application/json')
-    const body = JSON.parse(response.text)
-    expect(body.data).toBeUndefined()
-    expect(body.errors![0]).toMatchInlineSnapshot(`
+    expect(response.body.data).toBeUndefined()
+    expect(response.body.errors![0]).toMatchInlineSnapshot(`
       Object {
         "locations": Array [
           Object {


### PR DESCRIPTION
According to GraphQL over HTTP spec, even if there is `errors`, we should still return `data: null`, and content-type should be `application/json`.

https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes