### PR TITLE
Unopinionated vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["arcanis.vscode-zipfs", "esbenp.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "denoland.vscode-deno",
+    "dbaeumer.vscode-eslint"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,32 +1,12 @@
 {
-  "files.autoSave": "onFocusChange",
-  "eslint.format.enable": true,
-  "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "search.exclude": {
-    "**/.yarn": true,
-    "**/.pnp.*": true,
-    ".bob": true,
-    "**/.next": true,
-    "**/node_modules": true,
-    "**/dist": true
-  },
-  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
-  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "search.useGlobalIgnoreFiles": true,
+  "prettier.prettierPath": "./node_modules/prettier",
+  "typescript.tsdk": "./node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "files.exclude": {
-    "**/.git": true,
-    "**/.DS_Store": true,
-    "test-lib": true,
-    "lib": true,
-    "coverage": true,
-    "npm": true
-  },
-  "deno.enable": true,
   "deno.enablePaths": [
     "examples/deno",
     "examples/netlify-edge/netlify/edge-functions"
   ],
-  "deno.unstable": true,
   "deno.importMap": "examples/netlify-edge/.netlify/edge-functions-import-map.json"
 }


### PR DESCRIPTION
- `search.useGlobalIgnoreFiles` instead of list
- `files.exclude` is mostly defaults, I want all of it in the explorer
- `deno.enable` is unnecessary with `deno.enablePaths`
- `deno.unstable` should be users choice
- dropped `eslint.format.enable`, formatting will be done by prettier instead
- correct sdk paths
- formatting timing is users choice