### PR TITLE
docs: fix the link to see dependencies of Apollo Server

### DIFF
--- a/website/src/pages/docs/comparison.mdx
+++ b/website/src/pages/docs/comparison.mdx
@@ -87,7 +87,7 @@ Here you can see a comparison of bundle sizes on Bundlephobia>
 GraphQL Yoga only has a fraction of the dependencies of Apollo Server, and in general is much smaller.
 
 - [Dependency visualizer `graphql-yoga`](https://npm.anvaka.com/#/view/2d/graphql-yoga)
-- [Dependency visualizer `@apollo/server`](https://npm.anvaka.com/#/view/2d/@apollo/server)
+- [Dependency visualizer `@apollo/server`](https://npm.anvaka.com/#/view/2d/%2540apollo%252Fserver)
 
 GraphQL Yogas APIs are designed for code-splitting and thus have no side effects, where Apollo server specifies that is has side effects and thus, cannot be code splitted.
 


### PR DESCRIPTION
The NPM package name `@apollo/server` has funky characters, so the generated HTTP link doesn't work correctly if the web address is not URL encoded