### PR TITLE
Fix Apollo Client example to use correct operation parameter.

### DIFF
--- a/website/src/pages/docs/features/subscriptions.mdx
+++ b/website/src/pages/docs/features/subscriptions.mdx
@@ -161,7 +161,7 @@ class SSELink extends ApolloLink {
     url.searchParams.append('query', print(operation.query))
     if (operation.operationName) {
       url.searchParams.append(
-        'operationName',
+        'operation',
         JSON.stringify(operation.operationName),
       )
     }


### PR DESCRIPTION
The latest version of this seems to require an `operation` parameter instead of `operationName`.