### PR TITLE
Refactor Error Handling & Return correct HTTP status codes for Multipart

### DIFF
--- a/.changeset/shy-geckos-switch.md
+++ b/.changeset/shy-geckos-switch.md
@@ -1,7 +1,26 @@
 ---
-'@graphql-yoga/common': patch
+'@graphql-yoga/common': minor
 '@graphql-yoga/node': patch
 ---
 
+## Correct status code for multipart request errors
+
 Return correct 413 (Request Entity Too Large) HTTP status code if the given request body is larger then the specified one in `multipart` options.
 Previously it was returning 400 or 500 which is an incorrect behavior misleading the client.
+
+## Possible to configure the HTTP status code and headers of the response
+
+Now we add a new `http` field to `GraphQLErrorExtensions` that you can set the status code and headers of the response;
+
+```ts
+throw new GraphQLError('You are not authorized to access this field', {
+  extensions: {
+    http: {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Bearer',
+      },
+    },
+  },
+})
+```

--- a/.changeset/shy-geckos-switch.md
+++ b/.changeset/shy-geckos-switch.md
@@ -1,0 +1,7 @@
+---
+'@graphql-yoga/common': patch
+'@graphql-yoga/node': patch
+---
+
+Return correct 413 (Request Entity Too Large) HTTP status code if the given request body is larger then the specified one in `multipart` options.
+Previously it was returning 400 or 500 which is an incorrect behavior misleading the client.

--- a/examples/graphql-config/package.json
+++ b/examples/graphql-config/package.json
@@ -8,9 +8,9 @@
     "check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@graphql-codegen/cli": "^2.3.0",
-    "@graphql-codegen/typescript": "^2.4.1",
-    "@graphql-codegen/typescript-resolvers": "^2.4.2",
+    "@graphql-codegen/cli": "^2.6.2",
+    "@graphql-codegen/typescript": "^2.4.11",
+    "@graphql-codegen/typescript-resolvers": "^2.6.4",
     "@graphql-tools/schema": "^8.5.0",
     "graphql": "^16.1.0",
     "graphql-yoga": "2.10.0"

--- a/examples/subscriptions/package.json
+++ b/examples/subscriptions/package.json
@@ -13,8 +13,8 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^2.6.2",
-    "@graphql-codegen/typescript": "^2.4.8",
-    "@graphql-codegen/typescript-resolvers": "^2.6.1",
+    "@graphql-codegen/typescript": "^2.4.11",
+    "@graphql-codegen/typescript-resolvers": "^2.6.4",
     "ts-node": "10.8.1",
     "typescript": "4.7.4"
   }

--- a/examples/sveltekit/__tests__/test.ts
+++ b/examples/sveltekit/__tests__/test.ts
@@ -19,7 +19,7 @@ describe('SvelteKit integration', () => {
 		sveltekitProcess = spawn('yarn', ['workspace', 'sveltekit', 'preview']);
 		await new Promise<void>((resolve) => {
 			sveltekitProcess.stdout?.on('data', (chunk) => {
-				if (chunk.toString('utf-8').includes('http://localhost:3007')) {
+				if (chunk.toString('utf-8').includes(':3007')) {
 					resolve();
 				}
 			});

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.17",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "@graphql-tools/utils": "8.6.12"
+    "react-dom": "17.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.17",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "@graphql-tools/utils": "8.6.12"
   }
 }

--- a/packages/common/src/GraphQLYogaError.ts
+++ b/packages/common/src/GraphQLYogaError.ts
@@ -1,3 +1,29 @@
 import { EnvelopError } from '@envelop/core'
+import { createGraphQLError } from '@graphql-tools/utils'
+import { GraphQLError } from 'graphql'
 
 export { EnvelopError as GraphQLYogaError }
+
+export function handleError(
+  error: any,
+  errors: GraphQLError[] = [],
+): GraphQLError[] {
+  if (error.errors?.length) {
+    errors.push(
+      ...error.errors.map((singleError: any) =>
+        handleError(singleError, errors),
+      ),
+    )
+  } else if (error instanceof GraphQLError) {
+    errors.push(error)
+  } else if (error instanceof Error) {
+    errors.push(createGraphQLError(error.message))
+  } else if (typeof error === 'string') {
+    errors.push(createGraphQLError(error))
+  } else if (error.toString) {
+    errors.push(createGraphQLError(error.toString()))
+  } else {
+    errors.push(createGraphQLError('Unexpected error!'))
+  }
+  return errors
+}

--- a/packages/common/src/GraphQLYogaError.ts
+++ b/packages/common/src/GraphQLYogaError.ts
@@ -2,6 +2,12 @@ import { EnvelopError } from '@envelop/core'
 import { createGraphQLError } from '@graphql-tools/utils'
 import { GraphQLError } from 'graphql'
 
+declare module 'graphql' {
+  interface GraphQLErrorExtensions {
+    status?: number
+  }
+}
+
 export { EnvelopError as GraphQLYogaError }
 
 export function handleError(

--- a/packages/common/src/GraphQLYogaError.ts
+++ b/packages/common/src/GraphQLYogaError.ts
@@ -14,11 +14,19 @@ declare module 'graphql' {
 
 export { EnvelopError as GraphQLYogaError }
 
+function isAggregateError(obj: any): obj is AggregateError {
+  return obj != null && typeof obj === 'object' && 'errors' in obj
+}
+
+function hasToString(obj: any): obj is { toString(): string } {
+  return obj != null && typeof obj.toString === 'function'
+}
+
 export function handleError(
-  error: any,
+  error: unknown,
   errors: GraphQLError[] = [],
 ): GraphQLError[] {
-  if (error.errors?.length) {
+  if (isAggregateError(error)) {
     for (const singleError of error.errors) {
       errors.push(...handleError(singleError))
     }
@@ -28,7 +36,7 @@ export function handleError(
     errors.push(createGraphQLError(error.message))
   } else if (typeof error === 'string') {
     errors.push(createGraphQLError(error))
-  } else if ('toString' in error) {
+  } else if (hasToString(error)) {
     errors.push(createGraphQLError(error.toString()))
   } else {
     errors.push(createGraphQLError('Unexpected error!'))

--- a/packages/common/src/plugins/requestParser/POSTMultipart.ts
+++ b/packages/common/src/plugins/requestParser/POSTMultipart.ts
@@ -40,7 +40,9 @@ export async function parsePOSTMultipartRequest(
       e.message.startsWith('File size limit exceeded: ')
     ) {
       throw new GraphQLYogaError(e.message, {
-        status: 413,
+        http: {
+          status: 413,
+        },
       })
     }
     throw e

--- a/packages/common/src/plugins/requestParser/POSTMultipart.ts
+++ b/packages/common/src/plugins/requestParser/POSTMultipart.ts
@@ -1,6 +1,6 @@
 import { createGraphQLError } from '@graphql-tools/utils'
 import { dset } from 'dset'
-import { GraphQLParams, GraphQLYogaError } from '../../types.js'
+import { GraphQLParams } from '../../types.js'
 import { isContentTypeMatch } from './utils.js'
 
 export function isPOSTMultipartRequest(request: Request): boolean {

--- a/packages/common/src/plugins/requestParser/POSTMultipart.ts
+++ b/packages/common/src/plugins/requestParser/POSTMultipart.ts
@@ -1,4 +1,4 @@
-import { createGraphQLError } from '@graphql-tools/utils/typings/errors.js'
+import { createGraphQLError } from '@graphql-tools/utils'
 import { dset } from 'dset'
 import { GraphQLParams, GraphQLYogaError } from '../../types.js'
 import { isContentTypeMatch } from './utils.js'

--- a/packages/common/src/plugins/requestParser/POSTMultipart.ts
+++ b/packages/common/src/plugins/requestParser/POSTMultipart.ts
@@ -1,3 +1,4 @@
+import { createGraphQLError } from '@graphql-tools/utils/typings/errors.js'
 import { dset } from 'dset'
 import { GraphQLParams, GraphQLYogaError } from '../../types.js'
 import { isContentTypeMatch } from './utils.js'
@@ -12,39 +13,43 @@ export function isPOSTMultipartRequest(request: Request): boolean {
 export async function parsePOSTMultipartRequest(
   request: Request,
 ): Promise<GraphQLParams> {
+  let requestBody: FormData
   try {
-    const requestBody = await request.formData()
-    const operationsStr = requestBody.get('operations')?.toString() || '{}'
-    const operations = JSON.parse(operationsStr)
-    const mapStr = requestBody.get('map')?.toString() || '{}'
-    const map = JSON.parse(mapStr)
-    for (const fileIndex in map) {
-      const file = requestBody.get(fileIndex)
-      const keys = map[fileIndex]
-      for (const key of keys) {
-        dset(operations, key, file)
-      }
-    }
-
-    return {
-      operationName: operations.operationName,
-      query: operations.query,
-      variables: operations.variables,
-      extensions: operations.extensions,
-    }
-  } catch (e: any) {
+    requestBody = await request.formData()
+  } catch (e: unknown) {
     // Trick for cross-undici-fetch errors on Node.js
     // TODO: This needs a better solution
     if (
       e instanceof Error &&
       e.message.startsWith('File size limit exceeded: ')
     ) {
-      throw new GraphQLYogaError(e.message, {
-        http: {
-          status: 413,
+      throw createGraphQLError(e.message, {
+        extensions: {
+          http: {
+            status: 413,
+          },
         },
       })
     }
     throw e
+  }
+
+  const operationsStr = requestBody.get('operations')?.toString() || '{}'
+  const operations = JSON.parse(operationsStr)
+  const mapStr = requestBody.get('map')?.toString() || '{}'
+  const map = JSON.parse(mapStr)
+  for (const fileIndex in map) {
+    const file = requestBody.get(fileIndex)
+    const keys = map[fileIndex]
+    for (const key of keys) {
+      dset(operations, key, file)
+    }
+  }
+
+  return {
+    operationName: operations.operationName,
+    query: operations.query,
+    variables: operations.variables,
+    extensions: operations.extensions,
   }
 }

--- a/packages/common/src/plugins/types.ts
+++ b/packages/common/src/plugins/types.ts
@@ -21,14 +21,12 @@ export type Plugin<
    * Use this hook with your own risk. It is still experimental and may change in the future.
    * @internal
    */
-  onRequestParse?: OnRequestParseHook<TServerContext>
+  onRequestParse?: OnRequestParseHook
   /**
    * Use this hook with your own risk. It is still experimental and may change in the future.
    * @internal
    */
-  onResultProcess?: OnResultProcess<
-    TServerContext & TUserContext & YogaInitialContext
-  >
+  onResultProcess?: OnResultProcess
   /**
    * Use this hook with your own risk. It is still experimental and may change in the future.
    * @internal
@@ -47,14 +45,13 @@ export interface OnRequestEventPayload<TServerContext> {
   endResponse(response: Response): void
 }
 
-export type OnRequestParseHook<TServerContext> = (
-  payload: OnRequestParseEventPayload<TServerContext>,
+export type OnRequestParseHook = (
+  payload: OnRequestParseEventPayload,
 ) => PromiseOrValue<void | OnRequestParseHookResult>
 
 export type RequestParser = (request: Request) => PromiseOrValue<GraphQLParams>
 
-export interface OnRequestParseEventPayload<TServerContext> {
-  serverContext: TServerContext | undefined
+export interface OnRequestParseEventPayload {
   request: Request
   requestParser: RequestParser | undefined
   setRequestParser: (parser: RequestParser) => void
@@ -73,8 +70,8 @@ export interface OnRequestParseDoneEventPayload {
   setParams: (params: GraphQLParams) => void
 }
 
-export type OnResultProcess<TContext> = (
-  payload: OnResultProcessEventPayload<TContext>,
+export type OnResultProcess = (
+  payload: OnResultProcessEventPayload,
 ) => PromiseOrValue<void>
 
 export type ResultProcessorInput = PromiseOrValue<
@@ -86,9 +83,8 @@ export type ResultProcessor = (
   fetchAPI: FetchAPI,
 ) => PromiseOrValue<Response>
 
-export interface OnResultProcessEventPayload<TContext> {
+export interface OnResultProcessEventPayload {
   request: Request
-  context: TContext
   result: ResultProcessorInput
   resultProcessor: ResultProcessor
   setResultProcessor(resultProcessor: ResultProcessor): void

--- a/packages/common/src/plugins/types.ts
+++ b/packages/common/src/plugins/types.ts
@@ -86,7 +86,7 @@ export type ResultProcessor = (
 export interface OnResultProcessEventPayload {
   request: Request
   result: ResultProcessorInput
-  resultProcessor: ResultProcessor
+  resultProcessor?: ResultProcessor
   setResultProcessor(resultProcessor: ResultProcessor): void
 }
 

--- a/packages/common/src/plugins/useGraphiQL.ts
+++ b/packages/common/src/plugins/useGraphiQL.ts
@@ -74,7 +74,7 @@ export interface GraphiQLPluginConfig<TServerContext> {
 
 export function useGraphiQL<TServerContext>(
   config?: GraphiQLPluginConfig<TServerContext>,
-): Plugin {
+): Plugin<{}, TServerContext> {
   const logger = config?.logger ?? console
   let graphiqlOptionsFactory: GraphiQLOptionsFactory<TServerContext>
   if (typeof config?.options === 'function') {

--- a/packages/common/src/plugins/useHealthCheck.ts
+++ b/packages/common/src/plugins/useHealthCheck.ts
@@ -1,4 +1,4 @@
-import { GraphQLYogaError } from '../GraphQLYogaError.js'
+import { createGraphQLError } from '@graphql-tools/utils'
 import { YogaLogger } from '../logger.js'
 import { Plugin } from './types.js'
 
@@ -52,7 +52,7 @@ export function useHealthCheck(options?: HealthCheckPluginOptions): Plugin {
           )
           endResponse(response)
         } else {
-          throw new GraphQLYogaError(
+          throw createGraphQLError(
             `Readiness check failed with status ${readinessResponse.status}`,
           )
         }

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -117,11 +117,7 @@ export async function processRequest<TContext>({
 
   const result = await executeFn(executionArgs)
 
-  let resultProcessor: ResultProcessor = (_, fetchAPI) =>
-    new fetchAPI.Response(null, {
-      status: 406,
-      statusText: 'Not Acceptable',
-    })
+  let resultProcessor: ResultProcessor | undefined
 
   for (const onResultProcessHook of onResultProcessHooks) {
     await onResultProcessHook({
@@ -131,6 +127,13 @@ export async function processRequest<TContext>({
       setResultProcessor(newResultProcessor) {
         resultProcessor = newResultProcessor
       },
+    })
+  }
+
+  if (!resultProcessor) {
+    return new fetchAPI.Response(null, {
+      status: 406,
+      statusText: 'Not Acceptable',
     })
   }
 

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -45,20 +45,13 @@ export async function processRequest<TContext>({
   let document: DocumentNode
   try {
     document = enveloped.parse(params.query)
-  } catch (e: any) {
+  } catch (e: unknown) {
     if (e instanceof GraphQLError) {
       e.extensions.http = {
         status: 400,
       }
-      throw e
     }
-    throw createGraphQLError(e.message, {
-      extensions: {
-        http: {
-          status: 400,
-        },
-      },
-    })
+    throw e
   }
 
   const operation: OperationDefinitionNode | undefined =

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -7,7 +7,7 @@ import {
 } from 'graphql'
 import { RequestProcessContext } from './types.js'
 import { ResultProcessor } from './plugins/types.js'
-import { createGraphQLError } from '@graphql-tools/utils'
+import { AggregateError, createGraphQLError } from '@graphql-tools/utils'
 
 export async function processRequest<TContext>({
   request,

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -28,6 +28,12 @@ export function getErrorResponse({
     data: null,
     errors,
   }
+  if (errors.length === 1) {
+    const error = errors[0]
+    if (error.extensions?.status) {
+      status = error.extensions.status
+    }
+  }
   const decodedString = encodeString(JSON.stringify(payload))
   return new fetchAPI.Response(decodedString, {
     status,

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -512,7 +512,7 @@ export class YogaServer<
             )
           }
           // Remove http extensions from the final response
-          delete error.extensions.http
+          error.extensions.http = undefined
         }
       }
 

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -488,7 +488,7 @@ export class YogaServer<
       })
 
       return result
-    } catch (error: any) {
+    } catch (error: unknown) {
       const finalResponseInit = {
         status: 200,
         headers: {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -61,7 +61,7 @@ export interface YogaInitialContext {
   extensions?: Record<string, any>
 }
 
-export interface RequestProcessContext<TContext, TRootValue> {
+export interface RequestProcessContext<TContext> {
   request: Request
   enveloped: ReturnType<GetEnvelopedFn<TContext>>
   params: GraphQLParams
@@ -69,7 +69,7 @@ export interface RequestProcessContext<TContext, TRootValue> {
   /**
    * Response Hooks
    */
-  onResultProcessHooks: OnResultProcess<any>[]
+  onResultProcessHooks: OnResultProcess[]
 }
 
 export type CORSOptions =

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -639,6 +639,8 @@ describe('Incremental Delivery', () => {
 
     const body = await response.json()
 
+    expect(response.status).toBe(413)
+
     expect(body.errors).toBeDefined()
     expect(body.errors[0].message).toBe('File size limit exceeded: 12 bytes')
   })

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -42,6 +42,7 @@ describe('Disable Introspection with plugin', () => {
     expect(response.body.data).toBeNull()
     expect(response.body.errors![0]).toMatchInlineSnapshot(`
       Object {
+        "extensions": Object {},
         "locations": Array [
           Object {
             "column": 7,
@@ -304,20 +305,23 @@ it('parse error is sent to clients', async () => {
       body: JSON.stringify({ query: '{libl_pls' }),
     }).then((_) => _.json())
 
-    expect(result).toEqual({
-      data: null,
-      errors: [
-        {
-          locations: [
-            {
-              column: 10,
-              line: 1,
-            },
-          ],
-          message: `Syntax Error: Expected Name, found <EOF>.`,
-        },
-      ],
-    })
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "data": null,
+        "errors": Array [
+          Object {
+            "extensions": Object {},
+            "locations": Array [
+              Object {
+                "column": 10,
+                "line": 1,
+              },
+            ],
+            "message": "Syntax Error: Expected Name, found <EOF>.",
+          },
+        ],
+      }
+    `)
   } finally {
     await server.stop()
   }
@@ -339,20 +343,23 @@ it('validation error is sent to clients', async () => {
       body: JSON.stringify({ query: '{libl_pls}' }),
     }).then((_) => _.json())
 
-    expect(result).toEqual({
-      data: null,
-      errors: [
-        {
-          locations: [
-            {
-              column: 2,
-              line: 1,
-            },
-          ],
-          message: `Cannot query field "libl_pls" on type "Query".`,
-        },
-      ],
-    })
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "data": null,
+        "errors": Array [
+          Object {
+            "extensions": Object {},
+            "locations": Array [
+              Object {
+                "column": 2,
+                "line": 1,
+              },
+            ],
+            "message": "Cannot query field \\"libl_pls\\" on type \\"Query\\".",
+          },
+        ],
+      }
+    `)
   } finally {
     await server.stop()
   }
@@ -395,14 +402,15 @@ describe('Requests', () => {
       .send()
 
     expect(response.statusCode).toBe(405)
+
+    expect(response.headers['allow']).toBe('POST')
     const body = JSON.parse(response.text)
 
     expect(body.data).toEqual(null)
-    expect(body.errors).toEqual([
-      {
-        message: 'Can only perform a mutation operation from a POST request.',
-      },
-    ])
+    expect(body.errors).toHaveLength(1)
+    expect(body.errors[0].message).toEqual(
+      'Can only perform a mutation operation from a POST request.',
+    )
   })
 
   it('should send basic mutation', async () => {

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -442,12 +442,28 @@ describe('Requests', () => {
     expect(body.data.echo).toBe('hello')
   })
 
-  it('should error on malformed query', async () => {
+  it('should error on malformed JSON parameters', async () => {
+    const response = await request(yoga)
+      .post(endpoint)
+      .send('{ "query": "{ ping }"')
+
+    expect(response.statusCode).toBe(400)
+
+    const body = JSON.parse(response.text)
+
+    expect(body.errors).toBeDefined()
+    expect(body.data).toBeNull()
+  })
+
+  it('should error on malformed query string', async () => {
     const response = await request(yoga).post(endpoint).send({
       query: '{ query { ping }',
     })
 
+    expect(response.statusCode).toBe(400)
+
     const body = JSON.parse(response.text)
+
     expect(body.errors).toBeDefined()
     expect(body.data).toBeNull()
   })
@@ -458,6 +474,8 @@ describe('Requests', () => {
       .send({
         query: null,
       } as any)
+
+    expect(response.statusCode).toBe(400)
 
     const body = JSON.parse(response.text)
     expect(body.data).toBeNull()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,7 +2906,7 @@
     "@n1ru4l/push-pull-async-iterable-iterator" "^3.1.0"
     meros "^1.1.4"
 
-"@graphql-codegen/cli@^2.3.0", "@graphql-codegen/cli@^2.6.2":
+"@graphql-codegen/cli@^2.6.2":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.6.2.tgz#a9aa4656141ee0998cae8c7ad7d0bf9ca8e0c9ae"
   integrity sha512-UO75msoVgvLEvfjCezM09cQQqp32+mR8Ma1ACsBpr7nroFvHbgcu2ulx1cMovg4sxDBCsvd9Eq/xOOMpARUxtw==
@@ -2983,33 +2983,33 @@
     "@graphql-tools/utils" "^8.1.1"
     tslib "~2.3.0"
 
-"@graphql-codegen/typescript-resolvers@^2.4.2", "@graphql-codegen/typescript-resolvers@^2.6.1":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.6.3.tgz#6b14234605d9b052269f0638fd2ad4bf67853b5a"
-  integrity sha512-P+ELXivuxzbuU5I9Ye8twybzTo+NDdng6KGWvUaefnyKnbP4IP+XeddGJSFwD3/sMJvs/ZdEj0t13FncmRx2Og==
+"@graphql-codegen/typescript-resolvers@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.6.4.tgz#857e24279603f4e8f7293385a90a1f2498eb672e"
+  integrity sha512-BTV5q9d7V+4mVyYRnE8N7HyArmvDbUEY5JwyV94jhlN0AOq2zKQBrs8MRvx8v1VenjTGV+PlnDpF3aEtQu8o+g==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^2.4.0"
-    "@graphql-codegen/typescript" "^2.4.10"
-    "@graphql-codegen/visitor-plugin-common" "2.7.6"
+    "@graphql-codegen/typescript" "^2.4.11"
+    "@graphql-codegen/visitor-plugin-common" "2.8.0"
     "@graphql-tools/utils" "^8.1.1"
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/typescript@^2.4.1", "@graphql-codegen/typescript@^2.4.10", "@graphql-codegen/typescript@^2.4.8":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.4.10.tgz#245512826fc0c6663756cca6359ac4d45719af5f"
-  integrity sha512-Wr/GzYrpY8d8I9+ZFSkNefOpYaMtBL2s2E79IoEOLAqXHUWxM0reBwkEk4oHtLw27AmaXgngajPFPaO5QAhotQ==
+"@graphql-codegen/typescript@^2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.4.11.tgz#b9d8bddaeb79ff4a85e1d0f9c774afba7423177c"
+  integrity sha512-K3oDLPJRH9Wgpg9TOvb7L+xrJZ8HxkIzV2umqGn54c+8DQjvnRFBIYRO0THgUBMnEauE2sEy6RZkGHGfgQUruA==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^2.4.0"
     "@graphql-codegen/schema-ast" "^2.4.1"
-    "@graphql-codegen/visitor-plugin-common" "2.7.6"
+    "@graphql-codegen/visitor-plugin-common" "2.8.0"
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/visitor-plugin-common@2.7.6":
-  version "2.7.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.7.6.tgz#70be729551fedc090d69fe4f16272bccf5222d28"
-  integrity sha512-XHeopd8z5UE2alv8nn2LrF+qpfRpldeqHOwrmLmlzyCWcuz5vMiZ08CgtE03micQNQJg5s8Z9m72S3FrvBUoAA==
+"@graphql-codegen/visitor-plugin-common@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.8.0.tgz#f1de3bd5ee123e6f72c06423912a3a83a6044938"
+  integrity sha512-29MOaxBog7qaEhmeCzJn2mONSbcA+slCTzHN4nJ3aZl4KrC9V32rXlQpG5x0qHbFQ1LaG1f5gPO83xbiAeMBIw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^2.4.0"
     "@graphql-tools/optimize" "^1.0.1"
@@ -3182,7 +3182,7 @@
     p-limit "3.1.0"
     tslib "~2.3.0"
 
-"@graphql-tools/merge@8.2.10":
+"@graphql-tools/merge@8.2.10", "@graphql-tools/merge@^8.2.6":
   version "8.2.10"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.10.tgz#fe2fe5ad33dc2d1b0af8751c0c08d18bb6bb6d88"
   integrity sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==
@@ -3190,7 +3190,7 @@
     "@graphql-tools/utils" "8.6.9"
     tslib "~2.3.0"
 
-"@graphql-tools/merge@8.3.0", "@graphql-tools/merge@^8.2.6":
+"@graphql-tools/merge@8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.0.tgz#d3a8ba10942f8598788c3e03f97cc1d0c0b055f8"
   integrity sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==
@@ -3250,7 +3250,7 @@
     relay-compiler "12.0.0"
     tslib "~2.3.0"
 
-"@graphql-tools/schema@8.3.10":
+"@graphql-tools/schema@8.3.10", "@graphql-tools/schema@^8.0.0", "@graphql-tools/schema@^8.1.1", "@graphql-tools/schema@^8.1.2":
   version "8.3.10"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.10.tgz#c3e373e6ad854f533fc7e55859dd8f9e81de30dd"
   integrity sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==
@@ -3260,7 +3260,7 @@
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
-"@graphql-tools/schema@8.5.0", "@graphql-tools/schema@^8.0.0", "@graphql-tools/schema@^8.1.1", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.5.0":
+"@graphql-tools/schema@8.5.0", "@graphql-tools/schema@^8.5.0":
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.5.0.tgz#0332b3a2e674d16e9bf8a58dfd47432449ce2368"
   integrity sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==
@@ -3291,7 +3291,28 @@
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.11.0", "@graphql-tools/url-loader@^7.9.7":
+"@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.9.7":
+  version "7.9.20"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.9.20.tgz#3cbee69dac284fe238a853201031e072322a0368"
+  integrity sha512-APsYjsCuEAEK3mNZ7wYO0oOzDLdGzmAc9Mma9Ys8Eraxk7Y3NuS+A8r/naIM8oUq8207IRyek96fbhMqHCBGmg==
+  dependencies:
+    "@graphql-tools/delegate" "8.7.7"
+    "@graphql-tools/utils" "8.6.9"
+    "@graphql-tools/wrap" "8.4.16"
+    "@n1ru4l/graphql-live-query" "^0.9.0"
+    "@types/ws" "^8.0.0"
+    cross-undici-fetch "^0.4.0"
+    dset "^3.1.0"
+    extract-files "^11.0.0"
+    graphql-ws "^5.4.1"
+    isomorphic-ws "^4.0.1"
+    meros "^1.1.4"
+    sync-fetch "^0.3.1"
+    tslib "^2.3.0"
+    value-or-promise "^1.0.11"
+    ws "^8.3.0"
+
+"@graphql-tools/url-loader@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.11.0.tgz#c04d4d9f18af58230b589bdd55e81a003e19e5d6"
   integrity sha512-c3L/NW9MRkYct4FoQQubTf/VeBhPm0lry2EsgDdcdKmV+lOh3RQ4DAYMH61cTX++MPeQiECYEwCCm68J52xlMg==
@@ -3312,19 +3333,12 @@
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/utils@8.6.9":
-  version "8.6.9"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.9.tgz#fe1b81df29c9418b41b7a1ffe731710b93d3a1fe"
-  integrity sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==
+"@graphql-tools/utils@8.6.12", "@graphql-tools/utils@8.6.9", "@graphql-tools/utils@8.8.0", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0":
+  version "8.6.12"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.12.tgz#0a550dc0331fd9b097fe7223d65cbbee720556e4"
+  integrity sha512-WQ91O40RC+UJgZ9K+IzevSf8oolR1QE+WQ21Oyc2fgDYYiqT0eSf+HVyhZr/8x9rVjn3N9HeqCsywbdmbljg0w==
   dependencies:
-    tslib "~2.3.0"
-
-"@graphql-tools/utils@8.8.0", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0":
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.8.0.tgz#8332ff80a1da9204ccf514750dd6f5c5cccf17dc"
-  integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
-  dependencies:
-    tslib "^2.4.0"
+    tslib "~2.4.0"
 
 "@graphql-tools/wrap@8.4.16":
   version "8.4.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,7 +3333,21 @@
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/utils@8.6.12", "@graphql-tools/utils@8.6.9", "@graphql-tools/utils@8.8.0", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0":
+"@graphql-tools/utils@8.6.9":
+  version "8.6.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.9.tgz#fe1b81df29c9418b41b7a1ffe731710b93d3a1fe"
+  integrity sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==
+  dependencies:
+    tslib "~2.3.0"
+
+"@graphql-tools/utils@8.8.0", "@graphql-tools/utils@^8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.8.0.tgz#8332ff80a1da9204ccf514750dd6f5c5cccf17dc"
+  integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5":
   version "8.6.12"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.12.tgz#0a550dc0331fd9b097fe7223d65cbbee720556e4"
   integrity sha512-WQ91O40RC+UJgZ9K+IzevSf8oolR1QE+WQ21Oyc2fgDYYiqT0eSf+HVyhZr/8x9rVjn3N9HeqCsywbdmbljg0w==


### PR DESCRIPTION
- Remove the unnecessary generics from Yoga hooks
- Simplify error handling code. So we introduce a new extension field `http` that lets user to decide the HTTP status code and headers. This is still experimental. I think we can document it later.
- Handle Multipart Limit errors correctly and return 413 ( Request Entity Too Large ) HTTP status code in that case.
Closes https://github.com/dotansimha/graphql-yoga/issues/1324