### PR TITLE
Send specific origin in CORS instead of wildcard if credentials are allowed explicitly

### DIFF
--- a/.changeset/empty-readers-kick.md
+++ b/.changeset/empty-readers-kick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+Send specific origin instead of wildcard if credentials are allowed explicitly

--- a/.changeset/empty-readers-kick.md
+++ b/.changeset/empty-readers-kick.md
@@ -2,4 +2,13 @@
 '@graphql-yoga/common': patch
 ---
 
-Send specific origin instead of wildcard if credentials are allowed explicitly
+Send specific origin in CORS instead of wildcard if credentials are allowed explicitly like below;
+
+```ts
+createServer({
+  cors: {
+    origin: ['http://localhost:4000'], // Previously this was ignored even if `credentials` is true
+    credentials: true,
+  },
+})
+```

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -364,7 +364,7 @@ export class YogaServer<
 
     if (currentOrigin) {
       const credentialsAsked = request.headers.get('cookies')
-      if (credentialsAsked) {
+      if (credentialsAsked || corsOptions.credentials !== false) {
         headers['Access-Control-Allow-Origin'] = currentOrigin
       }
     }

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -804,5 +804,23 @@ describe('Browser', () => {
       })
       expect(result).toContain('Failed to fetch')
     })
+    test('send specific origin back to user if credentials are set true', async () => {
+      cors = {
+        origin: [`http://localhost:${anotherOriginPort}`],
+        credentials: true,
+      }
+      await page.goto(`http://localhost:${anotherOriginPort}`)
+      const result = await page.evaluate(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return document.getElementById('result')?.innerHTML
+      })
+      expect(result).toEqual(
+        JSON.stringify({
+          data: {
+            alwaysTrue: true,
+          },
+        }),
+      )
+    })
   })
 })


### PR DESCRIPTION
Related #1150