### PR TITLE
Handle edge case where Content-Type header provides a list

### DIFF
--- a/.changeset/fast-coats-explode.md
+++ b/.changeset/fast-coats-explode.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Handle edge case where Content-Type header provides a list

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -309,4 +309,46 @@ describe('requests', () => {
       'Unexpected parameter "test" in the request body.',
     )
   })
+
+  it('should use supported accept header when multiple are provided', async () => {
+    const response = await yoga.fetch('http://yoga/test-graphql', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: ['application/xml', 'application/json'],
+      },
+      body: JSON.stringify({ query: '{ ping }' }),
+    })
+
+    expect(response.ok).toBeTruthy()
+    const body = await response.json()
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "ping": "pong",
+        },
+      }
+    `)
+  })
+
+  it('should parse when multiple content-type headers are provided', async () => {
+    const response = await yoga.fetch('http://yoga/test-graphql', {
+      method: 'POST',
+      headers: {
+        // not valid as per HTTP spec, but some proxies/gateways dont care
+        'content-type': ['application/json', 'application/json'],
+      },
+      body: JSON.stringify({ query: '{ ping }' }),
+    })
+
+    expect(response.ok).toBeTruthy()
+    const body = await response.json()
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "ping": "pong",
+        },
+      }
+    `)
+  })
 })

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -335,7 +335,7 @@ describe('requests', () => {
     const response = await yoga.fetch('http://yoga/test-graphql', {
       method: 'POST',
       headers: {
-        // not valid as per HTTP spec, but some proxies/gateways dont care
+        // not valid as per HTTP spec, but some clients dont care
         'content-type': ['application/json', 'application/json'],
       },
       body: JSON.stringify({ query: '{ ping }' }),

--- a/packages/graphql-yoga/src/plugins/requestParser/utils.ts
+++ b/packages/graphql-yoga/src/plugins/requestParser/utils.ts
@@ -20,7 +20,7 @@ export function isContentTypeMatch(
 ): boolean {
   let contentType = request.headers.get('content-type')
 
-  // a list of content-types is not valid as per HTTP spec, but some proxies/gateways dont care
+  // a list of content-types is not valid as per HTTP spec, but some clients dont care
   contentType = contentType?.split(',')[0] || null
 
   return (

--- a/packages/graphql-yoga/src/plugins/requestParser/utils.ts
+++ b/packages/graphql-yoga/src/plugins/requestParser/utils.ts
@@ -18,7 +18,11 @@ export function isContentTypeMatch(
   request: Request,
   expectedContentType: string,
 ): boolean {
-  const contentType = request.headers.get('content-type')
+  let contentType = request.headers.get('content-type')
+
+  // a list of content-types is not valid as per HTTP spec, but some proxies/gateways dont care
+  contentType = contentType?.split(',')[0] || null
+
   return (
     contentType === expectedContentType ||
     !!contentType?.startsWith(`${expectedContentType};`)


### PR DESCRIPTION
@charlypoly discovered that sometimes a client misbehaves and provides a list of values in the `Content-Type` header. This is not valid as per the HTTP spec, but the culprits don't care...