### PR TITLE
fix typos

### DIFF
--- a/website/docs/features/subscriptions.mdx
+++ b/website/docs/features/subscriptions.mdx
@@ -155,11 +155,15 @@ class SSELink extends ApolloLink {
   public request(operation: Operation): Observable<FetchResult> {
     const url = new URL(this.options.uri)
     url.searchParams.append('query', print(operation.query))
-    url.searchParams.append(
-      'extensions',
-      JSON.stringify(operation.operationName),
-    )
-    url.searchParams.append('variables', JSON.stringify(operation.variables))
+    if (operation.operationName) {
+      url.searchParams.append(
+        'operationName',
+        JSON.stringify(operation.operationName),
+      )
+    }
+    if (operation.variables) {
+      url.searchParams.append('variables', JSON.stringify(operation.variables))
+    }
     if (operation.extensions) {
       url.searchParams.append(
         'extensions',


### PR DESCRIPTION
reported in https://tortilla-hq.slack.com/archives/C013PFF4T1U/p1659526791692779?thread_ts=1659526790.385189&cid=C013PFF4T1U

> https://www.graphql-yoga.com/docs/features/subscriptions#client-usage-with-apollo
correct me please if im wrong but i belive that first extension append is wrong or outdated, i got undefined there which messed with my subscription