### PR TITLE
Fixed graphiql ignoring options if `GraphiQLOptionFactory` returns Promise

### DIFF
--- a/.changeset/eighty-crabs-stare.md
+++ b/.changeset/eighty-crabs-stare.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/common': patch
+---
+
+Fixed graphiql ignoring options if `GraphiQLOptionFactory` returns Promise

--- a/packages/common/__tests__/graphiql.test.ts
+++ b/packages/common/__tests__/graphiql.test.ts
@@ -1,6 +1,3 @@
-import { AfterValidateHook } from '@envelop/core'
-import { GraphQLError } from 'graphql'
-import { Plugin } from '../src/plugins/types'
 import { createServer } from '../src/server'
 
 describe('GraphiQL', () => {

--- a/packages/common/__tests__/graphiql.test.ts
+++ b/packages/common/__tests__/graphiql.test.ts
@@ -1,0 +1,37 @@
+import { AfterValidateHook } from '@envelop/core'
+import { GraphQLError } from 'graphql'
+import { Plugin } from '../src/plugins/types'
+import { createServer } from '../src/server'
+
+describe('GraphiQL', () => {
+  describe('when received an option factory that returns Promise', () => {
+    it('should respect graphiql option', async () => {
+      const yoga = createServer({
+        graphiql: () => Promise.resolve({ title: 'Test GraphiQL' }),
+      })
+      const response = await yoga.fetch('http://localhost:3000/graphql', {
+        method: 'GET',
+        headers: {
+          Accept: 'text/html',
+        },
+      })
+      expect(response.headers.get('content-type')).toEqual('text/html')
+      const result = await response.text()
+      expect(result).toMatch(/<title>Test GraphiQL<\/title>/)
+    })
+
+    it('returns error when graphiql is disabled', async () => {
+      const yoga = createServer({
+        graphiql: () => Promise.resolve(false),
+      })
+      const response = await yoga.fetch('http://localhost:3000/graphql', {
+        method: 'GET',
+        headers: {
+          Accept: 'text/html',
+        },
+      })
+      expect(response.headers.get('content-type')).toEqual('application/json')
+      expect(response.status).toEqual(400)
+    })
+  })
+})

--- a/packages/common/src/plugins/useGraphiQL.ts
+++ b/packages/common/src/plugins/useGraphiQL.ts
@@ -104,7 +104,7 @@ export function useGraphiQL<TServerContext>(
         endResponse(response)
       } else if (shouldRenderGraphiQL(request)) {
         logger.debug(`Rendering GraphiQL`)
-        const graphiqlOptions = graphiqlOptionsFactory(
+        const graphiqlOptions = await graphiqlOptionsFactory(
           request,
           serverContext as TServerContext,
         )


### PR DESCRIPTION
fix for https://github.com/dotansimha/graphql-yoga/issues/1964

added `await` for `graphiqlOptionsFactory` return value which may be a Promise