### PR TITLE
Fix typo in AWS Lambda Integration doc

### DIFF
--- a/website/docs/integrations/integration-with-aws-lambda.mdx
+++ b/website/docs/integrations/integration-with-aws-lambda.mdx
@@ -29,7 +29,7 @@ export const handler: Handler = configure({
   // Pass Yoga as app
   app,
   // Pass Yoga's logger to listen to the logs from Serverless Express as well
-  log: server.logger,
+  log: app.logger,
 })
 ```
 


### PR DESCRIPTION
Syncs the code here with the example repo code: https://github.com/dotansimha/graphql-yoga/blob/8922c3b5bc693f0806c8676e7484a58838ddba9e/examples/aws-lambda/lambda/graphql.ts#L9