### PR TITLE
frontMatter `sidebar_label` is unused and smaller sidebar titles adjustments

### DIFF
--- a/website/src/pages/v3/_meta.json
+++ b/website/src/pages/v3/_meta.json
@@ -2,5 +2,6 @@
   "index": "Quick Start",
   "features": "Features",
   "integrations": "Integrations",
-  "migration": "Migration"
+  "migration": "Migration",
+  "comparison": "Comparison"
 }

--- a/website/src/pages/v3/comparison.mdx
+++ b/website/src/pages/v3/comparison.mdx
@@ -1,7 +1,6 @@
 ---
 id: comparison
 title: Comparison with other JavaScript GraphQL server libraries
-sidebar_label: Comparison
 ---
 
 ## GraphQL Yoga and Apollo Server

--- a/website/src/pages/v3/features/automatic-persisted-queries.mdx
+++ b/website/src/pages/v3/features/automatic-persisted-queries.mdx
@@ -1,7 +1,6 @@
 ---
 id: automatic-persisted-queries
 title: Automatic Persisted Queries
-sidebar_label: Automatic Persisted Queries
 ---
 
 import { PackageCmd } from '@theguild/components'

--- a/website/src/pages/v3/features/cors.mdx
+++ b/website/src/pages/v3/features/cors.mdx
@@ -1,7 +1,6 @@
 ---
 id: cors
 title: Configuring CORS with Yoga
-sidebar_label: CORS
 ---
 
 CORS stands for Cross Origin Resource Sharing. In a nutshell, as a security measure, browsers aren't allowed to access resources outside their own domain.

--- a/website/src/pages/v3/features/envelop-plugins.mdx
+++ b/website/src/pages/v3/features/envelop-plugins.mdx
@@ -1,7 +1,6 @@
 ---
 id: envelop-plugins
 title: Use Envelop Plugins within GraphQL Yoga
-sidebar_label: Envelop Plugins
 ---
 
 [Envelop is a lightweight JavaScript (TypeScript) library for customizing the GraphQL execution layer, allowing developers to build, share and compose plugins that enhance the capabilities of your GraphQL server](https://envelop.dev).

--- a/website/src/pages/v3/features/error-masking.mdx
+++ b/website/src/pages/v3/features/error-masking.mdx
@@ -1,7 +1,6 @@
 ---
 id: error-masking
 title: Error Masking
-sidebar_label: Error Masking
 ---
 
 Yoga uses [the Envelop `useMaskedErrors`](https://www.envelop.dev/plugins/use-masked-errors) for automatically masking unexpected errors and preventing sensitive information leaking to clients.

--- a/website/src/pages/v3/features/file-uploads.mdx
+++ b/website/src/pages/v3/features/file-uploads.mdx
@@ -1,7 +1,6 @@
 ---
 id: file-uploads
 title: Enable File Uploads in GraphQL Yoga
-sidebar_label: File Uploads
 ---
 
 GraphQL Yoga supports [GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec) which basically allows you to upload files via HTTP and consume the binary data inside GraphQL Resolvers.

--- a/website/src/pages/v3/features/graphiql.mdx
+++ b/website/src/pages/v3/features/graphiql.mdx
@@ -1,7 +1,6 @@
 ---
 id: graphiql
 title: GraphiQL
-sidebar_label: GraphiQL
 ---
 
 import { PackageCmd } from '@theguild/components'

--- a/website/src/pages/v3/features/persisted-operations.mdx
+++ b/website/src/pages/v3/features/persisted-operations.mdx
@@ -1,7 +1,6 @@
 ---
 id: persisted-operations
 title: Persisted Operations
-sidebar_label: Persisted Operations
 ---
 
 import { PackageCmd } from '@theguild/components'

--- a/website/src/pages/v3/features/response-caching.mdx
+++ b/website/src/pages/v3/features/response-caching.mdx
@@ -1,7 +1,6 @@
 ---
 id: response-caching
 title: Response Caching
-sidebar_label: Resposne Caching
 ---
 
 import { PackageCmd } from '@theguild/components'

--- a/website/src/pages/v3/features/subscriptions.mdx
+++ b/website/src/pages/v3/features/subscriptions.mdx
@@ -1,7 +1,6 @@
 ---
 id: subscriptions
 title: Subscriptions
-sidebar_label: Subscriptions
 ---
 
 import { PackageCmd } from '@theguild/components'

--- a/website/src/pages/v3/features/testing.mdx
+++ b/website/src/pages/v3/features/testing.mdx
@@ -1,7 +1,6 @@
 ---
 id: testing
 title: Testing
-sidebar_label: Testing
 ---
 
 GraphQL Yoga makes it easy to test your GraphQL API. It has built-in support for HTTP injection. You can use any testing framework of your choice.

--- a/website/src/pages/v3/index.mdx
+++ b/website/src/pages/v3/index.mdx
@@ -1,7 +1,6 @@
 ---
 id: quick-start
 title: Quick Start
-sidebar_label: Quick Start
 ---
 
 GraphQL Yoga is a batteries-included cross-platform [GraphQL over HTTP](https://github.com/graphql/graphql-over-http) spec-compliant GraphQL Server using [Envelop](https://envelop.dev), and [GraphQL Tools](https://graphql-tools.com) that runs anywhere.

--- a/website/src/pages/v3/integrations/integration-with-aws-lambda.mdx
+++ b/website/src/pages/v3/integrations/integration-with-aws-lambda.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-aws-lambda
 title: Integration with AWS Lambda
-sidebar_label: AWS Lambda
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-cloudflare-workers.mdx
+++ b/website/src/pages/v3/integrations/integration-with-cloudflare-workers.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-cloudflare-workers
 title: Integration with Cloudflare Workers
-sidebar_label: Cloudflare Workers
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-deno.mdx
+++ b/website/src/pages/v3/integrations/integration-with-deno.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-deno
 title: Integration with Deno
-sidebar_label: Deno
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-express.mdx
+++ b/website/src/pages/v3/integrations/integration-with-express.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-express
 title: Integration with Express
-sidebar_label: Express
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-fastify.mdx
+++ b/website/src/pages/v3/integrations/integration-with-fastify.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-fastify
 title: Integration with Fastify
-sidebar_label: Fastify
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-koa.mdx
+++ b/website/src/pages/v3/integrations/integration-with-koa.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-koa
 title: Integration with Koa
-sidebar_label: Koa
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-nestjs.mdx
+++ b/website/src/pages/v3/integrations/integration-with-nestjs.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-nestjs
 title: Integration with Nest
-sidebar_label: Nest
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-nextjs.mdx
+++ b/website/src/pages/v3/integrations/integration-with-nextjs.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-nextjs
 title: Integration with nextjs
-sidebar_label: Next.js
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/integration-with-sveltekit.mdx
+++ b/website/src/pages/v3/integrations/integration-with-sveltekit.mdx
@@ -1,7 +1,6 @@
 ---
 id: integration-with-sveltekit
 title: Integration with SvelteKit
-sidebar_label: SvelteKit
 type: Guide
 ---
 

--- a/website/src/pages/v3/integrations/z-other-environments.mdx
+++ b/website/src/pages/v3/integrations/z-other-environments.mdx
@@ -1,7 +1,6 @@
 ---
 id: z-other-environments
 title: Integration with other environments
-sidebar_label: Other Environments
 type: Guide
 ---
 

--- a/website/src/pages/v3/migration/_meta.json
+++ b/website/src/pages/v3/migration/_meta.json
@@ -1,5 +1,6 @@
 {
   "migration-from-apollo-server": "Apollo Server",
   "migration-from-express-graphql": "Express GraphQL",
-  "migration-from-yoga-v1": "Yoga v1"
+  "migration-from-yoga-v1": "Yoga v1",
+  "migration-from-yoga-v2": "Yoga v2"
 }

--- a/website/src/pages/v3/migration/migration-from-apollo-server.mdx
+++ b/website/src/pages/v3/migration/migration-from-apollo-server.mdx
@@ -1,7 +1,6 @@
 ---
 id: migration-from-apollo-server
 title: Migration from Apollo Server
-sidebar_label: Apollo Server
 type: Guide
 ---
 

--- a/website/src/pages/v3/migration/migration-from-express-graphql.mdx
+++ b/website/src/pages/v3/migration/migration-from-express-graphql.mdx
@@ -1,7 +1,6 @@
 ---
 id: migration-from-express-graphql
 title: Migration from Express GraphQL
-sidebar_label: Express GraphQL
 type: Guide
 ---
 

--- a/website/src/pages/v3/migration/migration-from-yoga-v1.mdx
+++ b/website/src/pages/v3/migration/migration-from-yoga-v1.mdx
@@ -1,7 +1,6 @@
 ---
 id: migration-from-yoga-v1
 title: Migration from Yoga V1
-sidebar_label: Yoga v1
 type: Guide
 ---
 

--- a/website/src/pages/v3/migration/migration-from-yoga-v2.mdx
+++ b/website/src/pages/v3/migration/migration-from-yoga-v2.mdx
@@ -1,7 +1,6 @@
 ---
 id: migration-from-yoga-v2
 title: Migration from Yoga V2
-sidebar_label: Yoga v2
 type: Guide
 ---
 


### PR DESCRIPTION
- Drop all `sidebar_label`
- Use `Comparison` instead of `Comparison with other JavaScript GraphQL server libraries` in the sidebar
- Use `Yoga v3` instead of `Migration from Yoga V2` in the sidebar (match naming)