### PR TITLE
docs(README): fix invalid examples link

### DIFF
--- a/packages/graphql-yoga/README.md
+++ b/packages/graphql-yoga/README.md
@@ -87,9 +87,9 @@ server.listen(4000, () => {
 
 Our [documentation website](https://www.the-guild.dev/graphql/yoga-server/v3) will help you get started.
 
-## [Examples](https://github.com/dotansimha/graphql-yoga/tree/readme/examples)
+## [Examples](https://github.com/dotansimha/graphql-yoga/tree/main/examples)
 
-We've made sure developers can quickly start with GraphQL Yoga by providing a comprehensive set of examples. [See all of them in the `examples/` folder.](https://github.com/dotansimha/graphql-yoga/tree/readme/examples)
+We've made sure developers can quickly start with GraphQL Yoga by providing a comprehensive set of examples. [See all of them in the `examples/` folder.](https://github.com/dotansimha/graphql-yoga/tree/main/examples)
 
 ## [Comparison](https://www.the-guild.dev/graphql/yoga-server/v3/comparison)
 


### PR DESCRIPTION
I discovered that links to the examples in the README aren't valid. This PR fixes it 🚀 