### PR TITLE
docs: revamp context documentation

### DIFF
--- a/website/docs/features/context.mdx
+++ b/website/docs/features/context.mdx
@@ -1,91 +1,236 @@
 ---
 id: context
 title: GraphQL Context
-sidebar_label: GraphQL Context
+sidebar_label: Context
 ---
 
-A context is an object in GraphQL-js that is provided per execution and it is passed to the resolvers as a third argument. You can learn more about [`Context` in GraphQL Tools docs](https://www.graphql-tools.com/docs/connectors).
+A context is usually created for each execution of a GraphQL Operation and it is passed to the resolver functions as a third argument.
+You can learn more about [`Context` in GraphQL Tools docs](https://www.graphql-tools.com/docs/connectors).
 
-In GraphQL Yoga, the context object is generated per HTTP request, and the content of this object differs based on your setup.
+It is commonly used for doing dependency injection.
 
-There are 4 steps that GraphQL Yoga follows to generate the final context object;
+Within GraphQL Yoga, the context object is generated per HTTP request.
 
-[Default Context](#default-context) -> [Server Context](#server-context) -> [User Context](#user-context) -> [Envelop Plugins](#envelop-plugins)
-
-## Default Context
+## Default context
 
 By default, GraphQL Yoga provides the following values in the context object independently from your environment and setup;
 
+- **_request_**: [Fetch API `Request` object](https://developer.mozilla.org/en-US/docs/Web/API/Request) that represents the incoming HTTP request in platform-independent way. It can be useful for accessing headers in order to authenticate an user.
 - **_query_**: The `DocumentNode` that was parsed from the GraphQL query string
-- **_request_**: [WHATWG `Request` object](https://developer.mozilla.org/en-US/docs/Web/API/Request) that represents the incoming HTTP request in platform-independent way
 - **_operationName_**: The operation name selected from the incoming query
 - **_variables_**: The variables that were defined in the query
 - **_extensions_**: The extensions that were received from the client
 
-## Server Context
+**Context usage example: log headers**
 
-While creating the server instance, GraphQL Yoga accepts an additional object from your base server framework or library that will be merged with the one above.
+```ts
+import { createServer } from '@graphql-yoga/node'
 
-### For Node.js (`.start()`, Express and Next.js etc)
+const server = createServer({
+  schema: {
+    typeDefs: /* GraphQL */ `
+      type Query {
+        logHeader: Boolean
+      }
+    `,
+    resolver: {
+      Query: {
+        logHeaders: (_, _args, context) => {
+          console.log(context.request.headers.get('x-foo'))
+        },
+      },
+    },
+  },
+})
+server.start()
+```
 
-If you are using GraphQL Yoga as a standalone server with `.start()` method or exposing it as a middleware as we show in our Express and Next.js recipes;
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "content-type: application/json" \
+  -H "x-foo: iliketurtles"
+  --data-raw '{"query": "query { logHeader }"}'
+```
+
+## Extending the initial context
+
+You can extend the existing context by using the `context` property.
+
+**Context extension example: object**
+
+```ts
+import { createServer } from '@graphql-yoga/node'
+
+const server = createServer({
+  schema: {
+    typeDefs: /* GraphQL */ `
+      type Query {
+        someNumber: Int!
+      }
+    `,
+    resolver: {
+      Query: {
+        someNumber: (_, _args, context) => {
+          context.someNumber
+        },
+      },
+    },
+  },
+  context: { someNumber: 13 },
+})
+server.start()
+```
+
+You can also pass a function as the `context` property. The function will be invoked for each incoming GraphQL request with the initial context as an argument and after the invocation it will be merged with the initial context.
+
+**Context extension example: function returning an object**
+
+```ts
+import { createServer } from '@graphql-yoga/node'
+
+const server = createServer({
+  schema: {
+    typeDefs: /* GraphQL */ `
+      type Query {
+        someNumber: Int!
+      }
+    `,
+    resolver: {
+      Query: {
+        someNumber: (_, _args, context) => {
+          context.someNumber
+        },
+      },
+    },
+  },
+  context: () => {
+    return { someNumber: 13 }
+  },
+})
+server.start()
+```
+
+The function can either return an object or a Promise that resolves to an object.
+
+**Context extension example: function returning a Promise**
+
+```ts
+import { createServer } from '@graphql-yoga/node'
+
+const server = createServer({
+  schema: {
+    typeDefs: /* GraphQL */ `
+      type Query {
+        someNumber: Int!
+      }
+    `,
+    resolver: {
+      Query: {
+        someNumber: (_, _args, context) => {
+          context.someNumber
+        },
+      },
+    },
+  },
+  context: async () => {
+    return { someNumber: 13 }
+  },
+})
+server.start()
+```
+
+## Advanced context life-cycle
+
+For most users the previous sections are already sufficient.
+If you, however, need to integrate Yoga with a custom framework and/or want to attach runtime/framework specific Request/Response objects to the context.
+Also if you are just curious about how Yoga works in depth, this might also be interesting to you!
+
+There are 4 steps that GraphQL Yoga follows to generate the final context object:
+
+- **[Default Context](#default-context)**: This context is constructed for each incoming request and the same on all platforms
+- **[Server Context](#server-context)**: The content of this context extension depends on the platform (Node.js/deno/etc.) and the framework (raw Node.js/express/fastify)
+- **[User Context](#user-context)**: This context is created for each incoming request with access to the default and server context.
+- **[Envelop Plugin Context](#envelop-plugins)**: The context from envelop plugins is processed last, the plugins have access to the default context, server context and user context.
+
+### Default Context
+
+See the above section [default context](#default-context).
+
+### Server Context
+
+When creating the server instance, GraphQL Yoga accepts an additional object from your base server framework or library that will be merged with the default context.
+
+#### Node.js (standalone, express and Next.js etc.)
+
+If you are using GraphQL Yoga as a standalone server with `.start()` method or exposing it as a middleware as we show in our [express](/docs/integrations/integration-with-express) and [Next.js](/docs/integrations/integration-with-nextjs) recipes.
 
 - **_req_**: [Node.js `IncomingMessage` object](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
 - **_res_**: [Node.js `ServerResponse` object](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 
-The `req` and `res` objects are merged into the initial context object.
-
-### For advanced Node.js frameworks like Fastify and Koa
-
-You might notice that we are implementing a custom middleware for more complicated server frameworks like Fastify and Koa because they need to handle received responses on their own, so we cannot use a basic Node.js [RequestListener](https://nodejs.org/api/http.html#http_class_http_incomingmessage) function.
-Since they limit our access to the underlying raw `ServerResponse` object, we use `.handleIncomingMessage` method and pass the server context as a second parameter;
-
-For **_Fastify_**, we do the following;
+The `req` and `res` objects are added to the initial context object.
 
 ```ts
-const response = await graphQLServer.handleIncomingMessage(req, {
-  req,
-  reply,
-})
+const serverContext = { ...defaultContext, req, res }
 ```
 
-and the context now has `reply` instead of `res`;
+Thus when using `@graphql-yoga/node`, it is possible to access `context.req` and `context.res` within the GraphQL resolvers or the user context factory function.
 
-- **_reply_**: [Fastify `Reply` object](https://www.fastify.io/docs/latest/Reply/)
+However, we recommend avoiding to use `context.req` and `context.res` wherever possible and instead favor `context.request`, as it is more future proof (as Node.js HTTP servers adopt the Fetch Response API).
 
-Also please check our generic definition in `createServer` call to have a type safety;
+#### Advanced Node.js frameworks (Fastify/Koa)
+
+You might notice that the middleware implementation is more complex for server frameworks like [Fastify](/docs/integrations/integration-with-fastify) and [koa](/docs/integrations/integration-with-koa), because of their custom request handling behavior.
+It is not possible to use a basic Node.js [RequestListener](https://nodejs.org/api/http.html#http_class_http_incomingmessage) function.
+
+Since they limit the access to the underlying raw `ServerResponse` object, the recipes use the `.handleIncomingMessage` method and pass the server context as the second parameter.
+
+E.g. for **_Fastify_**, a [`Reply`](<(https://www.fastify.io/docs/latest/Reply/)>) object is attached to the server context instead of the `Request` object, which is an intermediate framework specific response format.
+Also note the generic definition in `createServer` for corretcly typing the server context.
 
 ```ts
 const graphQLServer = createServer<{
   req: FastifyRequest
   reply: FastifyReply
 }>()
-```
 
-### For WHATWG-compliant environments like Cloudflare Workers and Deno
+// some where within the request handler
 
-If you are using Cloudflare Workers with `.start()` method, it will merge [WHATWG `FetchEvent` object](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent) into the context object.
-And that object is almost similar to what GraphQL Yoga provides you with `YogaInitialContext`. Other than that, GraphQL Yoga doesn't add anything specific to the context object because it is not needed like in Node.js.
-
-## User Context
-
-Besides the initial context generated based on your setup, GraphQL Yoga also accepts a user context object that will be merged with the initial context.
-You can pass a factory function to `context` parameter of `createServer` configuration. That function will receive the combination of the standard initial context and the server's (if available)`, then the return value will be merged into that.
-
-```ts
-createServer({
-  context: async ({ request }) => {
-    const user = await getUserByToken(request.headers.get('authorization'))
-    return {
-      user,
-    }
-  },
+const response = await graphQLServer.handleIncomingMessage(req, {
+  req,
+  reply,
 })
 ```
 
-In this case your final context object will have an extra `user` property.
+#### Fetch API Request compliant environments (Cloudflare Workers/Deno)
+
+If you are using [Cloudflare Workers with `@graphql-yoga/common` according to the integration guide](/docs/integrations/integration-with-cloudflare-workers), the [WHATWG `FetchEvent` object](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent) will be added as the server context object.
+That object is almost identical to what GraphQL Yoga provides you within `YogaInitialContext`.
+
+### User Context
+
+Besides the initial context generated based on your setup, GraphQL Yoga also accepts a user context object that will be merged with the initial context (built out of the default context and server context).
+You can pass a factory function to `context` parameter of `createServer` configuration.
+That function will receive the combination of the standard initial context and the server's (if available)`, then the return value will be merged into that.
+
+```ts
+import { createServer } from '@graphql-yoga/node'
+const server = createServer({
+  context: async ({ request }) => {
+    // get custom header value
+    const foo = request.headers.get('x-foo') ?? null
+    return {
+      foo,
+    }
+  },
+})
+server.start()
+```
+
+In this case your final context object will have an extra `foo` property.
+
+See the above section [`extending the initial context`](#extending-the-initial-context) for more details and useage examples.
 
 ## Envelop Plugins
 
-After all the above, Envelop plugins (if you have some) receive the context object and can modify it.
+After all of the above, Envelop plugins (if you have some) receive the context object and can modify or extend it.
 See the documentation for [Envelop plugins](/envelop-plugins) for more information.

--- a/website/routes.ts
+++ b/website/routes.ts
@@ -10,6 +10,7 @@ export function getRoutes(): IRoutes {
         $name: 'Features',
         $routes: [
           ['graphiql', 'GraphiQL'],
+          ['context', 'Context'],
           ['error-masking', 'Error Masking'],
           ['subscriptions', 'Subscriptions'],
           ['file-uploads', 'File Uploads'],


### PR DESCRIPTION
I think most people don't care about server context really and only want to quickly learn how `context: () => brrt` works.

So I tried restructuring it, the most important info for people that wanna get started is now on top, the advanced stuff and details are below.