### PR TITLE
User might supply malformed context to getEnveloped and fix graphql-ws example

### DIFF
--- a/.changeset/healthy-lizards-walk.md
+++ b/.changeset/healthy-lizards-walk.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Handle cases where user supplies a malformed/unexpected context

--- a/packages/graphql-yoga/src/plugins/requestValidation/usePreventMutationViaGET.ts
+++ b/packages/graphql-yoga/src/plugins/requestValidation/usePreventMutationViaGET.ts
@@ -53,7 +53,9 @@ export function usePreventMutationViaGET(): Plugin<YogaInitialContext> {
         result,
         context: {
           request,
-          params: { operationName },
+          // the `params` might be missing in cases where the user provided
+          // malformed context to getEnveloped (like `yoga.getEnveloped({})`)
+          params: { operationName } = {},
         },
       }) => {
         // Run only if this is a Yoga request

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -309,7 +309,9 @@ export class YogaServer<
                 this.logger.debug(titleBold('Execution start'))
                 // eslint-disable-next-line no-case-declarations
                 const {
-                  params: { query, operationName, variables, extensions },
+                  // the `params` might be missing in cases where the user provided
+                  // malformed context to getEnveloped (like `yoga.getEnveloped({})`)
+                  params: { query, operationName, variables, extensions } = {},
                 }: YogaInitialContext = events.args.contextValue
                 this.logger.debug(titleBold('Received GraphQL operation:'))
                 this.logger.debug({

--- a/website/src/pages/v3/features/subscriptions.mdx
+++ b/website/src/pages/v3/features/subscriptions.mdx
@@ -195,11 +195,11 @@ useServer(
     onSubscribe: async (ctx, msg) => {
       const { schema, execute, subscribe, contextFactory, parse, validate } =
         yogaApp.getEnveloped({
-            ...ctx,
-            req: ctx.extra.request,
-            socket: ctx.extra.socket,
-            params: msg.payload,
-          })
+          ...ctx,
+          req: ctx.extra.request,
+          socket: ctx.extra.socket,
+          params: msg.payload
+        })
 
       const args = {
         schema,

--- a/website/src/pages/v3/features/subscriptions.mdx
+++ b/website/src/pages/v3/features/subscriptions.mdx
@@ -194,7 +194,12 @@ useServer(
     subscribe: (args: any) => args.rootValue.subscribe(args),
     onSubscribe: async (ctx, msg) => {
       const { schema, execute, subscribe, contextFactory, parse, validate } =
-        yogaApp.getEnveloped(ctx)
+        yogaApp.getEnveloped({
+            ...ctx,
+            req: ctx.extra.request,
+            socket: ctx.extra.socket,
+            params: msg.payload,
+          })
 
       const args = {
         schema,


### PR DESCRIPTION
If you supply a malformed/unexpected context value to Yoga's envelop instance like this: `yoga.getEnveloped({})` - everything breaks because Yoga depends on the `params` being present in the context and envelop's typings don't require the correct context.

This PR considers, and properly handles, the fact that the `params` might be missing in some cases.

Also updated the `graphql-ws` example to show a correctly formatted context.