### PR TITLE
fix: enable schema description by default

### DIFF
--- a/packages/graphiql/src/YogaGraphiQL.tsx
+++ b/packages/graphiql/src/YogaGraphiQL.tsx
@@ -113,7 +113,6 @@ export function YogaGraphiQL(props: YogaGraphiQLProps): React.ReactElement {
       credentials: 'same-origin',
       specifiedByUrl: true,
       directiveIsRepeatable: true,
-      schemaDescription: true,
       ...props,
       headers: props.additionalHeaders || {},
     })
@@ -152,6 +151,7 @@ export function YogaGraphiQL(props: YogaGraphiQLProps): React.ReactElement {
       <GraphiQLProvider
         plugins={[explorerPlugin]}
         query={query}
+        schemaDescription={true}
         fetcher={fetcher}
       >
         <GraphiQLInterface

--- a/packages/graphql-yoga/src/plugins/useGraphiQL.ts
+++ b/packages/graphql-yoga/src/plugins/useGraphiQL.ts
@@ -31,7 +31,7 @@ export type GraphiQLOptions = {
    */
   headerEditorEnabled?: boolean
   /**
-   * The title to display at the top of the page. Defaults to `"YogaGraphiQL"`.
+   * The title to display at the top of the page. Defaults to `"Yoga GraphiQL"`.
    */
   title?: string
   /**


### PR DESCRIPTION
Currently, schema description was intended to enable by default
https://github.com/dotansimha/graphql-yoga/blob/8775f145708dd47bdc5bc1a5eb0478e18c47f143/packages/graphiql/src/YogaGraphiQL.tsx#L111-L119

But specifying it in `fetcher` props does not work, in this pull I change to use `GraphiQLProvider`'s props, same as [GraphiQL default components](https://github.com/graphql/graphiql/blob/6c3ca902d769893a4201f8856299af18b7e21a1b/packages/graphiql/src/components/GraphiQL.tsx#L155) 