### PR TITLE
chore: re-export specific things from @envelop/core

### DIFF
--- a/.changeset/thin-rings-buy.md
+++ b/.changeset/thin-rings-buy.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': major
+---
+
+export only specific things from `@envelop/core`

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -2,7 +2,29 @@ export * from './types.js'
 export * from './logger.js'
 export * from './server.js'
 
-export * from '@envelop/core'
+export {
+  // useful for anyone creating a new envelop instance
+  envelop,
+  // Default plugins
+  useEnvelop,
+  useLogger,
+  useExtendContext,
+  usePayloadFormatter,
+  // useful helpers
+  isIntrospectionOperationString,
+  makeSubscribe,
+  mapAsyncIterator,
+  makeExecute,
+  handleStreamOrSingleExecutionResult,
+  finalAsyncIterator,
+  errorAsyncIterator,
+  isAsyncIterable,
+  // Handy type utils
+  Maybe,
+  Optional,
+  PromiseOrValue,
+  Spread,
+} from '@envelop/core'
 export type { CORSOptions } from './plugins/useCORS.js'
 export type { GraphiQLOptions } from './plugins/useGraphiQL.js'
 export type { Plugin } from './plugins/types.js'


### PR DESCRIPTION
> after some thought I think we should really only export selective things from `@envelop/core` instead of exporting everything. This way we avoid any breaking changes downstream envelop impacting us. 

closes https://github.com/dotansimha/graphql-yoga/issues/2039