### PR TITLE
docs(envelop): fix typo in envelop example

### DIFF
--- a/website/docs/features/envelop-plugins.mdx
+++ b/website/docs/features/envelop-plugins.mdx
@@ -12,7 +12,7 @@ GraphQL Yoga uses [Envelop](https://envelop.dev) under the hood so you can easil
 The following example adds [GraphQL JIT](https://github.com/zalando-incubator/graphql-jit) to our GraphQL Server using [Envelop GraphQL JIT Plugin](https://www.envelop.dev/plugins/use-graphql-jit)
 
 ```ts
-import { useGraphQLJit } from '@envelop/graphql-jit'
+import { useGraphQlJit } from '@envelop/graphql-jit'
 import { createServer } from '@graphql-yoga/node'
 
 // Provide your schema


### PR DESCRIPTION
Fixing a small typo in the envelop example.