### PR TITLE
Refactor request processing

### DIFF
--- a/packages/common/src/plugins/requestValidation/useCheckGraphQLQueryParam.ts
+++ b/packages/common/src/plugins/requestValidation/useCheckGraphQLQueryParam.ts
@@ -1,0 +1,25 @@
+import { createGraphQLError } from '@graphql-tools/utils'
+import { Plugin } from '../types'
+
+export function useCheckGraphQLQueryParam(): Plugin {
+  return {
+    onRequestParse() {
+      return {
+        onRequestParseDone({ params }) {
+          if (params.query == null) {
+            throw createGraphQLError('Must provide query string.', {
+              extensions: {
+                http: {
+                  status: 400,
+                  headers: {
+                    Allow: 'GET, POST',
+                  },
+                },
+              },
+            })
+          }
+        },
+      }
+    },
+  }
+}

--- a/packages/common/src/plugins/requestValidation/useCheckMethodForGraphQL.ts
+++ b/packages/common/src/plugins/requestValidation/useCheckMethodForGraphQL.ts
@@ -1,0 +1,24 @@
+import { createGraphQLError } from '@graphql-tools/utils'
+import { Plugin } from '../types'
+
+export function useCheckMethodForGraphQL(): Plugin {
+  return {
+    onRequest({ request }) {
+      if (request.method !== 'GET' && request.method !== 'POST') {
+        throw createGraphQLError(
+          'GraphQL only supports GET and POST requests.',
+          {
+            extensions: {
+              http: {
+                status: 405,
+                headers: {
+                  Allow: 'GET, POST',
+                },
+              },
+            },
+          },
+        )
+      }
+    },
+  }
+}

--- a/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
+++ b/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
@@ -1,0 +1,19 @@
+import { AggregateError } from '@graphql-tools/utils'
+import { Plugin } from '../types'
+
+export function useHTTPValidationError(): Plugin {
+  return {
+    onValidate() {
+      return ({ valid, result }) => {
+        if (!valid) {
+          result.forEach((error) => {
+            error.extensions.http = {
+              status: 400,
+            }
+          })
+          throw new AggregateError(result)
+        }
+      }
+    },
+  }
+}

--- a/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
+++ b/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
@@ -1,0 +1,55 @@
+import { createGraphQLError } from '@graphql-tools/utils'
+import { OperationDefinitionNode, getOperationAST, GraphQLError } from 'graphql'
+import { YogaInitialContext } from '../../types'
+import { Plugin } from '../types'
+
+export function usePreventMutationViaGET(): Plugin<YogaInitialContext> {
+  return {
+    onParse() {
+      // We should improve this by getting Yoga stuff from the hook params directly instead of the context
+      return ({ result, context: { request, operationName } }) => {
+        if (result instanceof Error) {
+          if (result instanceof GraphQLError) {
+            result.extensions.http = {
+              status: 400,
+            }
+          }
+          throw result
+        }
+
+        const operation: OperationDefinitionNode | undefined = result
+          ? getOperationAST(result, operationName) ?? undefined
+          : undefined
+
+        if (!operation) {
+          throw createGraphQLError(
+            'Could not determine what operation to execute.',
+            {
+              extensions: {
+                http: {
+                  status: 400,
+                },
+              },
+            },
+          )
+        }
+
+        if (operation.operation === 'mutation' && request.method === 'GET') {
+          throw createGraphQLError(
+            'Can only perform a mutation operation from a POST request.',
+            {
+              extensions: {
+                http: {
+                  status: 405,
+                  headers: {
+                    Allow: 'POST',
+                  },
+                },
+              },
+            },
+          )
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
Motivation;
This PR moves all the business logic done for covering the spec from `processRequest` to individual plugins by using Envelop and Yoga's hooks. 
So we can see the default request/execution flow is now more clear because all those null checks etc looks a bit messy even if we try to keep them clean in that `processRequest` function.
It is more clear that we get the request object first, then extract GraphQL params with the specific request processor. After that, we parse the query parameter then validate it etc etc.
See here;
https://github.com/dotansimha/graphql-yoga/blob/6a20a3183f340922b9975b9785837dda72e7c832/packages/common/src/processRequest.ts#L18

Possible next tasks;
- Later we can categorize tests by the plugin to make it easier to find, maintain and update in the long term because I think we have a single huge `spec.ts` file to test all those validations and checks.
- `processRequest` function can retire and be a method in the server class or we can do other way around by breaking that class into individual function and make `createServer` a real factory function that returns an object instead of an instance of a class.

Some concerns;
 - We need to call `getOperationAST` twice in two different places: 
 - - 1: https://github.com/dotansimha/graphql-yoga/pull/1329/files#diff-bbe0c2e07695c40dadb4f2d90fceb65b11c3249ed309a8abba9634c845612ac8R21
 - - 2: https://github.com/dotansimha/graphql-yoga/pull/1329/files#diff-a2977091e2f5e1a3e732621087a5d072f751461b569ef500a0e3975b59a5c6f2R35
 - We can only access Yoga stuff through the context. If we integrate with Envelop, we can improve here.
 https://github.com/dotansimha/graphql-yoga/pull/1329/files#diff-bbe0c2e07695c40dadb4f2d90fceb65b11c3249ed309a8abba9634c845612ac8R10
 - We might need a comment there that call has side effects and we handle http errors in a different place.
 https://github.com/dotansimha/graphql-yoga/pull/1329/files#diff-a2977091e2f5e1a3e732621087a5d072f751461b569ef500a0e3975b59a5c6f2R21