### PR TITLE
Deprecate '.start' and '.stop' methods for common package

### DIFF
--- a/.changeset/chilly-zebras-tell.md
+++ b/.changeset/chilly-zebras-tell.md
@@ -1,0 +1,22 @@
+---
+'@graphql-yoga/common': minor
+---
+
+Deprecate `.start` and `.stop` in favor of more clear usage for Service Workers API which is used by Cloudflare Workers.
+Now Yoga implements `EventListenerObject` which has a `handleEvent` method that is an event listener function.
+
+NOTE: `.start` and `.stop` are going to be deprecated in the next major release.
+
+```ts
+import { createServer } from '@graphql-yoga/common'
+
+const yoga = createServer({
+  //...
+})
+
+//Before: yoga.start();
+self.addEventListener('fetch', yoga)
+
+//Before: yoga.stop();
+self.removeEventListener('fetch', yoga)
+```

--- a/examples/cloudflare-advanced/src/index.ts
+++ b/examples/cloudflare-advanced/src/index.ts
@@ -77,7 +77,7 @@ const server = createServer({
           async *subscribe() {
             while (true) {
               yield { time: new Date().toISOString() }
-              await new Promise((resolve) => setTimeout(resolve, 1000))
+              await new Promise((resolve) => setTimeout(resolve, 1000, {}))
             }
           },
         },
@@ -102,4 +102,4 @@ const server = createServer({
   },
 })
 
-server.start()
+self.addEventListener('fetch', server)

--- a/examples/cloudflare-modules/tsconfig.json
+++ b/examples/cloudflare-modules/tsconfig.json
@@ -6,8 +6,7 @@
     "lib": ["esnext"],
     "moduleResolution": "node",
     "sourceMap": true,
-    "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types"]
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "test"]

--- a/examples/file-upload-nexus/tsconfig.json
+++ b/examples/file-upload-nexus/tsconfig.json
@@ -7,6 +7,6 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "lib": ["esnext", "dom"]
+    "lib": ["esnext"]
   }
 }

--- a/examples/file-upload/tsconfig.json
+++ b/examples/file-upload/tsconfig.json
@@ -7,6 +7,6 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "lib": ["esnext", "dom"]
+    "lib": ["esnext"]
   }
 }

--- a/examples/service-worker/src/index.ts
+++ b/examples/service-worker/src/index.ts
@@ -2,4 +2,4 @@ import { createServer } from '@graphql-yoga/common'
 
 const server = createServer()
 
-server.start()
+self.addEventListener('fetch', server)

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -108,11 +108,6 @@ declare global {
   }
 }
 
-export type FetchEvent = Event & {
-  respondWith: (response: PromiseOrValue<Response>) => void
-  request: Request
-}
-
 export type FetchAPI = {
   /**
    * WHATWG compliant Request object constructor

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "module": "node16",
     "target": "es2018",
-    "lib": ["es6", "esnext", "es2015", "dom", "webworker"],
+    "lib": ["esnext", "webworker"],
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
@@ -35,5 +35,5 @@
     "jsx": "preserve"
   },
   "include": ["packages"],
-  "exclude": ["**/dist", "**/temp", "**/.bob"]
+  "exclude": ["**/dist", "**/temp", "**/.bob", "**/examples"]
 }

--- a/website/docs/integrations/integration-with-cloudflare-workers.mdx
+++ b/website/docs/integrations/integration-with-cloudflare-workers.mdx
@@ -38,7 +38,7 @@ import { createServer } from '@graphql-yoga/common'
 
 const server = createServer()
 
-server.start()
+self.addEventListener('fetch', server)
 ```
 
 > You can also check a full example on our GitHub repository [here](https://github.com/dotansimha/graphql-yoga/tree/master/examples/service-worker)


### PR DESCRIPTION
Handling a platform-specific logic inside Yoga is a bit confusing. This PR implements `EventListenerObject.handleEvent` method for Yoga so Yoga can be used as an event listener directly then it can be used with any event target.
And having an extra `.start()`, `.stop()` doesn't make sense in this case.

This PR also adds a deprecation notice to those existing methods to encourage people for the new usage.

```ts
import { createServer } from '@graphql-yoga/common'

const yoga = createServer({
  //...
})

//Before: yoga.start();
self.addEventListener('fetch', yoga)

//Before: yoga.stop();
self.removeEventListener('fetch', yoga)
```
