### PR TITLE
Fix typo in comparison.mdx

### DIFF
--- a/website/src/pages/docs/comparison.mdx
+++ b/website/src/pages/docs/comparison.mdx
@@ -31,7 +31,7 @@ As mentioned in the above paragraph `graphql-yoga` is built around W3C Request/R
 
 Apollo Server plans to drop active support for cloudflare workers and [pushes it onto the community](https://github.com/apollographql/apollo-server/issues/6034).
 
-GraphQL Yoga will continuously support all platforms and runtimes **wihtout any changes in your code** and
+GraphQL Yoga will continuously support all platforms and runtimes **without any changes in your code** and
 Furthermore, Yoga has a full end to end testing suite that actually deploys to all those runtimes in order to ensure integrity and prevent unexpected issues.
 
 Current list of supported and tested platform:


### PR DESCRIPTION
There was a misspelling of `without` on the `comparison.mdx` page. This PR fixes the spelling of that word.