### PR TITLE
graphql-sse plugin

### DIFF
--- a/.changeset/long-pandas-joke.md
+++ b/.changeset/long-pandas-joke.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Check HTTP request method after user-land plugins

--- a/.changeset/polite-owls-judge.md
+++ b/.changeset/polite-owls-judge.md
@@ -1,6 +1,5 @@
 ---
 '@graphql-yoga/plugin-graphql-sse': major
-'graphql-yoga': patch
 ---
 
 GraphQL over Server-Sent Events Protocol plugin for GraphQL Yoga

--- a/.changeset/polite-owls-judge.md
+++ b/.changeset/polite-owls-judge.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/plugin-graphql-sse': major
+'graphql-yoga': patch
+---
+
+GraphQL over Server-Sent Events Protocol plugin for GraphQL Yoga

--- a/examples/graphql-sse/package.json
+++ b/examples/graphql-sse/package.json
@@ -7,7 +7,7 @@
     "check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@graphql-yoga/plugin-graphql-sse": "1.0.0",
+    "@graphql-yoga/plugin-graphql-sse": "0.0.0",
     "graphql-yoga": "3.1.2",
     "graphql": "16.6.0"
   },

--- a/examples/graphql-sse/package.json
+++ b/examples/graphql-sse/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-graphql-sse",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "check": "tsc --pretty --noEmit"
+  },
+  "dependencies": {
+    "@graphql-yoga/plugin-graphql-sse": "1.0.0",
+    "graphql-yoga": "3.1.2",
+    "graphql": "16.6.0"
+  },
+  "devDependencies": {
+    "ts-node": "10.9.1",
+    "typescript": "4.9.4"
+  }
+}

--- a/examples/graphql-sse/src/app.ts
+++ b/examples/graphql-sse/src/app.ts
@@ -1,0 +1,70 @@
+import { Socket } from 'net'
+import { createServer } from 'http'
+import { createYoga, createSchema } from 'graphql-yoga'
+import { useGraphQLSSE } from '@graphql-yoga/plugin-graphql-sse'
+
+export function buildApp() {
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hello: String!
+        }
+        type Mutation {
+          dontChange: String!
+        }
+        type Subscription {
+          greetings: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          hello() {
+            return 'world'
+          },
+        },
+        Mutation: {
+          dontChange() {
+            return 'didntChange'
+          },
+        },
+        Subscription: {
+          greetings: {
+            async *subscribe() {
+              for (const hi of ['Hi', 'Bonjour', 'Hola', 'Ciao', 'Zdravo']) {
+                yield { greetings: hi }
+              }
+            },
+          },
+        },
+      },
+    }),
+    plugins: [useGraphQLSSE()],
+  })
+
+  const server = createServer(yoga)
+
+  // for termination
+  const sockets = new Set<Socket>()
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    server.once('close', () => sockets.delete(socket))
+  })
+
+  return {
+    start: (port: number) =>
+      new Promise<void>((resolve, reject) => {
+        server.on('error', (err) => reject(err))
+        server.on('listening', () => resolve())
+        server.listen(port)
+      }),
+    stop: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of sockets) {
+          socket.destroy()
+          sockets.delete(socket)
+        }
+        server.close(() => resolve())
+      }),
+  }
+}

--- a/examples/graphql-sse/src/index.ts
+++ b/examples/graphql-sse/src/index.ts
@@ -1,0 +1,11 @@
+import { buildApp } from './app'
+
+async function main() {
+  const app = buildApp()
+  await app.start(4000)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/examples/graphql-sse/tsconfig.json
+++ b/examples/graphql-sse/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "sourceMap": true,
+    "lib": ["esnext", "DOM", "DOM.Iterable"],
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -86,7 +86,6 @@ export interface OnRequestEventPayload<TServerContext> {
   fetchAPI: FetchAPI
   endResponse(response: Response): void
   url: URL
-  getEnveloped: GetEnvelopedFn<TServerContext & YogaInitialContext>
 }
 
 export type OnRequestParseHook<TServerContext> = (

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -4,7 +4,6 @@ import {
   PromiseOrValue,
   OnExecuteHook,
   OnSubscribeHook,
-  GetEnvelopedFn,
 } from '@envelop/core'
 import { ExecutionResult } from '@graphql-tools/utils'
 import { YogaServer } from '../server.js'

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -4,6 +4,7 @@ import {
   PromiseOrValue,
   OnExecuteHook,
   OnSubscribeHook,
+  GetEnvelopedFn,
 } from '@envelop/core'
 import { ExecutionResult } from '@graphql-tools/utils'
 import { YogaServer } from '../server.js'
@@ -85,6 +86,7 @@ export interface OnRequestEventPayload<TServerContext> {
   fetchAPI: FetchAPI
   endResponse(response: Response): void
   url: URL
+  getEnveloped: GetEnvelopedFn<TServerContext & YogaInitialContext>
 }
 
 export type OnRequestParseHook<TServerContext> = (

--- a/packages/graphql-yoga/src/plugins/useGraphiQL.ts
+++ b/packages/graphql-yoga/src/plugins/useGraphiQL.ts
@@ -43,7 +43,7 @@ export type GraphiQLOptions = {
   /**
    * Protocol for subscriptions
    */
-  subscriptionsProtocol?: 'SSE' | 'WS' | 'LEGACY_WS'
+  subscriptionsProtocol?: 'SSE' | 'GRAPHQL_SSE' | 'WS' | 'LEGACY_WS'
   /**
    * Extra headers you always want to pass with users' headers input
    */

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -495,8 +495,6 @@ export class YogaServer<
         endResponse(newResponse) {
           response = newResponse
         },
-        // @ts-expect-error is missing the TUserContext
-        getEnveloped: this.getEnveloped,
       })
       if (response) {
         return response

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -493,6 +493,8 @@ export class YogaServer<
         endResponse(newResponse) {
           response = newResponse
         },
+        // @ts-expect-error is missing the TUserContext
+        getEnveloped: this.getEnveloped,
       })
       if (response) {
         return response

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -322,7 +322,6 @@ export class YogaServer<
           logger: this.logger,
         }),
       // Middlewares before the GraphQL execution
-      useCheckMethodForGraphQL(),
       useRequestParser({
         match: isGETRequest,
         parse: parseGETRequest,
@@ -362,6 +361,9 @@ export class YogaServer<
               showLandingPage: options?.landingPage ?? true,
             }),
           )
+          // We check the method after user-land plugins because the plugin might support more methods (like graphql-sse).
+          // @ts-expect-error Add plugins has context but this hook doesn't care
+          addPlugin(useCheckMethodForGraphQL())
           // We make sure that the user doesn't send a mutation with GET
           // @ts-expect-error Add plugins has context but this hook doesn't care
           addPlugin(usePreventMutationViaGET())

--- a/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
+++ b/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
@@ -91,6 +91,8 @@ describe('graphql-sse', () => {
         },
       ]
     `)
+
+    client.dispose()
   })
 
   it('should stream using single connection and lazy mode', async () => {
@@ -149,6 +151,8 @@ describe('graphql-sse', () => {
         },
       ]
     `)
+
+    client.dispose()
   })
 
   it('should stream using single connection and non-lazy mode', async () => {
@@ -207,5 +211,7 @@ describe('graphql-sse', () => {
         },
       ]
     `)
+
+    client.dispose()
   })
 })

--- a/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
+++ b/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
@@ -1,0 +1,63 @@
+import { createYoga, createSchema } from 'graphql-yoga'
+import { useGraphQLSSE } from '../src/index.js'
+
+describe('graphql-sse', () => {
+  const schema = createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        hello: String!
+      }
+      type Subscription {
+        greetings: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        async hello() {
+          return 'world'
+        },
+      },
+      Subscription: {
+        greetings: {
+          async *subscribe() {
+            for (const hi of ['Hi', 'Bonjour', 'Hola', 'Ciao', 'Zdravo']) {
+              yield { greetings: hi }
+            }
+          },
+        },
+      },
+    },
+  })
+
+  const yoga = createYoga({
+    schema,
+    plugins: [useGraphQLSSE()],
+    maskedErrors: false,
+  })
+
+  it('should', async () => {
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          {
+            hello
+          }
+        `,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+
+    expect(response.ok).toBeTruthy()
+
+    await expect(response.json()).resolves.toMatchInlineSnapshot(`
+      {
+        "data": {
+          "hello": "world",
+        },
+      }
+    `)
+  })
+})

--- a/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
+++ b/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
@@ -217,4 +217,44 @@ describe('graphql-sse', () => {
 
     client.dispose()
   })
+
+  it('should use CORS settings from the server', async () => {
+    const yoga = createYoga({
+      schema,
+      cors: {
+        origin: 'http://yoga',
+        credentials: true,
+        allowedHeaders: ['x-some-header'],
+        methods: ['GET', 'POST', 'DELETE', 'PUT'],
+      },
+      plugins: [useGraphQLSSE()],
+      maskedErrors: false,
+    })
+
+    const res = await yoga.fetch('http://yoga/graphql/stream', {
+      method: 'OPTIONS',
+    })
+
+    expect(res.headers).toMatchInlineSnapshot(`
+      Headers {
+        Symbol(map): {
+          "Access-Control-Allow-Credentials": [
+            "true",
+          ],
+          "Access-Control-Allow-Headers": [
+            "x-some-header",
+          ],
+          "Access-Control-Allow-Methods": [
+            "GET, POST, DELETE, PUT",
+          ],
+          "Access-Control-Allow-Origin": [
+            "http://yoga",
+          ],
+          "Content-Length": [
+            "0",
+          ],
+        },
+      }
+    `)
+  })
 })

--- a/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
+++ b/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
@@ -40,6 +40,7 @@ describe('graphql-sse', () => {
     const client = createClient({
       url: 'http://yoga/graphql/stream',
       fetchFn: yoga.fetch,
+      abortControllerImpl: yoga.fetchAPI.AbortController,
       singleConnection: false, // distinct connection mode
       retryAttempts: 0,
     })
@@ -99,6 +100,7 @@ describe('graphql-sse', () => {
     const client = createClient({
       url: 'http://yoga/graphql/stream',
       fetchFn: yoga.fetch,
+      abortControllerImpl: yoga.fetchAPI.AbortController,
       singleConnection: true, // single connection mode
       lazy: true,
       retryAttempts: 0,
@@ -159,6 +161,7 @@ describe('graphql-sse', () => {
     const client = createClient({
       url: 'http://yoga/graphql/stream',
       fetchFn: yoga.fetch,
+      abortControllerImpl: yoga.fetchAPI.AbortController,
       singleConnection: true, // single connection mode
       lazy: false,
       retryAttempts: 0,

--- a/packages/plugins/graphql-sse/package.json
+++ b/packages/plugins/graphql-sse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-yoga/plugin-graphql-sse",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "GraphQL over Server-Sent Events Protocol plugin for GraphQL Yoga.",
   "repository": {
     "type": "git",

--- a/packages/plugins/graphql-sse/package.json
+++ b/packages/plugins/graphql-sse/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@graphql-yoga/plugin-graphql-sse",
+  "version": "1.0.0",
+  "description": "GraphQL over Server-Sent Events Protocol plugin for GraphQL Yoga.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/graphql-yoga.git",
+    "directory": "packages/plugins/graphql-sse"
+  },
+  "type": "module",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "scripts": {
+    "check": "tsc --pretty --noEmit"
+  },
+  "author": "Denis Badurina <badurinadenis@gmail.com>",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/typings/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "default": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "typings": "dist/typings/index.d.ts",
+  "typescript": {
+    "definition": "dist/typings/index.d.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "peerDependencies": {
+    "graphql-yoga": "^3.1.1",
+    "graphql": "^15.2.0 || ^16.0.0"
+  },
+  "dependencies": {
+    "@envelop/core": "3.0.4",
+    "graphql-sse": "^2.0.0"
+  },
+  "devDependencies": {
+    "graphql-yoga": "^3.1.1",
+    "tslib": "^2.4.1"
+  }
+}

--- a/packages/plugins/graphql-sse/package.json
+++ b/packages/plugins/graphql-sse/package.json
@@ -45,7 +45,6 @@
     "graphql": "^15.2.0 || ^16.0.0"
   },
   "dependencies": {
-    "@envelop/core": "3.0.4",
     "graphql-sse": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/plugins/graphql-sse/src/index.ts
+++ b/packages/plugins/graphql-sse/src/index.ts
@@ -1,8 +1,13 @@
 import { getOperationAST } from 'graphql'
 import { Plugin, YogaInitialContext } from 'graphql-yoga'
-import { createHandler } from 'graphql-sse/lib/use/fetch'
+import { HandlerOptions } from 'graphql-sse'
+import { createHandler, RequestContext } from 'graphql-sse/lib/use/fetch'
 
-export interface GraphQLSSEPluginOptions {
+export interface GraphQLSSEPluginOptions
+  extends Omit<
+    HandlerOptions<Request, RequestContext, any>,
+    'validate' | 'execute' | 'subscribe' | 'schema' | 'onSubscribe'
+  > {
   /**
    * Endpoint location where GraphQL over SSE will be served.
    *
@@ -19,12 +24,13 @@ export interface GraphQLSSEPluginOptions {
 export function useGraphQLSSE(
   options: GraphQLSSEPluginOptions = {},
 ): Plugin<YogaInitialContext> {
-  const { endpoint = '/graphql/stream' } = options
+  const { endpoint = '/graphql/stream', ...handlerOptions } = options
   let handler!: (request: Request) => Promise<Response>
   return {
     onYogaInit({ yoga }) {
       handler = createHandler(
         {
+          ...handlerOptions,
           async onSubscribe(req, params) {
             const enveloped = yoga.getEnveloped({
               // TODO: serverContext

--- a/packages/plugins/graphql-sse/src/index.ts
+++ b/packages/plugins/graphql-sse/src/index.ts
@@ -1,8 +1,6 @@
 import { getOperationAST } from 'graphql'
-import { Plugin, YogaInitialContext, FetchAPI } from 'graphql-yoga'
-import { createHandler } from 'graphql-sse'
-// TODO: not using fetch adapter because we need the FetchAPI too early.
-// import { createHandler } from 'graphql-sse/lib/use/fetch'
+import { Plugin, YogaInitialContext } from 'graphql-yoga'
+import { createHandler } from 'graphql-sse/lib/use/fetch'
 import { GetEnvelopedFn } from '@envelop/core'
 
 export interface GraphQLSSEPluginOptions {
@@ -22,7 +20,7 @@ export function useGraphQLSSE(
     Request,
     { serverContext: any; getEnveloped: GetEnvelopedFn<unknown> }
   >()
-  const handler = createHandler<Request, FetchAPI>({
+  const handler = createHandler({
     async onSubscribe(req, params) {
       const { serverContext, getEnveloped } = envelopedForReq.get(req.raw) || {}
       if (!getEnveloped) {
@@ -60,61 +58,11 @@ export function useGraphQLSSE(
     },
   })
   return {
-    async onRequest({
-      request,
-      getEnveloped,
-      endResponse,
-      serverContext,
-      fetchAPI,
-    }) {
+    async onRequest({ request, getEnveloped, endResponse, serverContext }) {
       const [path, _search] = request.url.split('?')
       if (path.endsWith(endpoint)) {
         envelopedForReq.set(request, { serverContext, getEnveloped })
-
-        const [resp, init] = await handler({
-          method: request.method,
-          url: request.url,
-          headers: request.headers,
-          body: () => request.text(),
-          raw: request,
-          context: fetchAPI,
-        })
-
-        if (!resp || typeof resp === 'string') {
-          return endResponse(new fetchAPI.Response(resp, init))
-        }
-
-        let cancelled = false
-        const enc = new fetchAPI.TextEncoder()
-        const stream = new fetchAPI.ReadableStream({
-          async pull(controller) {
-            const { done, value } = await resp.next()
-            if (value != null) {
-              controller.enqueue(enc.encode(value))
-            }
-            if (done) {
-              controller.close()
-            }
-          },
-          async cancel(e) {
-            cancelled = true
-            await resp.return(e)
-          },
-        })
-
-        if (request.signal.aborted) {
-          // it's possible that the request was aborted before listening
-          resp.return(undefined)
-        } else {
-          // make sure to connect the signals as well
-          request.signal.addEventListener('abort', () => {
-            if (!cancelled) {
-              resp.return()
-            }
-          })
-        }
-
-        endResponse(new fetchAPI.Response(stream, init))
+        endResponse(await handler(request))
       }
     },
   }

--- a/packages/plugins/graphql-sse/src/index.ts
+++ b/packages/plugins/graphql-sse/src/index.ts
@@ -1,0 +1,69 @@
+import { getOperationAST } from 'graphql'
+import { Plugin, YogaInitialContext } from 'graphql-yoga'
+import { createHandler } from 'graphql-sse/lib/use/fetch'
+import { GetEnvelopedFn } from '@envelop/core'
+
+export interface GraphQLSSEPluginOptions {
+  /**
+   * Endpoint location where GraphQL over SSE will be served.
+   *
+   * @default '/graphql/stream'
+   */
+  endpoint?: string
+}
+
+export function useGraphQLSSE(
+  options: GraphQLSSEPluginOptions = {},
+): Plugin<YogaInitialContext> {
+  const { endpoint = '/graphql/stream' } = options
+  const envelopedForReq = new WeakMap<
+    Request,
+    { serverContext: any; getEnveloped: GetEnvelopedFn<unknown> }
+  >()
+  const handler = createHandler({
+    async onSubscribe(req, params) {
+      const { serverContext, getEnveloped } = envelopedForReq.get(req.raw) || {}
+      if (!getEnveloped) {
+        throw new Error('Enveloped not prepared for request')
+      }
+
+      const enveloped = getEnveloped({
+        ...serverContext,
+        request: req.raw,
+        params,
+      })
+
+      const document = enveloped.parse(params.query)
+
+      enveloped.validate(enveloped.schema, document)
+
+      const contextValue = await enveloped.contextFactory()
+
+      const executionArgs = {
+        schema: enveloped.schema,
+        document,
+        contextValue,
+        variableValues: params.variables,
+        operationName: params.operationName,
+      }
+
+      const operation = getOperationAST(document, params.operationName)
+
+      const executeFn =
+        operation?.operation === 'subscription'
+          ? enveloped.subscribe
+          : enveloped.execute
+
+      return executeFn(executionArgs)
+    },
+  })
+  return {
+    async onRequest({ request, getEnveloped, endResponse, serverContext }) {
+      const [path, _search] = request.url.split('?')
+      if (path.endsWith(endpoint)) {
+        envelopedForReq.set(request, { serverContext, getEnveloped })
+        endResponse(await handler(request))
+      }
+    },
+  }
+}

--- a/packages/plugins/graphql-sse/src/index.ts
+++ b/packages/plugins/graphql-sse/src/index.ts
@@ -11,6 +11,11 @@ export interface GraphQLSSEPluginOptions {
   endpoint?: string
 }
 
+/**
+ * Get [GraphQL over Server-Sent Events Protocol](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md) integration with GraphQL Yoga by simply installing this plugin!
+ *
+ * Note that the endpoint defaults to `/graphql/stream`, this is where your [graphql-sse](https://github.com/enisdenjo/graphql-sse) client should connect.
+ */
 export function useGraphQLSSE(
   options: GraphQLSSEPluginOptions = {},
 ): Plugin<YogaInitialContext> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,21 @@ importers:
       ts-node-dev: 2.0.0_bspv7bpieoza2i5ctiw2ofswem
       typescript: 4.9.4
 
+  examples/graphql-sse:
+    specifiers:
+      '@graphql-yoga/plugin-graphql-sse': 1.0.0
+      graphql: 16.6.0
+      graphql-yoga: 3.1.2
+      ts-node: 10.9.1
+      typescript: 4.9.4
+    dependencies:
+      '@graphql-yoga/plugin-graphql-sse': link:../../packages/plugins/graphql-sse
+      graphql: 16.6.0
+      graphql-yoga: link:../../packages/graphql-yoga
+    devDependencies:
+      ts-node: 10.9.1_typescript@4.9.4
+      typescript: 4.9.4
+
   examples/graphql-ws:
     specifiers:
       graphql: 16.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,7 +440,7 @@ importers:
     dependencies:
       '@graphql-yoga/plugin-graphql-sse': link:../../packages/plugins/graphql-sse
       graphql: 16.6.0
-      graphql-yoga: link:../../packages/graphql-yoga
+      graphql-yoga: 3.1.2_graphql@16.6.0
     devDependencies:
       ts-node: 10.9.1_typescript@4.9.4
       typescript: 4.9.4
@@ -2384,6 +2384,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema/1.187.0:
     resolution: {integrity: sha512-cvkeRFyoVJ0B2HSl2Vreq9FfX521e6oa68SBvva06123E9n2DadXFI1oum8V/ywSe3rViq+VqbUTfCYHpCHxUA==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.3.8
     dev: false
     bundledDependencies:
       - jsonschema
@@ -2409,7 +2412,11 @@ packages:
       '@aws-cdk/cloud-assembly-schema': 1.187.0
       '@aws-cdk/cx-api': 1.187.0
       '@aws-cdk/region-info': 1.187.0
+      '@balena/dockerignore': 1.0.2
       constructs: 3.4.127
+      fs-extra: 9.1.0
+      ignore: 5.2.4
+      minimatch: 3.1.2
     dev: false
     bundledDependencies:
       - fs-extra
@@ -2484,6 +2491,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.187.0
+      semver: 7.3.8
     dev: false
     bundledDependencies:
       - semver
@@ -4108,6 +4116,9 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
+  /@balena/dockerignore/1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
@@ -5386,6 +5397,19 @@ packages:
       tslib: 2.4.1
       value-or-promise: 1.0.11
 
+  /@graphql-tools/executor/0.0.9_graphql@16.6.0:
+    resolution: {integrity: sha512-qLhQWXTxTS6gbL9INAQa4FJIqTd2tccnbs4HswOx35KnyLaLtREuQ8uTfU+5qMrRIBhuzpGdkP2ssqxLyOJ5rA==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.1.1_graphql@16.6.0
+      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
+      '@repeaterjs/repeater': 3.0.4
+      graphql: 16.6.0
+      tslib: 2.4.1
+      value-or-promise: 1.0.11
+    dev: false
+
   /@graphql-tools/git-loader/7.2.6_graphql@16.6.0:
     resolution: {integrity: sha512-QA94Gjp70xcdIYUbZDIm8fnuDN0IvoIIVVU+lXQemoV+vDeJKIjrP9tfOTjVDPIDXQnCYswvu9HLe8BlEApQYw==}
     peerDependencies:
@@ -5755,6 +5779,15 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@graphql-tools/utils/9.1.1_graphql@16.6.0:
+    resolution: {integrity: sha512-DXKLIEDbihK24fktR2hwp/BNIVwULIHaSTNTNhXS+19vgT50eX9wndx1bPxGwHnVBOONcwjXy0roQac49vdt/w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.6.0
+      tslib: 2.4.1
+    dev: false
+
   /@graphql-tools/utils/9.1.3:
     resolution: {integrity: sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==}
     peerDependencies:
@@ -5819,6 +5852,22 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 16.6.0
+
+  /@graphql-yoga/subscription/3.0.0:
+    resolution: {integrity: sha512-Wy1m2fcCrSj2a/KbtlQUEJ8Go7M95jeUXEH1dqbS6T6wbReqQHqq5ecSUKNhL49Xziy2Sh6od8iWm7MBUIWAlQ==}
+    dependencies:
+      '@graphql-yoga/typed-event-target': 1.0.0
+      '@repeaterjs/repeater': 3.0.4
+      '@whatwg-node/events': 0.0.2
+      tslib: 2.4.1
+    dev: false
+
+  /@graphql-yoga/typed-event-target/1.0.0:
+    resolution: {integrity: sha512-Mqni6AEvl3VbpMtKw+TIjc9qS9a8hKhiAjFtqX488yq5oJtj9TkNlFTIacAVS3vnPiswNsmDiQqvwUOcJgi1DA==}
+    dependencies:
+      '@repeaterjs/repeater': 3.0.4
+      tslib: 2.4.1
+    dev: false
 
   /@grpc/grpc-js/1.3.8:
     resolution: {integrity: sha512-4qJqqn+CU/nBydz9ePJP+oa8dz0U42Ut/GejlbyaQ1xTkynCc+ndNHHnISlNeHawDsv4MOAyP3mV/EnDNUw2zA==}
@@ -10235,6 +10284,21 @@ packages:
       - encoding
     dev: true
 
+  /@whatwg-node/fetch/0.5.3:
+    resolution: {integrity: sha512-cuAKL3Z7lrJJuUrfF1wxkQTb24Qd1QO/lsjJpM5ZSZZzUMms5TPnbGeGUKWA3hVKNHh30lVfr2MyRCT5Jfkucw==}
+    dependencies:
+      '@peculiar/webcrypto': 1.4.0
+      abort-controller: 3.0.0
+      busboy: 1.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1_bwnmzlpvx75llwj7xwqbxbjtui
+      node-fetch: 2.6.7
+      undici: 5.12.0
+      web-streams-polyfill: 3.2.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@whatwg-node/fetch/0.5.4:
     resolution: {integrity: sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==}
     dependencies:
@@ -10272,6 +10336,17 @@ packages:
       tslib: 2.4.1
     transitivePeerDependencies:
       - '@types/node'
+      - encoding
+    dev: false
+
+  /@whatwg-node/server/0.4.17:
+    resolution: {integrity: sha512-kq1AHyi87VWfiDqiSTAOY+py83HMJg42+fI8JAe1wjmMkJ8v/E5mKq5NpLNRM9Cnf7NHsQR0AwQgvX/RFuptaA==}
+    peerDependencies:
+      '@types/node': ^18.0.6
+    dependencies:
+      '@whatwg-node/fetch': 0.5.3
+      tslib: 2.4.1
+    transitivePeerDependencies:
       - encoding
     dev: false
 
@@ -11029,7 +11104,6 @@ packages:
   /at-least-node/1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -11087,6 +11161,15 @@ packages:
       '@aws-cdk/asset-awscli-v1': 2.2.45
       '@aws-cdk/asset-kubectl-v20': 2.1.1
       '@aws-cdk/asset-node-proxy-agent-v5': 2.0.38
+      '@balena/dockerignore': 1.0.2
+      case: 1.6.3
+      fs-extra: 9.1.0
+      ignore: 5.2.4
+      jsonschema: 1.4.1
+      minimatch: 3.1.2
+      punycode: 2.1.1
+      semver: 7.3.8
+      yaml: 1.10.2
     dev: true
     bundledDependencies:
       - '@balena/dockerignore'
@@ -11856,6 +11939,11 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
+    dev: true
+
+  /case/1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
     dev: true
 
   /ccount/2.0.1:
@@ -16358,7 +16446,6 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: true
 
   /fs-jetpack/5.1.0:
     resolution: {integrity: sha512-Xn4fDhLydXkuzepZVsr02jakLlmoARPy+YWIclo4kh0GyNGUHnTqeH/w/qIsVn50dFxtp8otPL2t/HcPJBbxUA==}
@@ -17025,6 +17112,28 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.6.0
+
+  /graphql-yoga/3.1.2_graphql@16.6.0:
+    resolution: {integrity: sha512-kn5VIH8f461xlMy4WZBBqS03e5Mre200juoHCMJoJhoAN/1Mu8MiLuGY2SBcEE/ROkF57QC63o2JjYTJ37L6zA==}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+    dependencies:
+      '@envelop/core': 3.0.4
+      '@envelop/parser-cache': 5.0.4_a6sekiasy2tqr6d5gj7n2wtjli
+      '@envelop/validation-cache': 5.0.5_a6sekiasy2tqr6d5gj7n2wtjli
+      '@graphql-tools/executor': 0.0.9_graphql@16.6.0
+      '@graphql-tools/schema': 9.0.12_graphql@16.6.0
+      '@graphql-tools/utils': 9.1.3_graphql@16.6.0
+      '@graphql-yoga/subscription': 3.0.0
+      '@whatwg-node/fetch': 0.5.3
+      '@whatwg-node/server': 0.4.17
+      dset: 3.1.2
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - encoding
+    dev: false
 
   /graphql/16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
@@ -19038,7 +19147,6 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
-    dev: true
 
   /jsonify/0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
@@ -19046,7 +19154,6 @@ packages:
 
   /jsonschema/1.4.1:
     resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
-    dev: false
 
   /jsonwebtoken/8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -26654,7 +26761,6 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
-    dev: true
 
   /unixify/1.0.0:
     resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,12 +970,10 @@ importers:
 
   packages/plugins/graphql-sse:
     specifiers:
-      '@envelop/core': 3.0.4
       graphql-sse: ^2.0.0
       graphql-yoga: ^3.1.1
       tslib: ^2.4.1
     dependencies:
-      '@envelop/core': 3.0.4
       graphql-sse: 2.0.0
     devDependencies:
       graphql-yoga: link:../../graphql-yoga

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,7 +432,7 @@ importers:
 
   examples/graphql-sse:
     specifiers:
-      '@graphql-yoga/plugin-graphql-sse': 1.0.0
+      '@graphql-yoga/plugin-graphql-sse': 0.0.0
       graphql: 16.6.0
       graphql-yoga: 3.1.2
       ts-node: 10.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,18 @@ overrides:
   '@changesets/assemble-release-plan': 5.2.1
 
 patchedDependencies:
-  '@changesets/assemble-release-plan@5.2.1':
-    hash: gxgixp7rzwjkputc2n2g47utqy
-    path: patches/@changesets__assemble-release-plan@5.2.1.patch
-  '@graphiql/react@0.13.3':
-    hash: yqm362ey3efuxzwgojxfo6tq5i
-    path: patches/@graphiql__react@0.13.3.patch
   formdata-node@4.4.1:
     hash: bwnmzlpvx75llwj7xwqbxbjtui
     path: patches/formdata-node@4.4.1.patch
+  '@changesets/assemble-release-plan@5.2.1':
+    hash: gxgixp7rzwjkputc2n2g47utqy
+    path: patches/@changesets__assemble-release-plan@5.2.1.patch
   nextra-theme-docs@2.0.0-beta.43:
     hash: sy7yomed2xkhjwtql55f5gmmlm
     path: patches/nextra-theme-docs@2.0.0-beta.43.patch
+  '@graphiql/react@0.13.3':
+    hash: yqm362ey3efuxzwgojxfo6tq5i
+    path: patches/@graphiql__react@0.13.3.patch
 
 importers:
 
@@ -966,6 +966,20 @@ importers:
       graphql-yoga: workspace:*
     devDependencies:
       graphql-yoga: link:../../graphql-yoga
+    publishDirectory: dist
+
+  packages/plugins/graphql-sse:
+    specifiers:
+      '@envelop/core': 3.0.4
+      graphql-sse: ^2.0.0
+      graphql-yoga: ^3.1.1
+      tslib: ^2.4.1
+    dependencies:
+      '@envelop/core': 3.0.4
+      graphql-sse: 2.0.0
+    devDependencies:
+      graphql-yoga: link:../../graphql-yoga
+      tslib: 2.4.1
     publishDirectory: dist
 
   packages/plugins/persisted-operations:
@@ -16509,6 +16523,13 @@ packages:
       graphql: 16.6.0
       tslib: 2.4.1
     dev: true
+
+  /graphql-sse/2.0.0:
+    resolution: {integrity: sha512-TTdFwxGM9RY68s22XWyhc+SyQn3PLbELDD2So0K6Cc6EIlBAyPuNV8VlPfNKa/la7gEf2SwHY7JoJplOmOY4LA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dev: false
 
   /graphql-tag/2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}

--- a/website/src/pages/docs/comparison.mdx
+++ b/website/src/pages/docs/comparison.mdx
@@ -65,16 +65,13 @@ GraphQL Yoga is fully compatible with the GraphQL over HTTP specification (inclu
 
 GraphQL Yoga supports [file uploads out of the box](/v3/features/file-uploads#enable-file-uploads-in-graphql-yoga) and fully supports the [GraphQL-Multipart-Request](https://github.com/jaydenseric/graphql-multipart-request-spec).
 
-### Real time and GraphQL Subscriptions over Server-Sent-Events (SSE)
+### Real time and GraphQL Subscriptions
 
-Apollo Server does not provide built-in solution for GraphQL Subscriptions.
-You can wire up `graphql-ws` or `graphql-sse` for adding either GraphQL over WebSocket or GraphQL over Server Sent Events support.
+GraphQL Yoga, compared to Apollo Server, has built-in support for [simple subscriptions over Server-Sent Events (SSE)](/v3/features/subscriptions#subscriptions) without the need of any additional libraries.
 
-GraphQL Yoga has built-in support for [GraphQL Subscriptions over Server-Sent-Events (SSE)](/v3/features/subscriptions#subscriptions) without the need of any additional libraries.
+Of course, in addition to that, GraphQL Yoga has integrations supporting the [GraphQL over WebSocket Protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) (via `graphql-ws`) and the [GraphQL over Server-Sent Events Protocol](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md) (via `graphql-sse`).
 
-In addition GraphQL Yoga also support GraphQL Subscriptions over WS (via `graphql-ws`).
-
-In addition to GraphQL Subscriptions, Yoga users can also use GraphQL Live Queries.
+Besides GraphQL Subscriptions, Yoga users can also use GraphQL Live Queries.
 
 ### Bundle Size and Dependencies
 

--- a/website/src/pages/docs/features/subscriptions.mdx
+++ b/website/src/pages/docs/features/subscriptions.mdx
@@ -16,7 +16,7 @@ You don't need any extra packages to use subscriptions.
   event streams must be distributed across all servers.
 </Callout>
 
-## Quick Start with Server Sent Events (SSE)
+## Quick Start with simple Server-Sent Events (SSE)
 
 Subscriptions can be added by extending your GraphQL schema with a `Subscription` type.
 
@@ -365,7 +365,47 @@ const executeSubscription = (
 const network = Network.create(executeQueryOrMutation, executeSubscription)
 ```
 
-## Subscriptions over WebSockets with `graphql-ws`
+## GraphQL over Server-Sent Events Protocol (via `graphql-sse`)
+
+In case you want the subscriptions to be transported following the [GraphQL over Server-Sent Events Protocol](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md), you simply use the `@graphql-yoga/plugin-graphql-sse` plugin for GraphQL Yoga that exposes an additional endpoint (defaulting to `/graphql/stream`) used for [graphql-sse](https://github.com/enisdenjo/graphql-sse) clients.
+
+The plugin will hijack the request from the `onRequest` hook and will use **all** envelop plugins provided.
+
+Also, consider setting the `subscriptionsProtocol` in GraphiQL options to `GRAPHQL_SSE` in order to have it use [graphql-sse](https://github.com/enisdenjo/graphql-sse).
+
+```ts filename="yoga-with-graphql-sse.ts"
+import { createServer } from 'node:http'
+import { createYoga } from 'graphql-yoga'
+import { useGraphQLSSE } from '@graphql-yoga/plugin-graphql-sse'
+
+const yogaApp = createYoga({
+  graphiql: {
+    // Use graphql-sse in GraphiQL.
+    subscriptionsProtocol: 'GRAPHQL_SSE'
+  },
+  plugins: [
+    // Simply install the graphql-sse plugin and you're off!
+    useGraphQLSSE()
+  ]
+})
+
+// Get NodeJS Server from Yoga
+const httpServer = createServer(yogaApp)
+
+httpServer.listen(4000, () => {
+  console.log('Server is running on port 4000')
+})
+```
+
+<Callout>
+  Check out [our working example](/examples/graphql-sse) for this integration.
+</Callout>
+
+### Client Integration
+
+Please refer to the [`graphql-sse` client recipes](https://github.com/enisdenjo/graphql-sse#recipes).
+
+## GraphQL over WebSocket Protocol (via `graphql-ws`)
 
 Suppose you want to use the [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) protocol with GraphQL Yoga, you can use the [`graphql-ws`](https://github.com/enisdenjo/graphql-ws) library.
 To have the same execution pipeline in `graphql-ws`, we can use the **Envelop** instance from GraphQL Yoga like below in Node.JS.
@@ -439,7 +479,7 @@ httpServer.listen(4000, () => {
 
 Please refer to the [`graphql-ws` client recipes](https://github.com/enisdenjo/graphql-ws#recipes).
 
-### SSE vs WebSocket
+## SSE vs WebSocket
 
 #### Advantages of SSE over WebSockets
 
@@ -454,7 +494,7 @@ Please refer to the [`graphql-ws` client recipes](https://github.com/enisdenjo/g
 
 #### SSE Gotchas
 
-- [Maximum open connections limit](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x) ([when not using http/2](https://developer.mozilla.org/en-US/docs/Glossary/HTTP_2))
+- [Maximum open connections limit](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x) ([when not using http/2](https://developer.mozilla.org/en-US/docs/Glossary/HTTP_2)). In this case, consider using the [`graphql-sse` integration](#graphql-over-server-sent-events-protocol-via-graphql-sse) with ["single connection mode"](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#single-connection-mode).
 
 ## PubSub
 


### PR DESCRIPTION
Closes #2138 
Closes #2279

New Yoga plugin named `@graphql-yoga/plugin-graphql-sse` allowing for full [GraphQL over Server-Sent Events](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md) support through [graphql-sse](https://github.com/enisdenjo/graphql-sse).

### TODO

- [x] CORS
- [x] Some graphql-sse handler options
- [x] Tests
- [x] Documentation