### PR TITLE
chore: fix the invalid changeset added within #1292

### DIFF
--- a/.changeset/fast-shirts-join.md
+++ b/.changeset/fast-shirts-join.md
@@ -1,3 +1,8 @@
+---
+'@graphql-yoga/common': patch
+'@graphql-yoga/node': patch
+---
+
 ## Multiple parameters are not recommended (not used internally) for log methods
 
 Previously sometimes Yoga used to send data to the provided logger like below;


### PR DESCRIPTION
https://github.com/dotansimha/graphql-yoga/pull/1292 introduced a changeset that broke the builds, due to a missing version bump header.

I added these a patch changes, but it is open for discussion whether this is actually a major (breaking) change...