### PR TITLE
docs: add section for codegen client preset

### DIFF
--- a/website/src/pages/docs/features/testing.mdx
+++ b/website/src/pages/docs/features/testing.mdx
@@ -309,3 +309,9 @@ for await (const executionResult of eventStream(response.body!)) {
   }
 }
 ```
+
+## TypeScript safe Test Suits with GraphQL Code Generator
+
+The GraphQL Code Generator allows you to generate TypeScript types for your GraphQL operations (queries, mutations and subscriptions), leading to a better developer experience when writing tests.
+
+[Learn more on the GraphQL Code Generator API Testing Guide](https://the-guild.dev/graphql/codegen/docs/guides/api-testing)


### PR DESCRIPTION
Note that we now also have the section for `@graphql-tools/http-executor`.

It would be great if  `@graphql-tools/http-executor` could infer types from `TypedDocumentNode`.