### PR TITLE
docs: fixed broken link to envelop plugins

### DIFF
--- a/website/docs/features/context.mdx
+++ b/website/docs/features/context.mdx
@@ -233,4 +233,4 @@ See the above section [`extending the initial context`](#extending-the-initial-c
 ## Envelop Plugins
 
 After all of the above, Envelop plugins (if you have some) receive the context object and can modify or extend it.
-See the documentation for [Envelop plugins](/features/envelop-plugins) for more information.
+See the documentation for [Envelop plugins](/docs/features/envelop-plugins) for more information.


### PR DESCRIPTION
Link went to `features/envelop-plugins` instead of `docs/features/envelop-plugins`, meaning you got a 404 :) 