### PR TITLE
fix: reuse headers between tabs

### DIFF
--- a/.changeset/rotten-turkeys-press.md
+++ b/.changeset/rotten-turkeys-press.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/graphiql': patch
+---
+
+Reuse the headers in all tabs

--- a/packages/graphiql/src/YogaGraphiQL.tsx
+++ b/packages/graphiql/src/YogaGraphiQL.tsx
@@ -181,7 +181,12 @@ export function YogaGraphiQL(props: YogaGraphiQLProps): React.ReactElement {
           defaultVariableEditorOpen={true}
           docExplorerOpen={showDocs}
           onToggleDocs={() => setShowDocs((isOpen) => !isOpen)}
-          tabs
+          tabs={{
+            onTabChange: (tab) => {
+              // recycle the request headers within all tabs
+              tab.tabs.forEach((t) => (t.headers = props.headers))
+            },
+          }}
           toolbar={{
             additionalContent: (
               <>


### PR DESCRIPTION
GraphiQL provides a callback to update all the tabs and we pass the headers from user and pass them to all tabs.

Closes #1163 
