### PR TITLE
Skip jest leak detection with noleak tests 

### DIFF
--- a/examples/hackernews/__integration-tests__/hackernews.spec.noleak.ts
+++ b/examples/hackernews/__integration-tests__/hackernews.spec.noleak.ts
@@ -4,7 +4,7 @@ import { createYoga, YogaServerInstance } from 'graphql-yoga'
 import { schema } from '../src/schema'
 import type { GraphQLContext } from '../src/context'
 
-describe.skip('hackernews example integration', () => {
+describe('hackernews example integration', () => {
   let yoga: YogaServerInstance<Record<string, any>, GraphQLContext>
   beforeAll(async () => {
     const { createContext } = await import('../src/context')

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,9 +14,15 @@ let testTimeout = undefined
 
 if (process.env.INTEGRATION_TEST === 'true') {
   testTimeout = 10000
-  testMatch.push(
-    '<rootDir>/**/__integration-tests__/**/?(*.)+(spec|test).[jt]s?(x)',
-  )
+  if (process.env.NOLEAK === 'true') {
+    testMatch.push(
+      '<rootDir>/**/__integration-tests__/**/?(*.)+(spec|test).noleak.[jt]s?(x)',
+    )
+  } else {
+    testMatch.push(
+      '<rootDir>/**/__integration-tests__/**/?(*.)+(spec|test).[jt]s?(x)',
+    )
+  }
   if (parseInt(process.versions.node.split('.')[0]) <= 14) {
     testMatch.push('!**/examples/sveltekit/**')
     testMatch.push('!**/examples/fastify*/**')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "yarn workspaces run check",
     "build": "yarn workspace @graphql-yoga/graphiql run build && yarn workspace @graphql-yoga/render-graphiql run build && yarn workspace graphql-yoga run generate-graphiql-html && bob build",
     "test": "jest --detectOpenHandles --detectLeaks",
-    "test:integration": "cross-env INTEGRATION_TEST=true jest --detectLeaks --logHeapUsage --forceExit",
+    "test:integration": "cross-env INTEGRATION_TEST=true jest --detectLeaks --logHeapUsage --forceExit; cross-env INTEGRATION_TEST=true NOLEAK=true jest --forceExit",
     "release": "yarn build && changeset publish",
     "start:docs": "yarn workspace website dev",
     "postinstall": "patch-package && husky install",


### PR DESCRIPTION
All integration test suites which should skip leak detection have `.noleak.` appended to its filename.
- `mytest.spec.ts` leak detection enabled
- `mytest.spec.noleak.ts` leak detection disabled

This breaks passing in jest arguments though, `yarn test:integration koa.spec` will not only test koa.spec...