### PR TITLE
fix: apply masked errors last

### DIFF
--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -252,12 +252,6 @@ export class YogaServer<
           }),
         ),
         enableIf(
-          !!maskedErrors,
-          useMaskedErrors(
-            typeof maskedErrors === 'object' ? maskedErrors : undefined,
-          ),
-        ),
-        enableIf(
           options?.context != null,
           useExtendContext(async (initialContext) => {
             if (options?.context) {
@@ -270,6 +264,12 @@ export class YogaServer<
           }),
         ),
         ...(options?.plugins ?? []),
+        enableIf(
+          !!maskedErrors,
+          useMaskedErrors(
+            typeof maskedErrors === 'object' ? maskedErrors : undefined,
+          ),
+        ),
       ],
     }) as GetEnvelopedFn<TUserContext & TServerContext & YogaInitialContext>
 


### PR DESCRIPTION
Error masking from yoga should always happen last, as we don't want users using the sentry envelop plugin or other plugins that hook into onExecute to receive the already masked errors.