### PR TITLE
fix(graphiql): use `location.href` instead of `graphqlEndpoint` from Yoga

### DIFF
--- a/.changeset/thirty-peaches-dress.md
+++ b/.changeset/thirty-peaches-dress.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Do not pass an explicit endpoint for GraphiQL

--- a/packages/graphql-yoga/src/plugins/useGraphiQL.ts
+++ b/packages/graphql-yoga/src/plugins/useGraphiQL.ts
@@ -56,7 +56,7 @@ export type GraphiQLRendererOptions = {
   /**
    * The endpoint requests should be sent. Defaults to `"/graphql"`.
    */
-  endpoint: string
+  endpoint?: string
 } & GraphiQLOptions
 
 export const renderGraphiQL = (opts: GraphiQLRendererOptions) =>
@@ -119,7 +119,6 @@ export function useGraphiQL<TServerContext extends Record<string, any>>(
 
         if (graphiqlOptions) {
           const graphiQLBody = await renderer({
-            endpoint: config.graphqlEndpoint,
             ...(graphiqlOptions === true ? {} : graphiqlOptions),
           })
 


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-yoga/issues/2132#issuecomment-1368916343