### PR TITLE
fix: respect the order in the accept header

### DIFF
--- a/.changeset/sweet-paws-kiss.md
+++ b/.changeset/sweet-paws-kiss.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Respect the order of mime types given in the accept header by the client

--- a/examples/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/examples/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -7,7 +7,8 @@ describe('Defer / Stream', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'multipart/mixed',
+        Accept:
+          'application/graphql-response+json, application/json, multipart/mixed',
       },
       body: JSON.stringify({
         query: /* GraphQL */ `
@@ -33,7 +34,8 @@ describe('Defer / Stream', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'multipart/mixed',
+        Accept:
+          'application/graphql-response+json, application/json, multipart/mixed',
       },
       body: JSON.stringify({
         query: /* GraphQL */ `

--- a/packages/graphql-yoga/src/plugins/resultProcessor/accept.ts
+++ b/packages/graphql-yoga/src/plugins/resultProcessor/accept.ts
@@ -1,41 +1,31 @@
-import { memoize1 } from '@graphql-tools/utils'
+export function getMediaTypesForRequestInOrder(request: Request): string[] {
+  const accepts = (request.headers.get('accept') || '*/*')
+    .replace(/\s/g, '')
+    .toLowerCase()
+    .split(',')
+  const mediaTypes: string[] = []
+  for (const accept of accepts) {
+    const [mediaType, ...params] = accept.split(';')
+    const charset =
+      params?.find((param) => param.includes('charset=')) || 'charset=utf-8' // utf-8 is assumed when not specified;
 
-export const getMediaTypesForRequest = memoize1(
-  function getMediaTypesForRequest(request: Request): string[] {
-    const accepts = (request.headers.get('accept') || '*/*')
-      .replace(/\s/g, '')
-      .toLowerCase()
-      .split(',')
-    const mediaTypes: string[] = []
-    for (const accept of accepts) {
-      const [mediaType, ...params] = accept.split(';')
-      const charset =
-        params?.find((param) => param.includes('charset=')) || 'charset=utf-8' // utf-8 is assumed when not specified;
-
-      if (charset !== 'charset=utf-8') {
-        // only utf-8 is supported
-        continue
-      }
-      mediaTypes.push(mediaType)
+    if (charset !== 'charset=utf-8') {
+      // only utf-8 is supported
+      continue
     }
-    return mediaTypes
-  },
-)
+    mediaTypes.push(mediaType)
+  }
+  return mediaTypes.reverse()
+}
 
-export function isAcceptableByRequest(
+export function isMatchingMediaType(
   askedMediaType: string,
-  request: Request,
-): boolean {
-  const mediaTypes = getMediaTypesForRequest(request)
+  processorMediaType: string,
+) {
   const [askedPre, askedSuf] = askedMediaType.split('/')
-  return mediaTypes.some((mediaType) => {
-    const [pre, suf] = mediaType.split('/')
-    if (
-      (pre === '*' || pre === askedPre) &&
-      (suf === '*' || suf === askedSuf)
-    ) {
-      return true
-    }
-    return false
-  })
+  const [pre, suf] = processorMediaType.split('/')
+  if ((pre === '*' || pre === askedPre) && (suf === '*' || suf === askedSuf)) {
+    return true
+  }
+  return false
 }

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -129,7 +129,7 @@ export interface OnResultProcessEventPayload {
   request: Request
   result: ResultProcessorInput
   resultProcessor?: ResultProcessor
-  acceptableMediaTypes: Set<string>
+  acceptableMediaTypes: string[]
   setResultProcessor(
     resultProcessor: ResultProcessor,
     acceptedMediaType: string,

--- a/packages/graphql-yoga/src/plugins/useResultProcessor.ts
+++ b/packages/graphql-yoga/src/plugins/useResultProcessor.ts
@@ -30,7 +30,10 @@ export function useResultProcessors(
           ) {
             continue
           }
-          for (const processorMediaType of resultProcessorConfig.mediaTypes) {
+          const processorMediaTypesInOrder = [
+            ...resultProcessorConfig.mediaTypes,
+          ].reverse()
+          for (const processorMediaType of processorMediaTypesInOrder) {
             acceptableMediaTypes.push(processorMediaType)
             if (isMatchingMediaType(processorMediaType, requestMediaType)) {
               setResultProcessor(

--- a/packages/graphql-yoga/src/process-request.ts
+++ b/packages/graphql-yoga/src/process-request.ts
@@ -23,7 +23,7 @@ export async function processResult({
 }) {
   let resultProcessor: ResultProcessor | undefined
 
-  const acceptableMediaTypes = new Set<string>()
+  const acceptableMediaTypes: string[] = []
   let acceptedMediaType = '*/*'
 
   for (const onResultProcessHook of onResultProcessHooks) {
@@ -45,7 +45,7 @@ export async function processResult({
       status: 406,
       statusText: 'Not Acceptable',
       headers: {
-        accept: [...acceptableMediaTypes].join('; charset=utf-8, '),
+        accept: acceptableMediaTypes.join('; charset=utf-8, '),
       },
     })
   }

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -63,7 +63,7 @@ import {
   isPOSTGraphQLStringRequest,
   parsePOSTGraphQLStringRequest,
 } from './plugins/requestParser/POSTGraphQLString.js'
-import { useResultProcessor } from './plugins/useResultProcessor.js'
+import { useResultProcessors } from './plugins/useResultProcessor.js'
 import { processRegularResult } from './plugins/resultProcessor/regular.js'
 import { processPushResult } from './plugins/resultProcessor/push.js'
 import { processMultipartResult } from './plugins/resultProcessor/multipart.js'
@@ -381,18 +381,21 @@ export class YogaServer<
         parse: parsePOSTFormUrlEncodedRequest,
       }),
       // Middlewares after the GraphQL execution
-      useResultProcessor({
-        mediaTypes: ['multipart/mixed'],
-        processResult: processMultipartResult,
-      }),
-      useResultProcessor({
-        mediaTypes: ['text/event-stream'],
-        processResult: processPushResult,
-      }),
-      useResultProcessor({
-        mediaTypes: ['application/graphql-response+json', 'application/json'],
-        processResult: processRegularResult,
-      }),
+      useResultProcessors([
+        {
+          mediaTypes: ['multipart/mixed'],
+          processResult: processMultipartResult,
+        },
+        {
+          mediaTypes: ['text/event-stream'],
+          processResult: processPushResult,
+        },
+        {
+          mediaTypes: ['application/graphql-response+json', 'application/json'],
+          noAsyncIterable: true,
+          processResult: processRegularResult,
+        },
+      ]),
       ...(options?.plugins ?? []),
       useLimitBatching(batchingLimit),
       useCheckGraphQLQueryParams(),


### PR DESCRIPTION
Yoga was choosing the processor according to the order we have in our internal plugins but it should respect the order of the accept header instead.
And also Yoga was ignoring other mime types in the accept header because the last accepted procesor was always chosen.

For example if there is an asynciterable result but `application/json, multipart/mixed` is given then Yoga chooses `json` no matter what then fails because `json` processor cannot process async iterables.