### PR TITLE
Bring back Node 12 support

### DIFF
--- a/.changeset/bright-monkeys-cry.md
+++ b/.changeset/bright-monkeys-cry.md
@@ -1,0 +1,9 @@
+---
+'@graphql-yoga/node': patch
+---
+
+Bring back Node 12 support
+
+Even if Node 12 reached the end of its life, we keep supporting it until the next major release.
+
+So in the previous release, we broke this support because of the new import names of Node's native packages such as `node:http` instead of `http`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [12, 14, 16, 18]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/packages/node/src/http-utils.ts
+++ b/packages/node/src/http-utils.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { Readable } from 'node:stream'
+import { Readable } from 'stream'
 import type { AddressInfo } from './types.js'
-import { Socket } from 'node:net'
+import type { Socket } from 'node:net'
 import { isAsyncIterable } from '@graphql-tools/utils'
 
 export interface NodeRequest {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,12 +4,12 @@ import {
   RequestListener,
   Server as NodeServer,
   ServerResponse,
-} from 'node:http'
-import { createServer as createHttpsServer } from 'node:https'
+} from 'http'
+import { createServer as createHttpsServer } from 'https'
 import { getNodeRequest, NodeRequest, sendNodeResponse } from './http-utils.js'
 import { YogaServer } from '@graphql-yoga/common'
 import type { YogaNodeServerOptions, AddressInfo } from './types.js'
-import { platform, release } from 'node:os'
+import { platform, release } from 'os'
 import { create } from 'cross-undici-fetch'
 
 class YogaNodeServer<


### PR DESCRIPTION
Even if Node 12 reached the end of its life, we keep supporting it until the next major release.

So in the previous release, we broke this support because of the new import names of Node's native packages such as `node:http` instead of `http`.