### PR TITLE
Improved migration from v2 guide

### DIFF
--- a/website/src/pages/v3/migration/migration-from-yoga-v2.mdx
+++ b/website/src/pages/v3/migration/migration-from-yoga-v2.mdx
@@ -13,7 +13,7 @@ So you need to uninstall `@graphql-yoga/common` and `@graphql-yoga/node` then in
 
 <PackageCmd packages={['graphql-yoga']} />
 
-**`createServer` renamed to `createYoga`**
+## `createServer` renamed to `createYoga`
 
 In order to prevent the confusion, we decided to rename `createServer` function to `createYoga`.
 
@@ -28,15 +28,15 @@ import { schema } from './schema';
  })
 ```
 
-**`handleIncomingMessage` renamed to `handleNodeRequest`**
+## `handleIncomingMessage` renamed to `handleNodeRequest`
 
 For some frameworks, we need to use this low-level function such as Fastify and Koa. So you can basically rename the method to `handleNodeRequest`.
 
-**No more `.start` and `.stop`**
+## No more `.start` and `.stop`
 
 Previously on Node and CF/Service Workers environments, Yoga handles server processes with `.start` and `.stop` methods together with some environment specific server configurations. Yoga no longer deals with HTTP server configuration so the following changes needed;
 
-**_For Node_**
+### For Node
 
 ```diff
 - import { createServer } from '@graphql-yoga/node'
@@ -54,14 +54,14 @@ Previously on Node and CF/Service Workers environments, Yoga handles server proc
 + server.listen(4000, '127.0.0.1')
 ```
 
-**_For CF/Service Workers_**
+### For CF/Service Workers
 
 ```diff
 - yoga.start()
 + self.addEventListener('fetch', yoga)
 ```
 
-**No more Node specific multipart configuration**
+## No more Node specific multipart configuration
 
 Previously it was possible to configure limitations of multipart request processing in `@graphql-yoga/node` package but now `graphql-yoga` package is completely platform agnostic and we avoid to have any Node specific configuration in GraphQL Yoga. But it is still possible to keep the same behavior by configuring `@whatwg-node/fetch` which is used by GraphQL Yoga internally for Node.js.
 
@@ -90,7 +90,8 @@ Previously it was possible to configure limitations of multipart request process
 })
 ```
 
-**`endpoint` and `graphiql.endpoint` options are now removed**
+## Removed `endpoint` and `graphiql.endpoint` options
+
 In v2, there is `endpoint` option which is used to configure the GraphQL endpoint, and `graphiql.endpoint` to point `GraphiQL` to a different GraphQL API.
 Now they are removed in favor `graphqlEndpoint` option. If you want to use `YogaGraphiQL` for a different GraphQL endpoint, you can use `@graphql-yoga/render-graphiql` package seperately.
 
@@ -99,29 +100,15 @@ Now they are removed in favor `graphqlEndpoint` option. If you want to use `Yoga
 + import { createYoga } from 'graphql-yoga'
 - createServer({
 + createYoga({
--  endpoint: '/mypath',
+-  endpoint: '/graphql',
 -  graphiql: {
--    endpoint: '/mypath',
+-    endpoint: '/graphiql',
 -  },
-+  graphqlEndpoint: '/mypath',
++  graphqlEndpoint: '/graphql',
 })
 ```
 
-**You need to define `graphqlEndpoint` if your GraphQL endpoint is not `/graphql`**
-
-For example, if you use Next.js or Sveltekit, you probably use `/api/graphql` or `/api/somethingelse` which is not `/graphql`.
-In v3, you need to tell Yoga explicitly what is your GraphQL endpoint.
-
-```diff
-- import { createServer } from '@graphql-yoga/node'
-+ import { createYoga } from 'graphql-yoga'
-- createServer({
-+ createYoga({
-+  graphqlEndpoint: '/api/graphql',
-})
-```
-
-** No more `GraphQLYogaError` so you can use `GraphQLError` instead **
+## No more `GraphQLYogaError`, use `GraphQLError` instead
 
 In v2, we introduced a new error class `GraphQLYogaError` which is a subclass of `GraphQLError` and it is now deprecated in favor of `GraphQLError`.
 So in resolvers, you can use it in the same way but the second parameter of `GraphQLError` constructor is not `extensions` but an object that contains more options for `GraphQLError`.
@@ -157,7 +144,7 @@ new GraphQLError('My error message', {
 })
 ```
 
-**No more `readinessCheckEndpoint`, consider using the `useReadinessCheck` plugin instead**
+## No more `readinessCheckEndpoint`, consider using the `useReadinessCheck` plugin instead
 
 A readiness health check is not something Yoga can accurately perform as it requires user-land context. Read more about the [new health check](/v3/features/health-check).
 


### PR DESCRIPTION
- Use headings for sections
- Drop duplicate `graphqlEndpoint` section
- Smaller wording changes