### PR TITLE
fix: correctly handle GraphQLYogaError thrown in contextFactory

### DIFF
--- a/.changeset/grumpy-comics-yell.md
+++ b/.changeset/grumpy-comics-yell.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/common': patch
+'@graphql-yoga/node': patch
+---
+
+Fix GraphQLYogaError being thrown from contextFactory to be treated as an unexpected error. The bug would previously prevent the GraphQLYogaError `extensions` from being exposed in the result and cause a status code of 500.

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -118,8 +118,19 @@ export async function processRequest<TContext, TRootValue = {}>({
     })
   }
 
-  const contextValue: TContext | undefined =
-    (await enveloped.contextFactory()) as TContext
+  let contextValue: TContext | undefined
+  try {
+    contextValue = (await enveloped.contextFactory()) as TContext
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      return getErrorResponse({
+        status: 200,
+        errors: [error],
+        fetchAPI,
+      })
+    }
+    throw error
+  }
 
   const executionArgs: ExecutionArgs = {
     schema: enveloped.schema,

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -72,6 +72,7 @@ import {
   isPOSTFormUrlEncodedRequest,
   parsePOSTFormUrlEncodedRequest,
 } from './plugins/requestParser/POSTFormUrlEncoded'
+import { GraphQLYogaError } from './GraphQLYogaError'
 
 interface OptionsWithPlugins<TContext> {
   /**
@@ -508,6 +509,13 @@ export class YogaServer<
 
       return result
     } catch (error: unknown) {
+      if (error instanceof GraphQLYogaError) {
+        return getErrorResponse({
+          status: 200,
+          errors: [error],
+          fetchAPI: this.fetchAPI,
+        })
+      }
       return getErrorResponse({
         status: 500,
         errors: [new Error((error as Error)?.message ?? 'Unexpected Error.')],

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -72,7 +72,6 @@ import {
   isPOSTFormUrlEncodedRequest,
   parsePOSTFormUrlEncodedRequest,
 } from './plugins/requestParser/POSTFormUrlEncoded'
-import { GraphQLYogaError } from './GraphQLYogaError'
 
 interface OptionsWithPlugins<TContext> {
   /**
@@ -509,13 +508,6 @@ export class YogaServer<
 
       return result
     } catch (error: unknown) {
-      if (error instanceof GraphQLYogaError) {
-        return getErrorResponse({
-          status: 200,
-          errors: [error],
-          fetchAPI: this.fetchAPI,
-        })
-      }
       return getErrorResponse({
         status: 500,
         errors: [new Error((error as Error)?.message ?? 'Unexpected Error.')],

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -260,6 +260,31 @@ describe('Context error', () => {
       }
     `)
   })
+
+  it('GraphQLYogaError thrown within context factory has error extensions exposed on the response', async () => {
+    const yoga = createServer({
+      logging: false,
+      context: () => {
+        throw new GraphQLYogaError('I like turtles', { foo: 1 })
+      },
+    })
+
+    const response = await request(yoga).post('/graphql').send({
+      query: '{ greetings }',
+    })
+    const body = JSON.parse(response.text)
+    expect(body).toStrictEqual({
+      data: null,
+      errors: [
+        {
+          message: 'I like turtles',
+          extensions: {
+            foo: 1,
+          },
+        },
+      ],
+    })
+  })
 })
 
 it('parse error is sent to clients', async () => {

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -284,6 +284,7 @@ describe('Context error', () => {
         },
       ],
     })
+    expect(response.status).toEqual(200)
   })
 })
 


### PR DESCRIPTION
Fix GraphQLYogaError being thrown from within the`contextFactory` to be treated as an unexpected error.

The bug would previously prevent the GraphQLYogaError `extensions` from being exposed in the result and cause a status code of 500.