### PR TITLE
fix: incremental delivery and subscription source cleanup

### DIFF
--- a/.changeset/unlucky-bobcats-cheer.md
+++ b/.changeset/unlucky-bobcats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/node': patch
+---
+
+Previously the async iterable returned by GraphQL executor isn't cleaned up properly on Node environments because ReadableStream implementation of Node doesn't call defined "cancel" method in the right time. Now it has been patched in cross-undici-fetch and we ensure "Response.body" is destroyed after Node.js's ServerResponse is ended by any means

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12, 14, 16, 18]
+      fail-fast: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@graphql-yoga/node": "2.13.2",
-    "cross-undici-fetch": "^0.4.2",
+    "cross-undici-fetch": "^0.4.13",
     "graphql": "^16.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "resolutions": {
     "@changesets/apply-release-plan": "6.0.0",
     "graphql": "16.5.0",
-    "cross-undici-fetch": "0.4.11",
+    "cross-undici-fetch": "0.4.13",
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.17",
     "react": "17.0.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -71,7 +71,7 @@
     "@graphql-tools/schema": "^8.5.0",
     "@graphql-tools/utils": "^8.8.0",
     "@graphql-yoga/subscription": "^2.2.2",
-    "cross-undici-fetch": "^0.4.2",
+    "cross-undici-fetch": "^0.4.13",
     "dset": "^3.1.1",
     "tslib": "^2.3.1"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -67,7 +67,7 @@
     "@graphql-tools/utils": "^8.8.0",
     "@graphql-yoga/common": "^2.12.2",
     "@graphql-yoga/subscription": "^2.2.2",
-    "cross-undici-fetch": "^0.4.2",
+    "cross-undici-fetch": "^0.4.13",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8885,10 +8885,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-undici-fetch@0.4.11, cross-undici-fetch@^0.3.5, cross-undici-fetch@^0.4.0, cross-undici-fetch@^0.4.2:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/cross-undici-fetch/-/cross-undici-fetch-0.4.11.tgz#bef38dc729a01db6e07c84fee6de1089b5d3d0a4"
-  integrity sha512-pRp+EWewyOPYIeUvwOqCIqylCFWqlBwwr6nlZB38v3PhWxS1RYfSgHUJApYTT8jm71SbL5p4qg5kUQv6ZyS24A==
+cross-undici-fetch@0.4.13, cross-undici-fetch@^0.3.5, cross-undici-fetch@^0.4.0, cross-undici-fetch@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/cross-undici-fetch/-/cross-undici-fetch-0.4.13.tgz#cc693121267f8203217e0c8768d3d4cf97889b44"
+  integrity sha512-7g4hCZcq/9DiYhF43lRWgtZjPqg8tMrjG3eO94QiFQcdFR4TcmcT0Czdu7H+brXDkdbWJQrjYCV93ggE61INDA==
   dependencies:
     abort-controller "^3.0.0"
     busboy "^1.6.0"


### PR DESCRIPTION
AsyncIterables returned from the `subscribe/execute` functions are not cleaned up (the `return` function is not called).
This causes memory leaks which results in the server going out of memory and crashing.

I created an integration test that proves a subscription is not cleaned up. 

It seems like the underlying issue might be within cross-undici-fetch but I am not 100% sure what is going wrong here.


________


Runnable example on CodeSandbox over here: https://codesandbox.io/s/regression-subscription-not-closed-d8d5mj?file=/index.ts


