### PR TITLE
chore: include patches in hash

### DIFF
--- a/.github/workflows/algolia-integrity.yml
+++ b/.github/workflows/algolia-integrity.yml
@@ -22,7 +22,7 @@ jobs:
         id: node-modules-cache-algolia-integrity
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/algolia-publish.yml
+++ b/.github/workflows/algolia-publish.yml
@@ -24,7 +24,7 @@ jobs:
         id: node-modules-cache-algolia-publish
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
         id: node-modules-cache-benchmark
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: node-modules-cache-test-node
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-${{ matrix.node-version }}-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-${{ matrix.node-version }}-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-${{ matrix.node-version }}-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/deployment-e2e.yml
+++ b/.github/workflows/deployment-e2e.yml
@@ -27,7 +27,7 @@ jobs:
         id: node-modules-cache-deployment-e2e
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         id: node-modules-cache-release
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn

--- a/.github/workflows/website-integrity.yml
+++ b/.github/workflows/website-integrity.yml
@@ -22,7 +22,7 @@ jobs:
         id: node-modules-cache-website-integrity
         with:
           path: '**/node_modules'
-          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}
+          key: ${{runner.os}}-18-node-modules-${{hashFiles('yarn.lock')}}-${{hashFiles('patches/**/*')}}
           restore-keys: |
             ${{runner.os}}-18-node-modules-
       - name: Install Dependencies using Yarn


### PR DESCRIPTION
applying patch-package patches is skipped as `node_modules` are cached without the patches being part of the cache key. By including them within the cache key we ensure that fresh node_modules are installed (and the patches are applied).