### PR TITLE
fix(validation): Hack to fix broken validation error messages

### DIFF
--- a/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
+++ b/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
@@ -7,6 +7,9 @@ export function useHTTPValidationError(): Plugin {
       return ({ valid, result }) => {
         if (!valid) {
           result.forEach((error) => {
+            if (!error.extensions) {
+              error[<any>'extensions'] = {}
+            }
             error.extensions.http = {
               status: 400,
             }

--- a/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
+++ b/packages/common/src/plugins/requestValidation/useHTTPValidationError.ts
@@ -7,11 +7,10 @@ export function useHTTPValidationError(): Plugin {
       return ({ valid, result }) => {
         if (!valid) {
           result.forEach((error) => {
-            if (!error.extensions) {
-              error[<any>'extensions'] = {}
-            }
-            error.extensions.http = {
-              status: 400,
+            if (error.extensions) {
+              error.extensions.http = {
+                status: 400,
+              }
             }
           })
           throw new AggregateError(result)

--- a/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
+++ b/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
@@ -12,6 +12,9 @@ export function usePreventMutationViaGET(): Plugin<YogaInitialContext> {
         if (request != null) {
           if (result instanceof Error) {
             if (result instanceof GraphQLError) {
+              if (!result.extensions) {
+                result[<any>'extensions'] = {}
+              }
               result.extensions.http = {
                 status: 400,
               }

--- a/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
+++ b/packages/common/src/plugins/requestValidation/usePreventMutationViaGET.ts
@@ -12,11 +12,10 @@ export function usePreventMutationViaGET(): Plugin<YogaInitialContext> {
         if (request != null) {
           if (result instanceof Error) {
             if (result instanceof GraphQLError) {
-              if (!result.extensions) {
-                result[<any>'extensions'] = {}
-              }
-              result.extensions.http = {
-                status: 400,
+              if (result.extensions) {
+                result.extensions.http = {
+                  status: 400,
+                }
               }
             }
             throw result


### PR DESCRIPTION
When making a request with a validation issue, the error `"Cannot set property 'http' of undefined"` is returned instead of the actual validation error.

This is caused by a bug in the validator code that assumes all GraphQLError objects have a populated `extension` property. When `error.extension` is undefined, the validator code errors out, and that error messages bubbles up instead of the right one.

My fix is just a hack to populate the `extension` property if it is missing. The typescript typing says it's a readonly property so I use some typescript magic to ignore that.

Better options would be to:
1. Ensure that the GraphQLError's are created with properly populated `extension` property in the first place.
2. Replace the GraphQLError in the validator code with a whole new instance, but with the `extension` property populated.

I chose my fix because it seemed like the least invasive option.

This issue can be recreated on CodeSandbox: https://codesandbox.io/s/graphql-yoga-bug-rgg8uc?file=/package.json

Querying a valid query works as expected:
```
query MyQuery {
  allItems {
    items {
      name
    }
  }
}
```

But querying an invalid query returns the wrong error message:
```
Querying
query MyQuery {
  allItems {
    items {
      names
    }
  }
}
```