### PR TITLE
docs: Fix bad redis import

### DIFF
--- a/website/docs/features/subscriptions.mdx
+++ b/website/docs/features/subscriptions.mdx
@@ -506,7 +506,7 @@ Yoga comes with an `EventTarget` implementation for [Redis Pub/Sub](https://redi
 <PackageInstall packages={['@graphql-yoga/redis-event-target ioredis']} />
 
 ```ts
-import { Redis } from 'ioredis'
+import Redis from 'ioredis'
 import { createPubSub } from '@graphql-yoga/common'
 import { createRedisEventTarget } from '@graphql-yoga/redis-event-target'
 


### PR DESCRIPTION
There is an error with import. 
```
'Redis' cannot be used as a value because it was exported using 'export type'.ts(1362)
```
Take a look here https://github.com/luin/ioredis