### PR TITLE
Deno import map resolves envelop to v2

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -7,7 +7,7 @@
     "@graphql-tools/utils": "npm:@graphql-tools/utils",
     "graphql": "npm:graphql",
     "dset": "npm:dset",
-    "@envelop/core": "npm:@envelop/core",
+    "@envelop/core": "npm:@envelop/core@2",
     "@envelop/parser-cache": "npm:@envelop/parser-cache",
     "@envelop/validation-cache": "npm:@envelop/validation-cache",
     "@whatwg-node/fetch": "npm:@whatwg-node/fetch",


### PR DESCRIPTION
The latest envelop release is v3, but Yoga's not ready yet. Change Deno's import map resolution for envelop to point to v2 instead.