### PR TITLE
[merge this and you are getting fired] resolve subscription issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12, 14, 16, 18]
+      fail-fast: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/packages/common/src/plugins/resultProcessor/multipart.ts
+++ b/packages/common/src/plugins/resultProcessor/multipart.ts
@@ -69,5 +69,19 @@ export function processMultipartResult(
     },
   })
 
+  /**
+   * Okay for some reason the cancel passed to new fetchAPI.ReadableStream
+   * is never called, let's assign it...
+   */
+  let cancel = readableStream.cancel.bind(readableStream)
+  readableStream.cancel = async (e) => {
+    await iterator.return?.(e)
+    try {
+      await cancel(e)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
   return new fetchAPI.Response(readableStream, responseInit)
 }

--- a/packages/common/src/plugins/resultProcessor/push.ts
+++ b/packages/common/src/plugins/resultProcessor/push.ts
@@ -58,7 +58,11 @@ export function processPushResult(
   let cancel = readableStream.cancel.bind(readableStream)
   readableStream.cancel = async (e) => {
     await iterator.return?.(e)
-    cancel(e)
+    try {
+      await cancel(e)
+    } catch (err) {
+      console.log(err)
+    }
   }
 
   return new fetchAPI.Response(readableStream, responseInit)

--- a/packages/common/src/plugins/resultProcessor/push.ts
+++ b/packages/common/src/plugins/resultProcessor/push.ts
@@ -45,9 +45,21 @@ export function processPushResult(
         controller.close()
       }
     },
+    // This is never called...
     async cancel(e) {
       await iterator.return?.(e)
     },
   })
+
+  /**
+   * Okay for some reason the cancel passed to new fetchAPI.ReadableStream
+   * is never called, let's assign it...
+   */
+  let cancel = readableStream.cancel.bind(readableStream)
+  readableStream.cancel = async (e) => {
+    await iterator.return?.(e)
+    cancel(e)
+  }
+
   return new fetchAPI.Response(readableStream, responseInit)
 }

--- a/patches/cross-undici-fetch+0.4.11.patch
+++ b/patches/cross-undici-fetch+0.4.11.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
+index 1466669..56c7baf 100644
+--- a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
++++ b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
+@@ -181,6 +181,7 @@ module.exports = function createNodePonyfill(opts = {}) {
+               options.body = streams.Readable.from(encoder.encode());
+             }
+             if (options.body[Symbol.toStringTag] === 'ReadableStream') {
++
+               options.body = streams.Readable.from(options.body);
+             }
+           }
+@@ -208,6 +209,9 @@ module.exports = function createNodePonyfill(opts = {}) {
+       ponyfills.Response = function Response(body, init) {
+         if (body != null && body[Symbol.toStringTag] === 'ReadableStream') {
+           const actualBody = streams.Readable.from(body);
++          actualBody.on("close", () => {
++            body.cancel()
++          })
+           // Polyfill ReadableStream is not working well with node-fetch's Response
+           return new OriginalResponse(actualBody, init);
+         }

--- a/patches/cross-undici-fetch+0.4.11.patch
+++ b/patches/cross-undici-fetch+0.4.11.patch
@@ -1,22 +1,34 @@
 diff --git a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
-index 1466669..56c7baf 100644
+index 1466669..79ab0ff 100644
 --- a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
 +++ b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
-@@ -181,6 +181,7 @@ module.exports = function createNodePonyfill(opts = {}) {
-               options.body = streams.Readable.from(encoder.encode());
-             }
-             if (options.body[Symbol.toStringTag] === 'ReadableStream') {
-+
-               options.body = streams.Readable.from(options.body);
-             }
-           }
-@@ -208,6 +209,9 @@ module.exports = function createNodePonyfill(opts = {}) {
+@@ -208,8 +208,28 @@ module.exports = function createNodePonyfill(opts = {}) {
        ponyfills.Response = function Response(body, init) {
          if (body != null && body[Symbol.toStringTag] === 'ReadableStream') {
            const actualBody = streams.Readable.from(body);
-+          actualBody.on("close", () => {
++          /**
++           * If we cancel an EventSource stream, the close event is emitted.
++           */
++          // actualBody.on("close", () => {
++          //   console.log("CLOSE")
++          //   body.cancel()
++          // })
++          /**
++           * For defer/stream aka incremental delivery a canceled response does not result in a close event.
++           * However, it seems like the pause event is always emitted.
++           * Using the pause event over the close event feels like a hack though.
++           * We should investigate on wht the close event is never emitted.
++           */
++          actualBody.on("pause", () => {
++            actualBody.destroy()
++            console.log("PAUSE")
 +            body.cancel()
 +          })
            // Polyfill ReadableStream is not working well with node-fetch's Response
-           return new OriginalResponse(actualBody, init);
+-          return new OriginalResponse(actualBody, init);
++          const response = new OriginalResponse(actualBody, init);
++
++          return response
          }
+         return new OriginalResponse(body, init);
+       };

--- a/patches/cross-undici-fetch+0.4.11.patch
+++ b/patches/cross-undici-fetch+0.4.11.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
-index 1466669..79ab0ff 100644
+index 1466669..570a81c 100644
 --- a/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
 +++ b/node_modules/cross-undici-fetch/dist/create-node-ponyfill.js
-@@ -208,8 +208,28 @@ module.exports = function createNodePonyfill(opts = {}) {
+@@ -208,8 +208,29 @@ module.exports = function createNodePonyfill(opts = {}) {
        ponyfills.Response = function Response(body, init) {
          if (body != null && body[Symbol.toStringTag] === 'ReadableStream') {
            const actualBody = streams.Readable.from(body);
@@ -20,10 +20,11 @@ index 1466669..79ab0ff 100644
 +           * We should investigate on wht the close event is never emitted.
 +           */
 +          actualBody.on("pause", () => {
-+            actualBody.destroy()
 +            console.log("PAUSE")
++            actualBody.destroy()
 +            body.cancel()
 +          })
++
            // Polyfill ReadableStream is not working well with node-fetch's Response
 -          return new OriginalResponse(actualBody, init);
 +          const response = new OriginalResponse(actualBody, init);


### PR DESCRIPTION
I have no idea about all of this and whether this fix is actually a good idea or has any other implications.

My learnings:

1. The `cancel` function argument passed to the `ReadableStream` constructor is never invoked when calling `cancel` on the `ReadableStream` instance.

2. If you create a `Readable` from a `ReadableStream` (`Readable.from(ReadableStream)`) and the `Readable` ends/is canceled, the `ReadableStream.cancel` function is never invoked.
    You can work around it by doing the following:
    ```ts
    const readable = streams.Readable.from(readableStream);
    readable.on("pause", () => {
      readableStream.cancel()
    })
    ```
3. If a multipart (defer/stream) HTTP request is canceled, the `close` event on the `ReadableStream` is never emitted. On a stream (SSE subscription) HTTP request it is emitted. However, the `pause` event seems to be emitted consistently. Could this be a bug where `readable.pause()` is called instead of `readable.destroy()`?