### PR TITLE
allow id as expected query params

### DIFF
--- a/packages/graphql-yoga/src/plugins/requestValidation/useCheckGraphQLQueryParams.ts
+++ b/packages/graphql-yoga/src/plugins/requestValidation/useCheckGraphQLQueryParams.ts
@@ -2,7 +2,13 @@ import { createGraphQLError } from '@graphql-tools/utils'
 import type { GraphQLParams } from '../../types'
 import type { Plugin } from '../types'
 
-const EXPECTED_PARAMS = ['query', 'variables', 'operationName', 'extensions']
+const EXPECTED_PARAMS = [
+  'query',
+  'variables',
+  'operationName',
+  'extensions',
+  'id',
+]
 
 export function assertInvalidParams(
   params: unknown,


### PR DESCRIPTION
Many clients send id's as part of graphql-requests which are usually analogous to operationName.
This PR-allows allows the graphql-server to ignore the passed id instead of erroring out as it currently does.

see: https://github.com/relay-tools/react-relay-network-modern/blob/master/src/RelayRequest.js