### PR TITLE
fix: apply the useHTTPValidationError plugin last

### DIFF
--- a/.changeset/grumpy-pens-watch.md
+++ b/.changeset/grumpy-pens-watch.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/common': patch
+'@graphql-yoga/node': patch
+---
+
+Apply the HTTP validation error plugin last in order to not interfere error masking when using the `handleValidationErrors` option.

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -384,8 +384,7 @@ export class YogaServer<
 
       // So the user can manipulate the query parameter
       useCheckGraphQLQueryParam(),
-      // We handle validation errors at the end
-      useHTTPValidationError(),
+
       // We make sure that the user doesn't send a mutation with GET
       usePreventMutationViaGET(),
 
@@ -395,6 +394,8 @@ export class YogaServer<
           typeof maskedErrors === 'object' ? maskedErrors : undefined,
         ),
       ),
+      // We handle validation errors at the end
+      useHTTPValidationError(),
     ]
 
     this.getEnveloped = envelop({

--- a/packages/node/__tests__/integration.spec.ts
+++ b/packages/node/__tests__/integration.spec.ts
@@ -192,6 +192,45 @@ describe('Masked Error Option', () => {
       },
     })
   })
+
+  it('can mask validation error', async () => {
+    const yoga = createServer({
+      schema,
+      logging: false,
+      maskedErrors: {
+        handleValidationErrors: true,
+        isDev: true,
+      },
+    })
+
+    const response = await request(yoga).post('/graphql').send({
+      query: '{ bubatzbieber }',
+    })
+    const body = JSON.parse(response.text)
+    expect(body).toMatchObject({
+      data: null,
+      errors: [
+        {
+          locations: [
+            {
+              column: 3,
+              line: 1,
+            },
+          ],
+          message: 'Unexpected error.',
+        },
+      ],
+    })
+    const { extensions } = body.errors![0]
+    expect(extensions).toMatchObject({
+      originalError: {
+        message: 'Cannot query field "bubatzbieber" on type "Query".',
+        stack: expect.stringContaining(
+          'GraphQLError: Cannot query field "bubatzbieber" on type "Query"',
+        ),
+      },
+    })
+  })
 })
 
 describe('Context error', () => {


### PR DESCRIPTION
Apply the HTTP validation error plugin last in order to not interfere error masking when using the `handleValidationErrors` option.

______


originally reported by @dthyresson on Slack