### PR TITLE
Add callout from Quick Start to GraphQL Codegen and server preset

### DIFF
--- a/website/src/components/codegen-callout.mdx
+++ b/website/src/components/codegen-callout.mdx
@@ -1,0 +1,10 @@
+import { Callout } from '@theguild/components'
+
+<Callout type="info">
+**Get the best developer experience!**
+
+GraphQL Code Generator and its server preset can help you build type-safe and scalable GraphQL servers.
+
+Check out [GraphQL Code Generator](https://the-guild.dev/graphql/codegen/docs/getting-started/), then read [how to set up GraphQL server with server preset](https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset).
+
+</Callout>

--- a/website/src/pages/docs/index.mdx
+++ b/website/src/pages/docs/index.mdx
@@ -148,6 +148,15 @@ export const schema = new GraphQLSchema({
   </Tab>
 </Tabs>
 
+<Callout type="info">
+**Get the best developer experience!**
+
+GraphQL Code Generator and its server preset can help you build type-safe and scalable GraphQL servers.
+
+Check out [GraphQL Code Generator](https://the-guild.dev/graphql/codegen/docs/getting-started/), then read [how to set up GraphQL server with server preset](https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset).
+
+</Callout>
+
 ## Server
 
 After you have created a GraphQL schema, simply pass it in to Yoga and liftoff! 🚀

--- a/website/src/pages/docs/index.mdx
+++ b/website/src/pages/docs/index.mdx
@@ -1,4 +1,5 @@
 import { PackageCmd, Tabs, Tab, Callout } from '@theguild/components'
+import CodegenCallout from '../../components/codegen-callout.mdx'
 
 # Quick start
 
@@ -33,6 +34,8 @@ export const schema = createSchema({
 })
 ```
 
+<CodegenCallout />
+
   </Tab>
 
   <Tab>
@@ -56,6 +59,8 @@ export const schema = makeExecutableSchema({
   }
 })
 ```
+
+<CodegenCallout />
 
   </Tab>
 
@@ -147,15 +152,6 @@ export const schema = new GraphQLSchema({
 
   </Tab>
 </Tabs>
-
-<Callout type="info">
-**Get the best developer experience!**
-
-GraphQL Code Generator and its server preset can help you build type-safe and scalable GraphQL servers.
-
-Check out [GraphQL Code Generator](https://the-guild.dev/graphql/codegen/docs/getting-started/), then read [how to set up GraphQL server with server preset](https://the-guild.dev/graphql/codegen/docs/guides/graphql-server-apollo-yoga-with-server-preset).
-
-</Callout>
 
 ## Server
 


### PR DESCRIPTION
This PR adds a callout at the bottom of Quick Start guide's Schema section to promote GraphQL Codegen and server preset:

![Screen Shot 2023-02-03 at 10 43 17 pm](https://user-images.githubusercontent.com/33769523/216595948-c1e66692-d43b-4538-926f-98588c204e76.png)

