### PR TITLE
Resolve the schema only if needed

### DIFF
--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -39,7 +39,7 @@ export type Plugin<
    * Use this hook with your own risk. It is still experimental and may change in the future.
    * @internal
    */
-  onRequestParse?: OnRequestParseHook
+  onRequestParse?: OnRequestParseHook<TServerContext>
   /**
    * Use this hook with your own risk. It is still experimental and may change in the future.
    * @internal
@@ -69,17 +69,18 @@ export interface OnRequestEventPayload<TServerContext> {
   url: URL
 }
 
-export type OnRequestParseHook = (
-  payload: OnRequestParseEventPayload,
+export type OnRequestParseHook<TServerContext> = (
+  payload: OnRequestParseEventPayload<TServerContext>,
 ) => PromiseOrValue<void | OnRequestParseHookResult>
 
 export type RequestParser = (
   request: Request,
 ) => PromiseOrValue<GraphQLParams> | PromiseOrValue<GraphQLParams[]>
 
-export interface OnRequestParseEventPayload {
+export interface OnRequestParseEventPayload<TServerContext> {
   request: Request
   requestParser: RequestParser | undefined
+  serverContext: TServerContext
   setRequestParser: (parser: RequestParser) => void
 }
 

--- a/packages/graphql-yoga/src/plugins/useSchema.ts
+++ b/packages/graphql-yoga/src/plugins/useSchema.ts
@@ -32,15 +32,8 @@ export const useSchema = <
       },
       onEnveloped({ setSchema }) {
         if (!schema) {
-          throw new GraphQLError(
+          throw new Error(
             `You provide a promise of a schema but it hasn't been resolved yet. Make sure you use this plugin with GraphQL Yoga.`,
-            {
-              extensions: {
-                http: {
-                  status: 500,
-                },
-              },
-            },
           )
         }
         setSchema(schema)
@@ -57,28 +50,14 @@ export const useSchema = <
       if (context?.request) {
         const schema = schemaByRequest.get(context.request)
         if (schema == null) {
-          throw new GraphQLError(
+          throw new Error(
             `No schema found for this request. Make sure you use this plugin with GraphQL Yoga.`,
-            {
-              extensions: {
-                http: {
-                  status: 500,
-                },
-              },
-            },
           )
         }
         setSchema(schema)
       } else {
-        throw new GraphQLError(
+        throw new Error(
           'Request object is not available in the context. Make sure you use this plugin with GraphQL Yoga.',
-          {
-            extensions: {
-              http: {
-                status: 500,
-              },
-            },
-          },
         )
       }
     },

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -203,7 +203,7 @@ export class YogaServer<
   protected plugins: Array<
     Plugin<TUserContext & TServerContext & YogaInitialContext, TServerContext>
   >
-  private onRequestParseHooks: OnRequestParseHook[]
+  private onRequestParseHooks: OnRequestParseHook<TServerContext>[]
   private onParamsHooks: OnParamsHook[]
   private onRequestHooks: OnRequestHook<TServerContext>[]
   private onResultProcessHooks: OnResultProcess[]
@@ -509,6 +509,7 @@ export class YogaServer<
         const onRequestParseResult = await onRequestParse({
           request,
           requestParser,
+          serverContext,
           setRequestParser(parser: RequestParser) {
             requestParser = parser
           },


### PR DESCRIPTION
Technically, `GraphQLSchema` is not needed until Yoga continues with the regular execution pipeline.
For example; The user provides a factory function to set a schema per request. But that function was being called even if the execution pipeline is stopped earlier by another plugin within `onRequest`.
So this PR changes this behavior by moving the schema resolution from `onRequest` to `onParams`.
