### PR TITLE
fix: upgrade envelop

### DIFF
--- a/.changeset/cool-dots-notice.md
+++ b/.changeset/cool-dots-notice.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/common': patch
+'@graphql-yoga/node': patch
+---
+
+Update `@envelop/core` which resolves swallowed context errors with error masking.

--- a/examples/apollo-federation/gateway/package.json
+++ b/examples/apollo-federation/gateway/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@apollo/gateway": "^0.52.0",
-    "@envelop/apollo-federation": "^2.4.0",
+    "@envelop/apollo-federation": "^2.5.0",
     "@graphql-yoga/node": "2.13.6",
     "graphql": "^16.5.0"
   }

--- a/examples/fastify-modules/package.json
+++ b/examples/fastify-modules/package.json
@@ -7,7 +7,7 @@
     "check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@envelop/graphql-modules": "3.4.2",
+    "@envelop/graphql-modules": "3.5.0",
     "@graphql-tools/load-files": "6.6.1",
     "@graphql-yoga/node": "2.13.6",
     "fastify": "4.4.0",

--- a/examples/generic-auth/package.json
+++ b/examples/generic-auth/package.json
@@ -19,7 +19,7 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@envelop/generic-auth": "4.3.2",
+    "@envelop/generic-auth": "4.4.0",
     "@graphql-yoga/node": "2.13.6",
     "graphql": "16.5.0"
   }

--- a/examples/live-query/package.json
+++ b/examples/live-query/package.json
@@ -13,7 +13,7 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@envelop/live-query": "4.0.1",
+    "@envelop/live-query": "4.1.0",
     "@n1ru4l/in-memory-live-query-store": "0.10.0",
     "@graphql-yoga/node": "2.13.6",
     "graphql": "16.5.0"

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -35,7 +35,7 @@
 		"vite": "2.9.15"
 	},
 	"dependencies": {
-		"@envelop/graphql-jit": "4.4.2",
+		"@envelop/graphql-jit": "4.5.0",
 		"@graphql-yoga/common": "2.12.5",
 		"graphql": "16.5.0"
 	},

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -64,9 +64,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@envelop/core": "^2.4.0",
-    "@envelop/parser-cache": "^4.4.0",
-    "@envelop/validation-cache": "^4.4.0",
+    "@envelop/core": "^2.5.0",
+    "@envelop/parser-cache": "^4.6.0",
+    "@envelop/validation-cache": "^4.6.0",
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-tools/schema": "^9.0.0",
     "@graphql-tools/utils": "^8.8.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -63,7 +63,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@envelop/core": "^2.4.0",
+    "@envelop/core": "^2.5.0",
     "@graphql-tools/utils": "^8.8.0",
     "@graphql-yoga/common": "^2.12.5",
     "@graphql-yoga/subscription": "^2.2.3",
@@ -71,8 +71,8 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@envelop/disable-introspection": "^3.4.0",
-    "@envelop/live-query": "^4.0.0",
+    "@envelop/disable-introspection": "3.5.0",
+    "@envelop/live-query": "4.1.0",
     "@types/eventsource": "1.1.9",
     "@types/node": "16.11.49",
     "eventsource": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,80 +2819,81 @@
     ts-node "^9"
     tslib "^2"
 
-"@envelop/apollo-federation@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/apollo-federation/-/apollo-federation-2.4.0.tgz#27f9081799de14e868c4da0c3c445bfb35211a79"
-  integrity sha512-DFU3DT+5RVzEFQtwa/Z2wYccfVBvnZz4C4xvYHpksO7VydAnmpBvLCaoBSLDwnxcnPli+8xmbNu8sC//+ZcPNw==
+"@envelop/apollo-federation@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@envelop/apollo-federation/-/apollo-federation-2.5.0.tgz#ce77e61c25314bced0043435f71f453a0b6c1b6d"
+  integrity sha512-1IOthv6kRvIunQu22j28BP6eF7pUc8IO+tDtnUT+IrX7ppv+tCt/hPlV6+b7ykh/2AbtQKwQ+Gl0lmWw99+7qw==
   dependencies:
     apollo-server-caching "^3.1.0"
     apollo-server-types "^3.2.0"
 
-"@envelop/core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-2.4.0.tgz#4319bd681a83fa0964c8be77f7535f728e2e05bb"
-  integrity sha512-ZA8d3sg69+IrZH0seB/HxHi+IYaOOu5OLzZBAHw7MrT2mBI0RyboM6QZv0gGvYJjQIUeJ1I2Zz4bqjOKNmgpxA==
+"@envelop/core@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-2.5.0.tgz#f37ba50ff2e997bcb310b366eacf40b2a2107ee0"
+  integrity sha512-nlDC9q75bjvS/ajbkkVlwGPSYlWhZOQ6StxMTEjvUVefL4o49NpMlGgxfN2mJ64y1CJ3MI/bIemZ3jOHmiv3Og==
   dependencies:
-    "@envelop/types" "2.3.0"
+    "@envelop/types" "2.3.1"
 
-"@envelop/disable-introspection@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/disable-introspection/-/disable-introspection-3.4.0.tgz#b9d19fad83913084dfb92e3b1af6fe10a95eb535"
-  integrity sha512-iDliDXiS/VLuuHWH0FoX8XY7IB1SYuFCrsQ548cQ+0iKAPYPuVbT1r5u6vN3On8m04q2baAl3vMg1fUpYq//HA==
+"@envelop/disable-introspection@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@envelop/disable-introspection/-/disable-introspection-3.5.0.tgz#2db05bab8da24ec097bf6dac707d3f0790ff2e7f"
+  integrity sha512-zBG4eJoCdJlkeQNdQuZl9hAlst1lDQrOaClDiCLnrxze/aStXVDFdn2+xV1L2q0AKdOW4O6NRECPfBXsqWnbOA==
 
-"@envelop/extended-validation@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@envelop/extended-validation/-/extended-validation-1.7.2.tgz#836b8224db2efdd76ea8dbe56e38421c173e1797"
-  integrity sha512-NoYh0BkDCES/EF1zEOIVKooEruWhzC+T3xLpUFMx/OIEGfev5NtIkVxjsaFkRbJXbA6B5DEGeZRZMyzom+0m3w==
+"@envelop/extended-validation@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@envelop/extended-validation/-/extended-validation-1.8.0.tgz#d593e9f3d52c19332dc17764a25a1f040c3c40cd"
+  integrity sha512-RldSbY/4Bun6puNXv2ihB7n8zpJJ/muhkv4MJ4SP1Y6E59YL8O91+czLg1rtO9hwl6qxpk0MCfwfPsJQasCcUg==
   dependencies:
     "@graphql-tools/utils" "^8.8.0"
 
-"@envelop/generic-auth@4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@envelop/generic-auth/-/generic-auth-4.3.2.tgz#46213a3c3dc72f797426fc1e7767b6916f30e74e"
-  integrity sha512-ApFme8C9AMa2Zc5dwqm0jExcxkBAdEdFfA20MPNKLnqZq3TVbknbGvtvgqkgXjUBBzCEf6n3aTOaWi7L8k0LVQ==
+"@envelop/generic-auth@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@envelop/generic-auth/-/generic-auth-4.4.0.tgz#cf890b435fa63e8e55b9afeec715d8b10645780f"
+  integrity sha512-CeL1rWz5AME+d0JBPhFGkJrxJs2Guh4iqaamiTTyhoUh/luBpkeFQMK6re94YgJ3dY2Mxk3c6iGZNESaWAsj5Q==
   dependencies:
-    "@envelop/extended-validation" "^1.7.2"
+    "@envelop/extended-validation" "^1.8.0"
 
-"@envelop/graphql-jit@4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@envelop/graphql-jit/-/graphql-jit-4.4.2.tgz#e6372952bfa0583f2b4727b64e9ed431efbca4c6"
-  integrity sha512-QZtl1Ljd482vv6SnxfpFFClOUo76ODPewo8OVasG1p8i965TRsBU/2nZkoWjUwHa1qEQJx53swWeJ4SKp4OgqQ==
+"@envelop/graphql-jit@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@envelop/graphql-jit/-/graphql-jit-4.5.0.tgz#708ade2f445de36d3505d94aad1d884a380c4b72"
+  integrity sha512-aE3eB1PupSniFSxBrCLZTq8oBCVwoXbLUr9DN+tWvAXmSaZebdFWAiL1IxTL8hQw1WLn6682JupDC1RYOexvuA==
   dependencies:
     graphql-jit "^0.7.0"
     lru-cache "^6.0.0"
 
-"@envelop/graphql-modules@3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@envelop/graphql-modules/-/graphql-modules-3.4.2.tgz#0ceebb6c4eacafefdee97f9134aee0d86e3d0a3d"
-  integrity sha512-L79VEBMwtchtE6qBxfZVn3SZ5PnrEOGe6DPVykiVuCh4hhafjTSFxx2jeuRP0Mt2+X4+KPHc3OVQwtsi7WcIjA==
+"@envelop/graphql-modules@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@envelop/graphql-modules/-/graphql-modules-3.5.0.tgz#72087d1db74c9b811e0106efb778e3e772aceec3"
+  integrity sha512-Le3ExHvzXPmfqu2e4f8Q/rkXUppO1TK6aNo18OZwydb91MaRVV+oAEkvArE5EErHilfsZM3adzwoG0OjQm/N/g==
 
-"@envelop/live-query@4.0.1", "@envelop/live-query@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@envelop/live-query/-/live-query-4.0.1.tgz#69784353f216faf9ac4397e47c1d9295611f0449"
-  integrity sha512-THVjB0IuwRlSursjxvEEhinjKZ39i6noZcwuFS0/3FRxau+NdDyvDLdLghMrc+3Yls4Obwc5FnC7TMOD9Kf1Bg==
+"@envelop/live-query@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@envelop/live-query/-/live-query-4.1.0.tgz#ea090ce70edf2035c0b25ba1bc80340852e9a96b"
+  integrity sha512-uj99MEdysjd3+H3BtcjYCeqQHDm/SVxTCsYGu5Gee1iW0BYGe4L7f6ZqCTh0GK+CxA0T28JNfvS3svPEiTb3FQ==
   dependencies:
     "@graphql-tools/utils" "^8.8.0"
     "@n1ru4l/graphql-live-query" "^0.10.0"
+    "@n1ru4l/graphql-live-query-patch" "^0.7.0"
     "@n1ru4l/in-memory-live-query-store" "^0.10.0"
 
-"@envelop/parser-cache@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/parser-cache/-/parser-cache-4.4.0.tgz#be4685b8fbed46a54ba740ae8e264a35328637ac"
-  integrity sha512-m/RhbWlkKmRftqytWfBGLJCtiUqSOb3gxXsk4/TOlABZZ8KPeI4Yiq5SwZh6UrFOaup00QZK+fWmfjdniLi/sA==
+"@envelop/parser-cache@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@envelop/parser-cache/-/parser-cache-4.6.0.tgz#3ff71acdfbc51097d0dd8051cb961f856cddc400"
+  integrity sha512-Oi3nX76tk5L7K6MdpPr4AjtpMW1XoyISeiaodYD8WxUWY7JzOA7qetuYguUZv/lK5VaLMsJuoWAwxbu1JKEe9A==
   dependencies:
-    tiny-lru "7.0.6"
+    lru-cache "^6.0.0"
 
-"@envelop/types@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-2.3.0.tgz#d633052eb3c7e7913380165ce041e2c0e358d5b6"
-  integrity sha512-K20KxpGlY+HKenms4Kccuh/YcCm0ytj1Zk0Ak6b6hKA68JI4YQ2GwGMq7A7gSOb1MxlbKqrnVdeQdXaDpQfCmA==
+"@envelop/types@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-2.3.1.tgz#b857b3fa5d4df7fadd53ef0ee17cf70b54e827b9"
+  integrity sha512-c5VLCVVRJ2R9LpDHg/N2BO2l4veaJhklquW+FX8GfzXU79DPWe8WmX4MbM6ABUZmSLOJkYInifHrnlqAoucxpQ==
 
-"@envelop/validation-cache@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@envelop/validation-cache/-/validation-cache-4.4.0.tgz#4700415730a6e3cd5114aaf2c2f557d0fe8bde5f"
-  integrity sha512-mvKc1GU9xtQC1yKYYoEbkmjXXEGB7U/ESqlFO33oaMB7z3ctoQpvldBSJj+xj3hF9OchMb1nQKKSYf0GYpF/Gw==
+"@envelop/validation-cache@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@envelop/validation-cache/-/validation-cache-4.6.0.tgz#c4ad678cffbbce05a6fbdd039e8cad20e01a2bbc"
+  integrity sha512-Xn5u/tQHid6GzWDenCJkIn5GsDm2fUCNnAudN1BGjXcRvAEFfTHuchpp1PJxvRAqGdYjznng+NkOcqrP5brQrw==
   dependencies:
-    tiny-lru "7.0.6"
+    lru-cache "^6.0.0"
 
 "@esbuild-plugins/node-globals-polyfill@^0.1.1":
   version "0.1.1"
@@ -4122,6 +4123,13 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
+
+"@n1ru4l/graphql-live-query-patch@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query-patch/-/graphql-live-query-patch-0.7.0.tgz#c5b30341d218627b9ed15cea37e72ea3c15f3632"
+  integrity sha512-1q49iNxqEIbmUp+qFAEVEn4ts344Cw72g5OtAuFeTwKtJT3V91kTPGMcRk5Pxb5FPHbvn52q+PCVKOAyVrtPwQ==
+  dependencies:
+    "@repeaterjs/repeater" "^3.0.4"
 
 "@n1ru4l/graphql-live-query@0.10.0", "@n1ru4l/graphql-live-query@^0.10.0":
   version "0.10.0"
@@ -20238,11 +20246,6 @@ tiny-invariant@^1.0.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
-
-tiny-lru@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
-  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
 tiny-lru@8.0.2, tiny-lru@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
Upgrades envelop and adds a test for ensuring that the error is exposed as the `extensions.originalError` in dev mode.
_________

Closes https://github.com/dotansimha/graphql-yoga/issues/1585

Related:
- https://github.com/dotansimha/graphql-yoga/issues/1585
- https://github.com/dotansimha/graphql-yoga/issues/1584