### PR TITLE
Don't accept an object of typeDefs and resolvers

### DIFF
--- a/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1746-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1746-dependencies.md
@@ -1,8 +1,8 @@
 ---
-"@graphql-yoga/plugin-apollo-inline-trace": patch
+'@graphql-yoga/plugin-apollo-inline-trace': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Added dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (to `dependencies`)
 - Removed dependency [`@whatwg-node/fetch@^0.4.2` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/null) (from `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
@@ -1,7 +1,7 @@
 ---
-"@graphql-yoga/plugin-apollo-inline-trace": patch
+'@graphql-yoga/plugin-apollo-inline-trace': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
@@ -1,7 +1,0 @@
----
-'@graphql-yoga/plugin-apollo-inline-trace': patch
----
-
-dependencies updates:
-
-- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-inline-trace-1753-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphql-yoga/plugin-apollo-inline-trace": patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-apq-1746-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apq-1746-dependencies.md
@@ -1,7 +1,7 @@
 ---
-"@graphql-yoga/plugin-apq": patch
+'@graphql-yoga/plugin-apq': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphql-yoga/plugin-apq": patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
@@ -1,7 +1,0 @@
----
-'@graphql-yoga/plugin-apq': patch
----
-
-dependencies updates:
-
-- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apq-1753-dependencies.md
@@ -1,7 +1,7 @@
 ---
-"@graphql-yoga/plugin-apq": patch
+'@graphql-yoga/plugin-apq': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)

--- a/.changeset/fifty-elephants-provide.md
+++ b/.changeset/fifty-elephants-provide.md
@@ -1,0 +1,7 @@
+---
+'graphql-yoga': patch
+'@graphql-yoga/plugin-apollo-inline-trace': patch
+'@graphql-yoga/plugin-apq': patch
+---
+
+`schema` no longer accepts an object of `typeDefs` and `resolvers` but instead you can use `createSchema` to create a GraphQL schema.

--- a/.changeset/fifty-elephants-provide.md
+++ b/.changeset/fifty-elephants-provide.md
@@ -1,5 +1,5 @@
 ---
-'graphql-yoga': patch
+'graphql-yoga': major
 '@graphql-yoga/plugin-apollo-inline-trace': patch
 '@graphql-yoga/plugin-apq': patch
 ---

--- a/.changeset/fifty-elephants-provide.md
+++ b/.changeset/fifty-elephants-provide.md
@@ -1,7 +1,5 @@
 ---
 'graphql-yoga': major
-'@graphql-yoga/plugin-apollo-inline-trace': patch
-'@graphql-yoga/plugin-apq': patch
 ---
 
 `schema` no longer accepts an object of `typeDefs` and `resolvers` but instead you can use `createSchema` to create a GraphQL schema.

--- a/.changeset/graphql-yoga-1746-dependencies.md
+++ b/.changeset/graphql-yoga-1746-dependencies.md
@@ -1,8 +1,8 @@
 ---
-"graphql-yoga": patch
+'graphql-yoga': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)
 - Updated dependency [`@whatwg-node/server@0.4.4` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.4.4) (from `0.4.2`, in `dependencies`)

--- a/.changeset/graphql-yoga-1753-dependencies.md
+++ b/.changeset/graphql-yoga-1753-dependencies.md
@@ -1,8 +1,7 @@
 ---
-'graphql-yoga': patch
+"graphql-yoga": patch
 ---
 
-dependencies updates:
+dependencies updates: 
 
-- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)
 - Removed dependency [`@graphql-tools/utils@^8.8.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/null) (from `dependencies`)

--- a/.changeset/graphql-yoga-1753-dependencies.md
+++ b/.changeset/graphql-yoga-1753-dependencies.md
@@ -1,0 +1,8 @@
+---
+"graphql-yoga": patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)
+- Removed dependency [`@graphql-tools/utils@^8.8.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/null) (from `dependencies`)

--- a/.changeset/graphql-yoga-1753-dependencies.md
+++ b/.changeset/graphql-yoga-1753-dependencies.md
@@ -1,8 +1,8 @@
 ---
-"graphql-yoga": patch
+'graphql-yoga': patch
 ---
 
-dependencies updates: 
+dependencies updates:
 
 - Updated dependency [`@whatwg-node/fetch@0.4.3` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.4.3) (from `^0.4.2`, in `dependencies`)
 - Removed dependency [`@graphql-tools/utils@^8.8.0` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/null) (from `dependencies`)

--- a/examples/defer-stream/src/index.ts
+++ b/examples/defer-stream/src/index.ts
@@ -1,4 +1,4 @@
-import { createYoga } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const wait = (time: number) =>
@@ -84,10 +84,10 @@ const resolvers = {
 }
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs,
     resolvers,
-  },
+  }),
   graphiql: {
     defaultQuery: /* GraphQL */ `
       # Slow alphabet

--- a/examples/graphql-armor/src/main.ts
+++ b/examples/graphql-armor/src/main.ts
@@ -1,4 +1,4 @@
-import { createYoga } from 'graphql-yoga'
+import { createSchema, createYoga } from 'graphql-yoga'
 import { EnvelopArmor } from '@escape.tech/graphql-armor'
 import { createServer } from 'http'
 
@@ -18,7 +18,7 @@ const booksStore = [
 
 const yoga = createYoga({
   plugins: [...enhancements.plugins],
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Book {
         title: String
@@ -33,7 +33,7 @@ const yoga = createYoga({
         books: () => booksStore,
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -63,12 +63,12 @@ The server returns the following response:
 This is what the [implementation](./index.js) looks like:
 
 ```js
-import { createServer } from 'http'
+import { createServer, createSchema } from 'http'
 import { createYoga } from 'graphql-yoga'
 // ... or using `require()`
-// const { createServer } = require('graphql-yoga')
+// const { createServer, createSchema } = require('graphql-yoga')
 
-const typeDefs = `
+const typeDefs = /* GraphQL */ `
   type Query {
     hello(name: String): String!
   }
@@ -81,10 +81,10 @@ const resolvers = {
 }
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs,
     resolvers,
-  },
+  }),
 })
 
 const server = createServer(yoga)

--- a/packages/graphql-yoga/__tests__/http-extensions.spec.ts
+++ b/packages/graphql-yoga/__tests__/http-extensions.spec.ts
@@ -42,7 +42,7 @@ describe('GraphQLError.extensions.http', () => {
 
   it('picks the highest status code and headers for GraphQLErrors thrown within multiple resolvers', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             a: String
@@ -71,7 +71,7 @@ describe('GraphQLError.extensions.http', () => {
             },
           },
         },
-      },
+      }),
     })
 
     const response = await yoga.fetch('http://yoga/graphql', {
@@ -103,7 +103,7 @@ describe('GraphQLError.extensions.http', () => {
 
   it('picks the header of the last GraphQLError when multiple errors are thrown within multiple resolvers', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             a: String
@@ -136,7 +136,7 @@ describe('GraphQLError.extensions.http', () => {
             },
           },
         },
-      },
+      }),
     })
 
     let response = await yoga.fetch('http://yoga/graphql', {
@@ -158,7 +158,7 @@ describe('GraphQLError.extensions.http', () => {
 
   it('should not contain the http extensions in response result', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             a: String
@@ -180,7 +180,7 @@ describe('GraphQLError.extensions.http', () => {
             },
           },
         },
-      },
+      }),
     })
 
     let response = await yoga.fetch('http://yoga/graphql', {
@@ -197,13 +197,13 @@ describe('GraphQLError.extensions.http', () => {
 
   it('should respect http extensions status consistently on parsing fail', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             _: String
           }
         `,
-      },
+      }),
     })
 
     let response = await yoga.fetch('http://yoga/graphql', {
@@ -223,13 +223,13 @@ describe('GraphQLError.extensions.http', () => {
 
   it('should respect http extensions status consistently on validation fail', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             _: String
           }
         `,
-      },
+      }),
     })
 
     let response = await yoga.fetch('http://yoga/graphql', {
@@ -249,13 +249,13 @@ describe('GraphQLError.extensions.http', () => {
 
   it('should respond with status 500 when error without http extension is thrown', async () => {
     const yoga = createYoga({
-      schema: {
+      schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {
             _: String
           }
         `,
-      },
+      }),
       context: () => {
         throw new GraphQLError('No http status extension', {
           extensions: { http: { headers: { 'x-foo': 'bar' } } },

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -60,7 +60,6 @@
     "@envelop/validation-cache": "^4.6.0",
     "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-tools/schema": "^9.0.0",
-    "@graphql-tools/utils": "^8.8.0",
     "@graphql-yoga/subscription": "^2.2.2",
     "@whatwg-node/fetch": "0.4.3",
     "@whatwg-node/server": "0.4.4",

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -81,7 +81,6 @@ import { useLimitBatching } from './plugins/requestValidation/useLimitBatching.j
 export type YogaServerOptions<
   TServerContext extends Record<string, any>,
   TUserContext extends Record<string, any>,
-  TRootValue,
 > = {
   /**
    * Enable/disable logging or provide a custom logger.
@@ -147,8 +146,7 @@ export type YogaServerOptions<
   renderGraphiQL?: (options?: GraphiQLOptions) => PromiseOrValue<BodyInit>
 
   schema?: YogaSchemaDefinition<
-    TUserContext & TServerContext & YogaInitialContext,
-    TRootValue
+    TUserContext & TServerContext & YogaInitialContext
   >
 
   /**
@@ -199,7 +197,6 @@ export type BatchingOptions =
 export class YogaServer<
   TServerContext extends Record<string, any>,
   TUserContext extends Record<string, any>,
-  TRootValue,
 > {
   /**
    * Instance of envelop
@@ -221,9 +218,7 @@ export class YogaServer<
   private maskedErrorsOpts: YogaMaskedErrorOpts | null
   private id: string
 
-  constructor(
-    options?: YogaServerOptions<TServerContext, TUserContext, TRootValue>,
-  ) {
+  constructor(options?: YogaServerOptions<TServerContext, TUserContext>) {
     this.id = options?.id ?? 'yoga'
     this.fetchAPI =
       options?.fetchAPI ??
@@ -662,21 +657,14 @@ export class YogaServer<
 export type YogaServerInstance<
   TServerContext extends Record<string, any>,
   TUserContext extends Record<string, any>,
-  TRootValue extends Record<string, any>,
-> = ServerAdapter<
-  TServerContext,
-  YogaServer<TServerContext, TUserContext, TRootValue>
->
+> = ServerAdapter<TServerContext, YogaServer<TServerContext, TUserContext>>
 
 export function createYoga<
   TServerContext extends Record<string, any> = {},
   TUserContext extends Record<string, any> = {},
-  TRootValue extends Record<string, any> = {},
 >(
-  options: YogaServerOptions<TServerContext, TUserContext, TRootValue>,
-): YogaServerInstance<TServerContext, TUserContext, TRootValue> {
-  const server = new YogaServer<TServerContext, TUserContext, TRootValue>(
-    options,
-  )
+  options: YogaServerOptions<TServerContext, TUserContext>,
+): YogaServerInstance<TServerContext, TUserContext> {
+  const server = new YogaServer<TServerContext, TUserContext>(options)
   return createServerAdapter(server, server.fetchAPI.Request)
 }

--- a/website/src/pages/v3/features/envelop-plugins.mdx
+++ b/website/src/pages/v3/features/envelop-plugins.mdx
@@ -13,11 +13,11 @@ The following example adds [GraphQL JIT](https://github.com/zalando-incubator/gr
 
 ```ts
 import { useGraphQlJit } from '@envelop/graphql-jit'
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         greetings: String!
@@ -28,7 +28,7 @@ const yoga = createYoga({
         greetings: () => 'Hello World!',
       },
     },
-  },
+  }),
   plugins: [useGraphQlJit()],
 })
 

--- a/website/src/pages/v3/features/error-masking.mdx
+++ b/website/src/pages/v3/features/error-masking.mdx
@@ -15,12 +15,12 @@ Exposing such information to the outside world can make you vulnerable for targe
 Let's setup a simple schema that calls a remote service that is unavailable.
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { fetch } from '@whatwg-node/fetch'
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         greeting: String!
@@ -38,7 +38,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 // Start the server and explore http://localhost:4000/graphql
@@ -99,12 +99,12 @@ node server.js
 ```
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { fetch } from '@whatwg-node/fetch'
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         greeting: String!
@@ -122,7 +122,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)
@@ -173,7 +173,7 @@ This can be achieved by throwing a `GraphQLError` instead of a "normal" [`Error`
 E.g. you might want to throw an error if a resource cannot be found by an ID.
 
 ```ts
-import { createServer } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { GraphQLError } from 'graphql'
 
 const users = [
@@ -193,7 +193,7 @@ const users = [
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type User {
         id: ID!
@@ -215,7 +215,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 // Start the server and explore http://localhost:4000/graphql
@@ -260,7 +260,7 @@ Sometimes it is useful to enrich errors with additional information, such as an 
 Error extensions can be passed as the second parameter to the `GraphQLError` constructor.
 
 ```ts
-import { createServer } from 'graphql-yoga'
+import { createSchema, createServer } from 'graphql-yoga'
 import { GraphQLError } from 'graphql'
 
 const users = [
@@ -280,7 +280,7 @@ const users = [
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type User {
         id: ID!
@@ -310,7 +310,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 // Start the server and explore http://localhost:4000/graphql

--- a/website/src/pages/v3/features/file-uploads.mdx
+++ b/website/src/pages/v3/features/file-uploads.mdx
@@ -25,7 +25,7 @@ import { createYoga } from 'graphql-yoga'
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       scalar File
 
@@ -52,7 +52,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 // Start the server and explore http://localhost:4000/graphql
 const server = createServer(yoga)

--- a/website/src/pages/v3/features/response-caching.mdx
+++ b/website/src/pages/v3/features/response-caching.mdx
@@ -15,12 +15,12 @@ Response caching is a technique for reducing server load by caching GraphQL quer
 ## Quick Start
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'node:http'
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: `type Query { slow: String}`,
     resolvers: {
       Query: {
@@ -30,7 +30,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
   plugins: [
     useResponseCache({
       // global cache

--- a/website/src/pages/v3/features/subscriptions.mdx
+++ b/website/src/pages/v3/features/subscriptions.mdx
@@ -26,7 +26,7 @@ import { createYoga } from 'graphql-yoga'
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         hello: String
@@ -52,7 +52,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)
@@ -257,13 +257,13 @@ GraphQL Yoga comes with a built-in PubSub (publish/subscribe) bus. This makes it
 `server.ts`
 
 ```ts
-import { createServer, createPubSub } from 'graphql-yoga'
+import { createServer, createPubSub, createSchema } from 'graphql-yoga'
 
 const pubSub = createPubSub()
 
 // Provide your schema
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         hello: String
@@ -295,7 +295,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)

--- a/website/src/pages/v3/index.mdx
+++ b/website/src/pages/v3/index.mdx
@@ -17,11 +17,11 @@ import { PackageCmd } from '@theguild/components'
 You will need to provide schema to Yoga, either by an existing executable schema, or by providing your type definitions and resolver map.
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         hello: String
@@ -32,7 +32,7 @@ const yoga = createYoga({
         hello: () => 'Hello from Yoga!',
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)

--- a/website/src/pages/v3/integrations/integration-with-sveltekit.mdx
+++ b/website/src/pages/v3/integrations/integration-with-sveltekit.mdx
@@ -24,11 +24,11 @@ In a SvelteKit project:import { PackageCmd } from '@theguild/components';
 Create the file `src/routes/api/graphql.ts`:
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import type { RequestEvent } from '@sveltejs/kit'
 
 const yogaApp = createYoga<RequestEvent>({
-  schema: {
+  schema: createSchema({
     typeDefs: `
 			type Query {
 				hello: String
@@ -39,7 +39,7 @@ const yogaApp = createYoga<RequestEvent>({
         hello: () => 'SvelteKit - GraphQL Yoga',
       },
     },
-  },
+  }),
   // Needed to be defined explicitly because our endpoint lives at a different path other than `/graphql`
   graphqlEndpoint: '/api/graphql',
 })

--- a/website/src/pages/v3/migration/migration-from-apollo-server.mdx
+++ b/website/src/pages/v3/migration/migration-from-apollo-server.mdx
@@ -43,7 +43,7 @@ import { schema } from './schema'
 - const server = new ApolloServer({
 + const yoga = createYoga({
   // You can also pass `typeDefs` and `resolvers` here directly if you previously use `ApolloServer` constructor to build your `GraphQLSchema`
-  // schema: { typeDefs, resolvers },
+  // schema: createSchema({ typeDefs, resolvers }),
   schema,
 +  plugins: [useApolloServerErrors()],
 })
@@ -51,7 +51,6 @@ import { schema } from './schema'
 + const server = createServer(yoga)
 
 server.listen(4000)
-+ server.listen(4000)
 ```
 
 ## Migration from standalone `apollo-server`

--- a/website/src/pages/v3/migration/migration-from-yoga-v1.mdx
+++ b/website/src/pages/v3/migration/migration-from-yoga-v1.mdx
@@ -15,8 +15,8 @@ You can start with updating `graphql-yoga` package.import { PackageCmd } from '@
 
 ## Server setup
 
-Yoga v1 no longer uses a class for constructing the server, the `createServer` function is now used.
-Also the `typeDefs` and `resolvers` config options must now be passed to a `schema` property.
+Yoga v1 no longer uses a class for constructing the server, the `createYoga` function is now used.
+Also the `typeDefs` and `resolvers` config options must now be passed to a `schema` property with `createSchema`.
 
 **Yoga v1**
 
@@ -32,12 +32,12 @@ server.start()
 **Yoga v3**
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 import { typeDefs, resolvers } from './schema'
 
 const yoga = createYoga({
-  schema: { typeDefs, resolvers },
+  schema: createSchema({ typeDefs, resolvers }),
 })
 
 const server = createServer(yoga)
@@ -70,18 +70,18 @@ In Yoga v3 you now need to use the `fs` module for Node.js.
 ```ts
 import * as path from 'path'
 import * as fs from 'fs'
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 import { resolvers } from './schema'
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs: fs.readFileSync(
       path.join(__dirname, 'type-definitions.graphql'),
       'utf-8',
     ),
     resolvers,
-  },
+  }),
 })
 
 const server = createServer(yoga)
@@ -197,16 +197,16 @@ server.listen(4000)
 **Yoga v3**
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 import { typeDefs, resolvers } from './schema'
 import { db } from './db'
 
 const yoga = createYoga({
-  schema: {
+  schema: createSchema({
     typeDefs,
     resolvers,
-  },
+  }),
   context: (initialContext) => {
     const authHeader =
       initialContext.request.headers.get('authorization') ?? null
@@ -267,7 +267,7 @@ server.start()
 **Yoga v3**
 
 ```ts
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 import { useGraphQLMiddleware } from '@envelop/graphql-middleware'
 import { typeDefs, resolvers } from './schema'
@@ -294,7 +294,7 @@ const permissions = {
 }
 
 const yoga = createYoga({
-  schema: { typeDefs, resolvers },
+  schema: createSchema({ typeDefs, resolvers }),
   plugins: [useGraphQLMiddleware([permissions])],
 })
 
@@ -404,7 +404,7 @@ server.start()
 **Yoga v3**
 
 ```ts
-import { createPubSub, createYoga } from 'graphql-yoga'
+import { createPubSub, createYoga, createSchema } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const pubSub = new PubSub<{
@@ -413,7 +413,7 @@ const pubSub = new PubSub<{
 
 const yoga = createYoga({
   context: { pubSub },
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         _: Boolean
@@ -442,7 +442,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)
@@ -511,7 +511,7 @@ const pubSub = new PubSub<{
 
 const yoga = createYoga({
   context: { pubSub },
-  schema: {
+  schema: createSchema({
     typeDefs: /* GraphQL */ `
       type Query {
         _: Boolean
@@ -543,7 +543,7 @@ const yoga = createYoga({
         },
       },
     },
-  },
+  }),
 })
 
 const server = createServer(yoga)


### PR DESCRIPTION
- Remove `getDefaultSchema`
- No longer set a default schema
- No longer accept `{ typeDefs, resolvers }` but use `createSchema({ typeDefs, resolvers })` instead

So Yoga won't have `@graphql-tools/schema` in the bundle if schema is created in a different way.