### PR TITLE
Update subscriptions.mdx

### DIFF
--- a/website/docs/features/subscriptions.mdx
+++ b/website/docs/features/subscriptions.mdx
@@ -177,10 +177,12 @@ const client = createClient({
       forwardSubscription(operation) {
         const url = new URL('http://localhost:4000/graphql')
         url.searchParams.append('query', operation.query)
-        url.searchParams.append(
-          'variables',
-          JSON.stringify(operation.variables || {}),
-        )
+        if (operation.variables) {
+          url.searchParams.append(
+            'variables',
+            JSON.stringify(operation.variables),
+          )
+        }
         return {
           subscribe: (sink) => {
             const eventsource = new EventSource(url.toString(), {

--- a/website/docs/features/subscriptions.mdx
+++ b/website/docs/features/subscriptions.mdx
@@ -179,7 +179,7 @@ const client = createClient({
         url.searchParams.append('query', operation.query)
         url.searchParams.append(
           'variables',
-          JSON.stringify(operation.variables),
+          JSON.stringify(operation.variables || {}),
         )
         return {
           subscribe: (sink) => {


### PR DESCRIPTION
Hey,
the urql example is failing, if no variables exists. The query will contain `variables=undefined` which will end in an error.

Better to use either the proposed change or that:
```
if (operation.variables) {
    url.searchParams.append('variables', JSON.stringify(operation.variables));
}
```