### PR TITLE
test: add failing test for parse and validation error handling

### DIFF
--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -347,11 +347,12 @@ export class YogaServer<
 
       // So the user can manipulate the query parameter
       useCheckGraphQLQueryParam(),
-      // We handle validation errors at the end
-      useHTTPValidationError(),
+
       // We make sure that the user doesn't send a mutation with GET
       usePreventMutationViaGET(),
       this.maskedErrorsOpts != null && useMaskedErrors(this.maskedErrorsOpts),
+      // We handle validation errors at the end
+      useHTTPValidationError(),
       useUnhandledRoute({
         graphqlEndpoint: this.graphqlEndpoint,
         showLandingPage: options?.landingPage ?? true,


### PR DESCRIPTION
We need to talk about GraphQLError  and error masking in Yoga v3.

So far in envelop we had the following condition for detecting whether an error needs to be masked:
```ts
if (
  /** execution error */
  (err.originalError && err.originalError instanceof EnvelopError === false) ||
  /** validate and parse errors */
  (err.originalError === undefined && err instanceof EnvelopError === false)
) {
```
[Source](https://github.com/n1ru4l/envelop/blob/714978702da9824de62d033f6f319dfa89ea8552/packages/core/src/plugins/use-masked-errors.ts#L17-L22)

However, in Yoga v3 this has changed
```ts
if (err.originalError && err.originalError.name !== 'GraphQLError')
```
[Source](https://github.com/dotansimha/graphql-yoga/blob/8354c16446f582282b11ce157297539da3dea595/packages/graphql-yoga/src/utils/yogaDefaultFormatError.ts#L1-L43)

The new method has the following drawback:

Errors without a err.originalError will no longer be masked which breaks maskedErrors.handleValidationErrors and maskedErrors.handleParseErrors
 
I also know that we cannot simply add the undefined check as GraphQLError is also internally used by Yoga. 

______

Related: 
- https://github.com/dotansimha/graphql-yoga/pull/1600