### PR TITLE
add test to ensure yoga does not corrupt uploaded files + update Next.js examples/instructions

### DIFF
--- a/examples/nextjs-auth/pages/api/graphql.ts
+++ b/examples/nextjs-auth/pages/api/graphql.ts
@@ -1,10 +1,17 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { createServer } from '@graphql-yoga/node'
-import { NextApiRequest, NextApiResponse } from 'next'
-import { Session } from 'next-auth'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import type { Session } from 'next-auth'
 import { getSession } from 'next-auth/react'
 
-const server = createServer<
+export const config = {
+  api: {
+    // Disable body parsing (required for file uploads)
+    bodyParser: false,
+  },
+}
+
+export default createServer<
   {
     req: NextApiRequest
     res: NextApiResponse
@@ -53,5 +60,3 @@ const server = createServer<
     defaultQuery: `query Session { session { expires user { id email image } } }`,
   },
 })
-
-export default server

--- a/examples/nextjs/pages/api/graphql.ts
+++ b/examples/nextjs/pages/api/graphql.ts
@@ -1,10 +1,15 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { createServer } from '@graphql-yoga/node'
-import { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-const server = createServer<{
+export const config = {
+  api: {
+    // Disable body parsing (required for file uploads)
+    bodyParser: false,
+  },
+}
+
+export default createServer<{
   req: NextApiRequest
   res: NextApiResponse
 }>()
-
-export default server

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -717,7 +717,7 @@ function md5File(path: string) {
   })
 }
 
-describe.only('file uploads', () => {
+describe('file uploads', () => {
   it('uploading and streaming a binary file succeeds', async () => {
     const sourceFilePath = path.join(
       __dirname,

--- a/website/docs/integrations/integration-with-nextjs.mdx
+++ b/website/docs/integrations/integration-with-nextjs.mdx
@@ -18,14 +18,19 @@ type: Guide
 ```ts
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { createServer } from '@graphql-yoga/node'
-import { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-const server = createServer<{
+export const config = {
+  api: {
+    // Disable body parsing (required for file uploads)
+    bodyParser: false,
+  },
+}
+
+export default createServer<{
   req: NextApiRequest
   res: NextApiResponse
 }>()
-
-export default server
 ```
 
 > You can also check a full example on our GitHub repository [here](https://github.com/dotansimha/graphql-yoga/tree/master/examples/nextjs)


### PR DESCRIPTION
Trying to reproduce https://github.com/dotansimha/graphql-yoga/issues/1331 with `@graphql-yoga/node` in standalone mode. It seems like file uploads only get corrupted with Next.js, which I reproduced locally (See https://github.com/n1ru4l/next-js-yoga-file-upload-reproduction#readme).

______

Closes https://github.com/dotansimha/graphql-yoga/issues/1331