### PR TITLE
chore: run vercel builds on renovate pull requests

### DIFF
--- a/scripts/vercel-ignore-build-step.sh
+++ b/scripts/vercel-ignore-build-step.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exit 1;

--- a/scripts/vercel-ignore-build-step.sh
+++ b/scripts/vercel-ignore-build-step.sh
@@ -1,13 +1,3 @@
 #!/bin/bash
 
-echo "VERCEL_GIT_COMMIT_AUTHOR_LOGIN: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN"
-
-if [ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" == "renovate-bot" ]; then
-  # Don't build
-  echo "🛑 - Renovate Build cancelled"
-  exit 0;
-else
-  # Proceed with the build
-    echo "✅ - Build can proceed"
-  exit 1;
-fi
+exit 1;


### PR DESCRIPTION
Apply changes mentioned in https://github.com/dotansimha/graphql-yoga/issues/1264#issuecomment-1146820656

> We originally introduced that script in order to reduce noise and a clogged-up vercel build queue for all the PRs created by renovate. However, as we are now batching renovate updates into less frequent PRs it should be fine to run vercel builds/deployments on every PR.

By running this on every PR we have a higher chance of catching dependency updates that break vercel deployments.