### PR TITLE
Fix docs - replace logger with logging

### DIFF
--- a/website/docs/integrations/integration-with-fastify.mdx
+++ b/website/docs/integrations/integration-with-fastify.mdx
@@ -29,7 +29,7 @@ const graphQLServer = createServer<{
   reply: FastifyReply
 }>({
   // Integrate Fastify logger
-  logger: app.log,
+  logging: app.log,
 })
 
 /**


### PR DESCRIPTION
The docs specify the key to be logger but I got this

![image](https://user-images.githubusercontent.com/1165845/170867479-0f4653fd-0abf-4fa2-b0b6-a02ed75c3743.png)

It should be `logging` rather if I am not wrong