### PR TITLE
Fix install instructions for persisted operations

### DIFF
--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -13,7 +13,7 @@ change this behavior by overriding the `getPersistedOperationKey` option to supp
 
 Persisted operations requires installing a separate package.
 
-<PackageCmd packages={['@graphql-yoga/persisted-operations']} />
+<PackageCmd packages={['@graphql-yoga/plugin-persisted-operations']} />
 
 ```ts filename="Persisted operation setup"
 import { createYoga, createSchema } from 'graphql-yoga'


### PR DESCRIPTION
The examples later in this doc reference `@graphql-yoga/plugin-persisted-operations` and were throwing errors when using `@graphql-yoga/persisted-operations`, which appears to install an older version of the plugin.