### PR TITLE
Logging refactor

### DIFF
--- a/.changeset/fast-shirts-join.md
+++ b/.changeset/fast-shirts-join.md
@@ -1,14 +1,12 @@
 ## Multiple parameters are not recommended (not used internally) for log methods
 
-Previously Yoga used to send data to the provided logger like below;
+Previously sometimes Yoga used to send data to the provided logger like below;
 
 ```js
 yogaLogger.debug(arg1, arg2, arg3)
 ```
 
-This behavior is working fine with JavaScript's native `console` implementation.
-
-Then we realized some logger implementations like Pino only accepts a single parameter for its logging methods. We decided to avoid sending multiple parameters to the logger.
+This behavior is working fine with JavaScript's native `console` implementation but most of the other non native logger implementation like Pino only accept a single parameter for its logging methods. So we decided to avoid sending multiple parameters to the logger.
 However, in order to prevent a breaking change, we kept the signatures of logger methods and they will still accept multiple parameters in a single call. You should keep on mind that eventually we will stop accepting multiple parameters and have the behavior similar to Pino's.
 
 ## Note for custom logger and fastify users

--- a/.changeset/fast-shirts-join.md
+++ b/.changeset/fast-shirts-join.md
@@ -1,0 +1,34 @@
+## Multiple parameters are not recommended (not used internally) for log methods
+
+Previously Yoga used to send data to the provided logger like below;
+
+```js
+yogaLogger.debug(arg1, arg2, arg3)
+```
+
+This behavior is working fine with JavaScript's native `console` implementation.
+
+Then we realized some logger implementations like Pino only accepts a single parameter for its logging methods. We decided to avoid sending multiple parameters to the logger.
+However, in order to prevent a breaking change, we kept the signatures of logger methods and they will still accept multiple parameters in a single call. You should keep on mind that eventually we will stop accepting multiple parameters and have the behavior similar to Pino's.
+
+## Note for custom logger and fastify users
+
+We still recommend to update your `logging` parameter in `createServer` call to make sure the other parameters after the first one aren't ignored if exists;
+
+```js
+createServer({
+  ...someOtherOptions,
+  logging: {
+    // app.log is Fastify's logger
+    // You should replace it with your own if you have some other logger implementation
+    debug: (...args) => args.forEach((arg) => app.log.debug(arg)),
+    info: (...args) => args.forEach((arg) => app.log.info(arg)),
+    warn: (...args) => args.forEach((arg) => app.log.warn(arg)),
+    error: (...args) => args.forEach((arg) => app.log.error(arg)),
+  },
+})
+```
+
+## No more custom `inspect`
+
+Previously Yoga's default logger implementation was using a platform independent port of Node's `util.inspect`. It was helping us to mimic `console.log`'s behavior to serialize object in a pretty way. But we no longer use it and pass multiple parameters to `console.log/debug/info/error` instead and leave the serialization to the environment. Don't get confused with the one above :) This is an optimization with default `console` which already supports multiple values. But the improvement above is for non native logger implementations.

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -10,7 +10,8 @@
     "@graphql-yoga/node": "2.9.2",
     "fastify": "4.0.2",
     "ts-node": "10.4.0",
-    "typescript": "4.5.2"
+    "typescript": "4.5.2",
+    "pino-pretty": "8.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.11.7"

--- a/examples/fastify/src/app.ts
+++ b/examples/fastify/src/app.ts
@@ -55,7 +55,12 @@ export function buildApp(logging = true) {
       },
     },
     // Integrate Fastify Logger to Yoga
-    logging: app.log,
+    logging: {
+      debug: (...args) => args.forEach((arg) => app.log.debug(arg)),
+      info: (...args) => args.forEach((arg) => app.log.info(arg)),
+      warn: (...args) => args.forEach((arg) => app.log.warn(arg)),
+      error: (...args) => args.forEach((arg) => app.log.error(arg)),
+    },
   })
 
   app.addContentTypeParser('multipart/form-data', {}, (req, payload, done) =>

--- a/examples/fastify/src/app.ts
+++ b/examples/fastify/src/app.ts
@@ -2,7 +2,14 @@ import { createServer } from '@graphql-yoga/node'
 import fastify, { FastifyReply, FastifyRequest } from 'fastify'
 
 export function buildApp(logging = true) {
-  const app = fastify({ logger: logging })
+  const app = fastify({
+    logger: logging && {
+      transport: {
+        target: 'pino-pretty',
+      },
+      level: 'debug',
+    },
+  })
 
   const graphQLServer = createServer<{
     req: FastifyRequest

--- a/examples/fastify/src/index.ts
+++ b/examples/fastify/src/index.ts
@@ -3,7 +3,9 @@ import { buildApp } from './app'
 const app = buildApp(true)
 
 app
-  .listen(4000)
+  .listen({
+    port: 4000,
+  })
   .then((serverUrl) => {
     app.log.info(`GraphQL API located at ${serverUrl}/graphql`)
   })

--- a/examples/sveltekit/__tests__/test.ts
+++ b/examples/sveltekit/__tests__/test.ts
@@ -5,7 +5,7 @@ let browser: puppeteer.Browser;
 let page: puppeteer.Page;
 let sveltekitProcess: ReturnType<typeof spawn>;
 
-jest.setTimeout(10000);
+jest.setTimeout(60000);
 
 describe('SvelteKit integration', () => {
 	beforeAll(async () => {
@@ -50,7 +50,7 @@ describe('SvelteKit integration', () => {
 
 		// 1/ Wait for the introspection query result getting our type "hello"
 		let res = await page.waitForResponse((res) => res.url().endsWith('/api/graphql'), {
-			timeout: 3000
+			timeout: 0
 		}); // It's the response... It can take a bit of time in the CI... (Magic number to find it easily)
 		let json = await res.json();
 		let str = JSON.stringify(json, null, 0);
@@ -60,7 +60,7 @@ describe('SvelteKit integration', () => {
 		const buttonExecute = await page.waitForSelector(`button[class="execute-button"]`);
 		buttonExecute?.click();
 		res = await page.waitForResponse((res) => res.url().endsWith('/api/graphql'), {
-			timeout: 3000
+			timeout: 0
 		}); // It's the response... It can take a bit of time in the CI... (Magic number to find it easily)
 		json = await res.json();
 		str = JSON.stringify(json, null, 0);

--- a/packages/common/__tests__/logging.test.ts
+++ b/packages/common/__tests__/logging.test.ts
@@ -28,17 +28,13 @@ describe('Logging', () => {
     it(`doesn't print debug messages if DEBUG env var isn't set`, () => {
       jest.spyOn(console, 'debug')
       defaultYogaLogger.debug('TEST')
-      expect(console.debug).not.toHaveBeenCalledWith(
-        expect.stringContaining('TEST'),
-      )
+      expect(console.debug).not.toHaveBeenCalled()
     })
     it(`prints debug messages if DEBUG env var is set`, () => {
       process.env.DEBUG = '1'
       jest.spyOn(console, 'debug').mockImplementationOnce(() => {})
       defaultYogaLogger.debug('TEST')
-      expect(console.debug).toHaveBeenCalledWith(
-        expect.stringContaining('TEST'),
-      )
+      expect(console.debug).toHaveBeenCalled()
     })
   })
 })

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -1,5 +1,3 @@
-import { inspect } from '@graphql-tools/utils'
-
 type MessageTransformer = (msg: string) => string
 
 const ANSI_CODES = {
@@ -27,6 +25,15 @@ export const debugColor: MessageTransformer = (msg) =>
 export const titleBold: MessageTransformer = (msg) =>
   ANSI_CODES.bold + msg + ANSI_CODES.reset
 
+const LEVEL_COLOR = {
+  warn: ANSI_CODES.orange,
+  info: ANSI_CODES.cyan,
+  error: ANSI_CODES.red,
+  debug: ANSI_CODES.magenta,
+  title: ANSI_CODES.bold,
+  reset: ANSI_CODES.reset,
+}
+
 export interface YogaLogger {
   debug: (...args: any[]) => void
   info: (...args: any[]) => void
@@ -42,54 +49,66 @@ const isDebug = () =>
     ? true
     : false
 
-function getPrefix() {
-  return titleBold(`🧘 Yoga -`)
-}
-
-function getLoggerMessage(...args: any[]) {
-  return args
-    .map((arg) => (typeof arg === 'string' ? arg : inspect(arg)))
-    .join(` `)
-}
+const prefix = [LEVEL_COLOR.title, `🧘 Yoga -`, LEVEL_COLOR.reset]
 
 export const defaultYogaLogger: YogaLogger = {
   debug(...args: any[]) {
     if (isDebug()) {
-      const message = getLoggerMessage(...args)
-      const fullMessage = `🐛 ${getPrefix()} ${debugColor(message)}`
+      const fullMessage = [
+        `🐛 `,
+        ...prefix,
+        LEVEL_COLOR.debug,
+        ...args,
+        LEVEL_COLOR.reset,
+      ]
       // Some environments don't have other console methods
       if (console.debug) {
-        console.debug(fullMessage)
+        console.debug(...fullMessage)
       } else {
-        console.log(fullMessage)
+        console.log(...fullMessage)
       }
     }
   },
   info(...args: any[]) {
-    const message = getLoggerMessage(...args)
-    const fullMessage = `💡 ${getPrefix()} ${infoColor(message)}`
+    const fullMessage = [
+      `💡 `,
+      ...prefix,
+      LEVEL_COLOR.info,
+      ...args,
+      LEVEL_COLOR.reset,
+    ]
     if (console.info) {
-      console.info(fullMessage)
+      console.info(...fullMessage)
     } else {
-      console.log(fullMessage)
+      console.log(...fullMessage)
     }
   },
   warn(...args: any[]) {
-    const message = getLoggerMessage(...args)
-    const fullMessage = `⚠️ ${getPrefix()} ${warnColor(message)}`
+    const fullMessage = [
+      `⚠️ `,
+      ...prefix,
+      LEVEL_COLOR.warn,
+      ...args,
+      LEVEL_COLOR.reset,
+    ]
     if (console.warn) {
-      console.warn(fullMessage)
+      console.warn(...fullMessage)
     } else {
-      console.log(fullMessage)
+      console.log(...fullMessage)
     }
   },
   error(...args: any[]) {
-    const message = getLoggerMessage(...args)
-    const fullMessage = `❌ ${getPrefix()} ${errorColor(message)}`
+    const fullMessage = [
+      `❌ `,
+      ...prefix,
+      LEVEL_COLOR.error,
+      ...args,
+      LEVEL_COLOR.reset,
+    ]
     if (console.error) {
-      console.error(fullMessage)
+      console.error(...fullMessage)
     } else {
-      console.log(fullMessage)
+      console.log(...fullMessage)
     }
   },
 }

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -293,26 +293,20 @@ export class YogaServer<
                   variables,
                   extensions,
                 }: YogaInitialContext = events.args.contextValue
-                if (query) {
-                  this.logger.debug(
-                    '\n' + titleBold('Received GraphQL operation:') + '\n',
-                    query,
-                  )
-                }
-                if (operationName) {
-                  this.logger.debug('\t operationName:', operationName)
-                }
-                if (variables) {
-                  this.logger.debug('\t variables:', variables)
-                }
-                if (extensions) {
-                  this.logger.debug('\t extensions:', extensions)
-                }
+                this.logger.debug(titleBold('Received GraphQL operation:'))
+                this.logger.debug({
+                  query,
+                  operationName,
+                  variables,
+                  extensions,
+                })
                 break
               case 'execute-end':
               case 'subscribe-end':
                 this.logger.debug(titleBold('Execution end'))
-                this.logger.debug('\t result:', events.result)
+                this.logger.debug({
+                  result: events.result,
+                })
                 break
             }
           },

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -131,7 +131,7 @@ class YogaNodeServer<
           },
         )
       } catch (e: any) {
-        this.logger.error(`GraphQL Server couldn't start`, e)
+        this.logger.error(`GraphQL Server couldn't start;\n${e.stack}`)
         reject(e)
       }
     })
@@ -147,8 +147,7 @@ class YogaNodeServer<
       this.nodeServer.close((err) => {
         if (err != null) {
           this.logger.error(
-            'Something went wrong while trying to shutdown the server',
-            err,
+            `Something went wrong while trying to shutdown the server;\n${err.stack}`,
           )
           reject(err)
         } else {

--- a/website/docs/integrations/integration-with-fastify.mdx
+++ b/website/docs/integrations/integration-with-fastify.mdx
@@ -29,7 +29,12 @@ const graphQLServer = createServer<{
   reply: FastifyReply
 }>({
   // Integrate Fastify logger
-  logging: app.log,
+  logging: {
+    debug: (...args) => args.forEach((arg) => app.log.debug(arg)),
+    info: (...args) => args.forEach((arg) => app.log.info(arg)),
+    warn: (...args) => args.forEach((arg) => app.log.warn(arg)),
+    error: (...args) => args.forEach((arg) => app.log.error(arg)),
+  },
 })
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,10 +3682,18 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
-"@jridgewell/trace-mapping@0.3.9", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.10.tgz#db436f0917d655393851bc258918c00226c9b183"
+  integrity sha512-Q0YbBd6OTsXm8Y21+YUSDXupHnodNC2M4O18jtd3iwJ3+vMZNdKGols0a9G6JOK0dcJ3IdUUHoh908ZI6qhk8Q==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -6897,6 +6905,16 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+args@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/args/-/args-5.0.1.tgz#4bf298df90a4799a09521362c579278cc2fdd761"
+  integrity sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==
+  dependencies:
+    camelcase "5.0.0"
+    chalk "2.4.2"
+    leven "2.1.0"
+    mri "1.1.4"
+
 aria-hidden@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
@@ -7997,6 +8015,11 @@ camelcase-keys@^7.0.0:
     quick-lru "^5.1.1"
     type-fest "^1.2.1"
 
+camelcase@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -8487,6 +8510,11 @@ colorette@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
+colorette@^2.0.7:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.18.tgz#4c260bcf86437ce94fa58e2e49a83b623f3c4d66"
+  integrity sha512-rHDY1i4V4JBCXHnHwaVyA202CKSj2kUrjI5cSJQbTdnFeI4ShV3e19Fe7EQfzL2tjSrvYyWugdGAtEc1lLvGDg==
 
 colors-option@^3.0.0:
   version "3.0.0"
@@ -9415,6 +9443,11 @@ date-time@^3.1.0:
   integrity sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==
   dependencies:
     time-zone "^1.0.0"
+
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debounce@^1.2.0:
   version "1.2.1"
@@ -11350,6 +11383,11 @@ extract-zip@2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
+
+fast-copy@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.3.tgz#bf6e05ac3cb7a9d66fbf12c51dd4440e9ddd4afb"
+  integrity sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -14457,7 +14495,7 @@ jose@^4.1.4, jose@^4.3.7:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.8.1.tgz#dc7c2660b115ba29b44880e588c5ac313c158247"
   integrity sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==
 
-joycon@^3.0.1:
+joycon@^3.0.1, joycon@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
@@ -14842,6 +14880,11 @@ lazystream@^1.0.0:
   integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
   dependencies:
     readable-stream "^2.0.5"
+
+leven@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -16443,6 +16486,11 @@ move-file@^3.0.0:
   dependencies:
     path-exists "^5.0.0"
 
+mri@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
+
 mri@^1.1.0, mri@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -17326,6 +17374,11 @@ omit.js@^2.0.2:
   resolved "https://registry.yarnpkg.com/omit.js/-/omit.js-2.0.2.tgz#dd9b8436fab947a5f3ff214cb2538631e313ec2f"
   integrity sha512-hJmu9D+bNB40YpL9jYebQl4lsTW6yEHRTroJzNLqQJYHm7c+NQnJGfZmIWh8S3q3KoaxV1aLhV6B3+0N0/kyJg==
 
+on-exit-leak-free@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz#b39c9e3bf7690d890f4861558b0d7b90a442d209"
+  integrity sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==
+
 on-exit-leak-free@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz#4a2accb382278a266848bb1a21439e5fc3cd9881"
@@ -18027,7 +18080,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pino-abstract-transport@v0.5.0:
+pino-abstract-transport@^0.5.0, pino-abstract-transport@v0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz#4b54348d8f73713bfd14e3dc44228739aa13d9c0"
   integrity sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==
@@ -18035,10 +18088,29 @@ pino-abstract-transport@v0.5.0:
     duplexify "^4.1.2"
     split2 "^4.0.0"
 
+pino-pretty@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-8.0.0.tgz#adb99b0da4624edff04d0e9fc756638b9feabe2c"
+  integrity sha512-6Zn+2HBc8ZXEJb1XYZfY0Kh0jVBeKxmu077BzE0wzJZzQwNffmdQbIH7bNe0WPLjLApnVTx8TvvR8UNUcgE4nA==
+  dependencies:
+    args "5.0.1"
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^2.1.1"
+    fast-safe-stringify "^2.0.7"
+    joycon "^3.1.1"
+    on-exit-leak-free "^0.2.0"
+    pino-abstract-transport "^0.5.0"
+    pump "^3.0.0"
+    readable-stream "^3.6.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^2.2.0"
+    strip-json-comments "^3.1.1"
+
 pino-std-serializers@^5.0.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-5.5.0.tgz#7693eb57c1420c9bbb10454a30d15f747be9cfa5"
-  integrity sha512-nfUj7JpkLStgTGdeq20KsNDZMsZoAcTlOKXxoSQBKQTcBbVAFTYUdkw7NADlEeFadqpnKN4w2fWHbpGLsdQXIg==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-5.6.0.tgz#31b141155d6520967c5ec72944d08fb45c490fd3"
+  integrity sha512-VdUXCw8gO+xhir7sFuoYSjTnzB+TMDGxhAC/ph3YS3sdHnXNdsK0wMtADNUltfeGkn2KDxEM21fnjF3RwXyC8A==
 
 pino@^8.0.0:
   version "8.0.0"
@@ -20018,6 +20090,13 @@ socks@^2.3.3:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.2.0"
+
+sonic-boom@^2.2.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-2.8.0.tgz#c1def62a77425090e6ad7516aad8eb402e047611"
+  integrity sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==
+  dependencies:
+    atomic-sleep "^1.0.0"
 
 sonic-boom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Multiple parameters are not recommended (not used internally) for log methods

Previously sometimes Yoga used to send data to the provided logger like below;

```js
yogaLogger.debug(arg1, arg2, arg3)
```

This behavior is working fine with JavaScript's native `console` implementation but most of the other non native logger implementation like Pino only accept a single parameter for its logging methods. So we decided to avoid sending multiple parameters to the logger.
However, in order to prevent a breaking change, we kept the signatures of logger methods and they will still accept multiple parameters in a single call. You should keep on mind that eventually we will stop accepting multiple parameters and have the behavior similar to Pino's.

## Note for custom logger and fastify users

We still recommend to update your `logging` parameter in `createServer` call to make sure the other parameters after the first one aren't ignored if exists;

```js
createServer({
  ...someOtherOptions,
  logging: {
    // app.log is Fastify's logger
    // You should replace it with your own if you have some other logger implementation
    debug: (...args) => args.forEach((arg) => app.log.debug(arg)),
    info: (...args) => args.forEach((arg) => app.log.info(arg)),
    warn: (...args) => args.forEach((arg) => app.log.warn(arg)),
    error: (...args) => args.forEach((arg) => app.log.error(arg)),
  },
})
```

## No more custom `inspect`

Previously Yoga's default logger implementation was using a platform independent port of Node's `util.inspect`. It was helping us to mimic `console.log`'s behavior to serialize object in a pretty way. But we no longer use it and pass multiple parameters to `console.log/debug/info/error` instead and leave the serialization to the environment. Don't get confused with the one above :) This is an optimization with default `console` which already supports multiple values. But the improvement above is for non native logger implementations.
