### PR TITLE
refactor: create `URL` instance once and pass it in context for `onRequestHook`

### DIFF
--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -38,6 +38,7 @@ export interface OnRequestEventPayload<TServerContext> {
   serverContext: TServerContext | undefined
   fetchAPI: FetchAPI
   endResponse(response: Response): void
+  url: URL
 }
 
 export type OnRequestParseHook = (

--- a/packages/graphql-yoga/src/plugins/useGraphiQL.ts
+++ b/packages/graphql-yoga/src/plugins/useGraphiQL.ts
@@ -93,10 +93,10 @@ export function useGraphiQL<TServerContext>(
   const renderer = config?.render ?? renderGraphiQL
 
   return {
-    async onRequest({ request, serverContext, fetchAPI, endResponse }) {
+    async onRequest({ request, serverContext, fetchAPI, endResponse, url }) {
       if (
         shouldRenderGraphiQL(request) &&
-        config.graphqlEndpoint === new URL(request.url).pathname
+        config.graphqlEndpoint === url.pathname
       ) {
         logger.debug(`Rendering GraphiQL`)
         const graphiqlOptions = graphiqlOptionsFactory(

--- a/packages/graphql-yoga/src/plugins/useHealthCheck.ts
+++ b/packages/graphql-yoga/src/plugins/useHealthCheck.ts
@@ -16,8 +16,8 @@ export function useHealthCheck({
   readinessCheckEndpoint = '/readiness',
 }: HealthCheckPluginOptions = {}): Plugin {
   return {
-    async onRequest({ request, endResponse, fetchAPI }) {
-      const { pathname: requestPath } = new URL(request.url)
+    async onRequest({ request, endResponse, fetchAPI, url }) {
+      const { pathname: requestPath } = url
       if (requestPath === healthCheckEndpoint) {
         logger.debug(`Responding Health Check`)
         const response = new fetchAPI.Response(

--- a/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
+++ b/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
@@ -6,9 +6,8 @@ export function useUnhandledRoute(args: {
   showLandingPage: boolean
 }): Plugin {
   return {
-    onRequest({ request, fetchAPI, endResponse }) {
-      // new URL is slow
-      const { pathname: requestPath } = new URL(request.url)
+    onRequest({ request, fetchAPI, endResponse, url }) {
+      const { pathname: requestPath } = url
       if (requestPath !== args.graphqlEndpoint) {
         if (
           args.showLandingPage === true &&

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -401,6 +401,7 @@ export class YogaServer<
           endResponse(newResponse) {
             response = newResponse
           },
+          url: new URL(request.url),
         })
         if (response) {
           return response


### PR DESCRIPTION
closes https://github.com/dotansimha/graphql-yoga/issues/1486