### PR TITLE
Update integration-with-nextjs.mdx

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-nextjs.mdx
+++ b/website/src/pages/docs/integrations/integration-with-nextjs.mdx
@@ -12,7 +12,7 @@ import { PackageCmd } from '@theguild/components'
 
 ```ts filename="pages/api/graphql.ts"
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import { createYoga } from 'graphql-yoga'
+import { createYoga, createSchema } from 'graphql-yoga'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export const config = {


### PR DESCRIPTION
The example next.js api routes in the graphql-yoga official document seems to be missing `import { createSchema } from 'graphql-yoga';`.