### PR TITLE
support older graphql js version

### DIFF
--- a/.changeset/smart-pens-compete.md
+++ b/.changeset/smart-pens-compete.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+inline functions to support multiple version of graphql-js

--- a/packages/graphql-yoga/src/validations/overlapping-fields-can-be-merged.ts
+++ b/packages/graphql-yoga/src/validations/overlapping-fields-can-be-merged.ts
@@ -22,8 +22,7 @@ import {
   ObjectFieldNode,
   ValueNode,
 } from 'graphql'
-import { inspect } from 'graphql/jsutils/inspect.js'
-import type { Maybe } from 'graphql/jsutils/Maybe.js'
+import { inspect, Maybe } from '@graphql-tools/utils'
 import type { ObjMap } from 'graphql/jsutils/ObjMap.js'
 import { naturalCompare } from 'graphql/jsutils/naturalCompare.js'
 

--- a/packages/graphql-yoga/src/validations/overlapping-fields-can-be-merged.ts
+++ b/packages/graphql-yoga/src/validations/overlapping-fields-can-be-merged.ts
@@ -23,8 +23,69 @@ import {
   ValueNode,
 } from 'graphql'
 import { inspect, Maybe } from '@graphql-tools/utils'
-import type { ObjMap } from 'graphql/jsutils/ObjMap.js'
-import { naturalCompare } from 'graphql/jsutils/naturalCompare.js'
+
+interface ObjMap<T> {
+  [key: string]: T
+}
+
+/**
+ * Returns a number indicating whether a reference string comes before, or after,
+ * or is the same as the given string in natural sort order.
+ *
+ * See: https://en.wikipedia.org/wiki/Natural_sort_order
+ *
+ */
+export function naturalCompare(aStr: string, bStr: string): number {
+  let aIndex = 0
+  let bIndex = 0
+
+  while (aIndex < aStr.length && bIndex < bStr.length) {
+    let aChar = aStr.charCodeAt(aIndex)
+    let bChar = bStr.charCodeAt(bIndex)
+
+    if (isDigit(aChar) && isDigit(bChar)) {
+      let aNum = 0
+      do {
+        ++aIndex
+        aNum = aNum * 10 + aChar - DIGIT_0
+        aChar = aStr.charCodeAt(aIndex)
+      } while (isDigit(aChar) && aNum > 0)
+
+      let bNum = 0
+      do {
+        ++bIndex
+        bNum = bNum * 10 + bChar - DIGIT_0
+        bChar = bStr.charCodeAt(bIndex)
+      } while (isDigit(bChar) && bNum > 0)
+
+      if (aNum < bNum) {
+        return -1
+      }
+
+      if (aNum > bNum) {
+        return 1
+      }
+    } else {
+      if (aChar < bChar) {
+        return -1
+      }
+      if (aChar > bChar) {
+        return 1
+      }
+      ++aIndex
+      ++bIndex
+    }
+  }
+
+  return aStr.length - bStr.length
+}
+
+const DIGIT_0 = 48
+const DIGIT_9 = 57
+
+function isDigit(code: number): boolean {
+  return !isNaN(code) && DIGIT_0 <= code && code <= DIGIT_9
+}
 
 function sortValueNode(valueNode: ValueNode): ValueNode {
   switch (valueNode.kind) {


### PR DESCRIPTION
utils are internal in `graphql-js` and importing this way we are basically breaking different variants of `graphql-js` this allows us to use across version