### PR TITLE
feat: allow setting a new execution result via the onResultProcessHook

### DIFF
--- a/.changeset/silly-maps-bake.md
+++ b/.changeset/silly-maps-bake.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/common': minor
+'@graphql-yoga/node': minor
+---
+
+Allow setting a new execution result via the onResultProcessHook.

--- a/packages/common/src/plugins/types.ts
+++ b/packages/common/src/plugins/types.ts
@@ -82,6 +82,7 @@ export interface OnResultProcessEventPayload {
   request: Request
   result: ResultProcessorInput
   resultProcessor?: ResultProcessor
+  setResult(newResult: ResultProcessorInput): void
   setResultProcessor(resultProcessor: ResultProcessor): void
 }
 

--- a/packages/common/src/processRequest.ts
+++ b/packages/common/src/processRequest.ts
@@ -1,6 +1,6 @@
 import { getOperationAST, ExecutionArgs } from 'graphql'
 import { RequestProcessContext } from './types.js'
-import { ResultProcessor } from './plugins/types.js'
+import { ResultProcessor, ResultProcessorInput } from './plugins/types.js'
 
 export async function processRequest<TContext>({
   request,
@@ -36,7 +36,7 @@ export async function processRequest<TContext>({
       : enveloped.execute
 
   // Get the result to be processed
-  const result = await executeFn(executionArgs)
+  let result: ResultProcessorInput = await executeFn(executionArgs)
 
   let resultProcessor: ResultProcessor | undefined
 
@@ -45,6 +45,7 @@ export async function processRequest<TContext>({
       request,
       result,
       resultProcessor,
+      setResult: (newResult) => (result = newResult),
       setResultProcessor(newResultProcessor) {
         resultProcessor = newResultProcessor
       },


### PR DESCRIPTION
From #graphql-yoga discord:

```
[01:20] marais: how do we set a custom pattern for responses?
[01:20] marais: as in, i dont want yoga to always create json responses, i need it to be multipart of defer/stream
```

~~This currently requires adding a `setResult` API within the experimental `onResultProcess` hook.~~ (**EDIT:** see comment below.)
We can make this more straight-forward to use in v3