### PR TITLE
docs: fix example typo

### DIFF
--- a/website/src/pages/docs/features/subscriptions.mdx
+++ b/website/src/pages/docs/features/subscriptions.mdx
@@ -188,7 +188,7 @@ class SSELink extends ApolloLink {
     if (operation.operationName) {
       url.searchParams.append(
         'operationName',
-        JSON.stringify(operation.operationName)
+        operation.operationName
       )
     }
     if (operation.variables) {


### PR DESCRIPTION
I was trying out a rewrite to Yoga through through the documentation examples and my Apollo Client custom config looked pretty close to the example but it was failing for SSE requests. It turns out my request was being stringified twice so it would go from `analyticEvent` to `"analyticEvent"` and when adding that to the URL params it was coming back with 

```
data: {"errors":[{"message":"Could not determine what operation to execute."}]}
```

