### PR TITLE
upgrade and fix Deno example

### DIFF
--- a/.changeset/fuzzy-plums-check.md
+++ b/.changeset/fuzzy-plums-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+fix(common): accept the server context if Yoga instance is used as a Request handler

--- a/examples/deno/index.ts
+++ b/examples/deno/index.ts
@@ -1,10 +1,10 @@
-import { serve } from 'https://deno.land/std@0.117.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.153.0/http/server.ts'
 import { createServer } from 'https://cdn.skypack.dev/@graphql-yoga/common'
 
 const graphQLServer = createServer()
 
-serve(graphQLServer, {
-  addr: ':4000',
+serve(graphQLServer.handleRequest, {
+  port: 4000,
 })
 
 console.log('Server is running on http://localhost:4000/graphql')

--- a/examples/deno/index.ts
+++ b/examples/deno/index.ts
@@ -1,9 +1,9 @@
 import { serve } from 'https://deno.land/std@0.153.0/http/server.ts'
-import { createServer } from 'https://cdn.skypack.dev/@graphql-yoga/common'
+import { createServer } from 'https://cdn.skypack.dev/@graphql-yoga/common?dts'
 
 const graphQLServer = createServer()
 
-serve(graphQLServer.handleRequest, {
+serve(graphQLServer, {
   port: 4000,
 })
 

--- a/packages/common/src/server.ts
+++ b/packages/common/src/server.ts
@@ -640,6 +640,10 @@ export type YogaServerInstance<TServerContext, TUserContext, TRootValue> =
   YogaServer<TServerContext, TUserContext, TRootValue> &
     (
       | WindowOrWorkerGlobalScope['fetch']
+      | ((
+          request: Request,
+          serverContext?: TServerContext,
+        ) => Promise<Response>)
       | ((context: { request: Request }) => Promise<Response>)
     )
 

--- a/website/src/pages/docs/integrations/integration-with-deno.mdx
+++ b/website/src/pages/docs/integrations/integration-with-deno.mdx
@@ -9,13 +9,13 @@ But instead of `graphql-yoga` npm package, we will use `@graphql-yoga/common` wh
 ## Example
 
 ```ts filename="deno-example.ts"
-import { serve } from 'https://deno.land/std@0.117.0/http/server.ts'
-import { createServer } from 'https://cdn.skypack.dev/@graphql-yoga/common?dts'
+import { serve } from 'https://deno.land/std/http/server.ts'
+import { createServer } from 'https://cdn.skypack.dev/@graphql-yoga/common'
 
 const graphQLServer = createServer()
 
 serve(graphQLServer, {
-  addr: ':4000',
+  port: 4000,
 })
 
 console.log('Server is running on http://localhost:4000/graphql')


### PR DESCRIPTION
The Deno example does not work against the latest version of `graphql-yoga` or `Deno`.

This PR fixes and upgrades the version of `serve`.