### PR TITLE
feat: scope GraphiQL to version compatible with common

### DIFF
--- a/.changeset/sweet-bags-swim.md
+++ b/.changeset/sweet-bags-swim.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+Ensure the GraphiQL version is compatible with the `@graphql-yoga/common` version by hard-coding the version number before publishing/building.

--- a/packages/common/scripts/generate-graphiql-html.js
+++ b/packages/common/scripts/generate-graphiql-html.js
@@ -1,6 +1,15 @@
 const minifyHtml = require('@minify-html/js')
 const { readFileSync, writeFileSync } = require('fs')
 const { join } = require('path')
+const fs = require('fs')
+
+const graphiqlVersion = JSON.parse(
+  fs.readFileSync(
+    join(__dirname, '..', '..', 'graphiql', 'package.json'),
+    'utf-8',
+  ),
+).version
+
 const cfg = minifyHtml.createConfiguration({
   do_not_minify_doctype: true,
   keep_spaces_between_attributes: true,
@@ -8,7 +17,13 @@ const cfg = minifyHtml.createConfiguration({
   minify_js: true,
 })
 const minified = minifyHtml
-  .minify(readFileSync(join(__dirname, '../src/graphiql.html')), cfg)
+  .minify(
+    readFileSync(
+      join(__dirname, '..', 'src', 'graphiql.html'),
+      'utf-8',
+    ).replace(/__GRAPHIQL_VERSION__/g, graphiqlVersion),
+    cfg,
+  )
   .toString('utf-8')
 writeFileSync(
   join(__dirname, '../src/graphiqlHTML.ts'),

--- a/packages/common/src/graphiql.html
+++ b/packages/common/src/graphiql.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="https://www.graphql-yoga.com/favicon.ico" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphql-yoga/graphiql/dist/style.css"
+      href="https://unpkg.com/@graphql-yoga/graphiql@__GRAPHIQL_VERSION__/dist/style.css"
     />
   </head>
   <body id="body" class="no-focus-outline">
@@ -14,7 +14,7 @@
     <div id="root"></div>
 
     <script type="module">
-      import { renderYogaGraphiQL } from 'https://unpkg.com/@graphql-yoga/graphiql'
+      import { renderYogaGraphiQL } from 'https://unpkg.com/@graphql-yoga/graphiql@__GRAPHIQL_VERSION__'
       renderYogaGraphiQL(root, __OPTS__)
     </script>
   </body>

--- a/packages/common/src/plugins/useGraphiQL.ts
+++ b/packages/common/src/plugins/useGraphiQL.ts
@@ -52,6 +52,8 @@ export const renderGraphiQL = (opts?: GraphiQLOptions) =>
   graphiqlHTML
     .replace('__TITLE__', opts?.title || 'Yoga GraphiQL')
     .replace('__OPTS__', JSON.stringify(opts ?? {}))
+    // TODO: replace this with the @graphql-yoga/graphiql version
+    .replace('__GRAPHIQL_VERSION__', '2.3.0')
 
 export type GraphiQLOptionsFactory<TServerContext> = (
   request: Request,

--- a/packages/common/src/plugins/useGraphiQL.ts
+++ b/packages/common/src/plugins/useGraphiQL.ts
@@ -52,8 +52,6 @@ export const renderGraphiQL = (opts?: GraphiQLOptions) =>
   graphiqlHTML
     .replace('__TITLE__', opts?.title || 'Yoga GraphiQL')
     .replace('__OPTS__', JSON.stringify(opts ?? {}))
-    // TODO: replace this with the @graphql-yoga/graphiql version
-    .replace('__GRAPHIQL_VERSION__', '2.3.0')
 
 export type GraphiQLOptionsFactory<TServerContext> = (
   request: Request,

--- a/scripts/canary-release.js
+++ b/scripts/canary-release.js
@@ -8,9 +8,6 @@ const readChangesets = require('@changesets/read').default
 const assembleReleasePlan = require('@changesets/assemble-release-plan').default
 const applyReleasePlan = require('@changesets/apply-release-plan').default
 const { getPackages } = require('@manypkg/get-packages')
-const {
-  promises: { unlink },
-} = require('fs')
 
 function getNewVersion(version, type) {
   const gitHash = cp


### PR DESCRIPTION
The GraphiQL version that is loaded from CDN should be consistent for a single version so that the GraphiQL does not unexpectedly break in the future when its API is changed and this newer version is loaded from the CDN. 
This PR changes the HTML build script to include the proper version string.