### PR TITLE
chore: remove `@graphql-tools/utils` as dep

### DIFF
--- a/.changeset/breezy-ads-walk.md
+++ b/.changeset/breezy-ads-walk.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+remove graphql tools as dep

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -48,26 +48,26 @@
     "access": "public"
   },
   "dependencies": {
-    "@graphql-tools/utils": "8.12.0",
     "@envelop/core": "3.0.2",
     "@envelop/parser-cache": "5.0.1",
     "@envelop/validation-cache": "5.0.1",
-    "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-tools/schema": "^9.0.0",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "@graphql-yoga/subscription": "^3.0.0-next.0",
-    "@whatwg-node/server": "0.4.11",
     "@whatwg-node/fetch": "0.4.7",
+    "@whatwg-node/server": "0.4.11",
     "dset": "^3.1.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@types/node": "16.11.64",
-    "html-minifier-terser": "7.0.0",
     "@envelop/disable-introspection": "4.0.1",
     "@envelop/live-query": "5.0.1",
+    "@graphql-tools/utils": "^8.12.0",
+    "@types/node": "16.11.64",
     "graphql": "^16.0.1",
-    "graphql-scalars": "1.18.0",
     "graphql-http": "^1.6.0",
+    "graphql-scalars": "1.18.0",
+    "html-minifier-terser": "7.0.0",
     "puppeteer": "18.2.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,12 +2330,20 @@
     apollo-server-types "^3.2.0"
     tslib "^2.4.0"
 
-"@envelop/core@3.0.2", "@envelop/core@^2.4.0":
+"@envelop/core@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@envelop/core/-/core-3.0.2.tgz#0c74b7cf2a1b3fc15bef29dfbebea084249bf5a3"
   integrity sha512-0kYBq0gKIARF6vFYw5upUcBgI2oP3wYaDTUfjiX4RhMIkox3DiKPUwRiZHu16ILGr8Qi6p+HTKXRyoSdl9CCqA==
   dependencies:
     "@envelop/types" "3.0.0"
+    tslib "2.4.0"
+
+"@envelop/core@^2.4.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-2.6.0.tgz#1b7a346a37040c217f0f9b60c3358efc6c3b1b94"
+  integrity sha512-yTptKinJN//i6m1kXUbnLBl/FobzddI4ehURAMS08eRUOQwAuXqJU9r8VdTav8nIZLb4t6cuDWFb3n331LiwLw==
+  dependencies:
+    "@envelop/types" "2.4.0"
     tslib "2.4.0"
 
 "@envelop/disable-introspection@4.0.1":
@@ -2409,6 +2417,13 @@
     "@graphql-tools/utils" "^8.8.0"
     fast-json-stable-stringify "^2.1.0"
     lru-cache "^6.0.0"
+    tslib "^2.4.0"
+
+"@envelop/types@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-2.4.0.tgz#129163df73503581b68950704f4064a6b0f2c6ed"
+  integrity sha512-pjxS98cDQBS84X29VcwzH3aJ/KiLCGwyMxuj7/5FkdiaCXAD1JEvKEj9LARWlFYj1bY43uII4+UptFebrhiIaw==
+  dependencies:
     tslib "^2.4.0"
 
 "@envelop/types@3.0.0":
@@ -3022,7 +3037,7 @@
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/utils@8.12.0", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0":
+"@graphql-tools/utils@8.12.0", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.12.0", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0":
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.12.0.tgz#243bc4f5fc2edbc9e8fd1038189e57d837cbe31f"
   integrity sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==
@@ -12368,7 +12383,17 @@ graphql-ws@5.11.2, graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.2.tgz#d5e0acae8b4d4a4cf7be410a24135cfcefd7ddc0"
   integrity sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==
 
-graphql@16.0.0-experimental-stream-defer.5, graphql@16.5.0, graphql@16.6.0, graphql@^16.0.0, graphql@^16.0.1, graphql@^16.1.0, graphql@^16.2.0, graphql@^16.3.0, graphql@^16.5.0:
+graphql@16.0.0-experimental-stream-defer.5:
+  version "16.0.0-experimental-stream-defer.5"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.0-experimental-stream-defer.5.tgz#d668566fd33053a054dc5367c38c20a4ac4e4224"
+  integrity sha512-bluMjYpxh3a1lwZuNP+FAaEDMWzccVhkv+STcw0ckB2EPtLRTYUdXQhF9YBbUHd3tZSAR7LXzsxIw2GZXhg5rw==
+
+graphql@16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
+  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
+graphql@16.6.0, graphql@^16.0.0, graphql@^16.0.1, graphql@^16.1.0, graphql@^16.2.0, graphql@^16.3.0, graphql@^16.5.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==


### PR DESCRIPTION
we only used a type from `@graphql-tools/utils` in our tests and not actaully using it anywhere so no need for end users to install it.