### PR TITLE
Use non-www to the codegen website

### DIFF
--- a/website/src/pages/docs/features/introspection.mdx
+++ b/website/src/pages/docs/features/introspection.mdx
@@ -3,7 +3,7 @@ import { PackageCmd, Callout } from '@theguild/components'
 # Introspection
 
 A powerful feature of GraphQL is schema introspection.
-This feature is used by GraphiQL for exploring the schema and also by tooling such as [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) for generating type-safe client/frontend code.
+This feature is used by GraphiQL for exploring the schema and also by tooling such as [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) for generating type-safe client/frontend code.
 
 GraphQL schema introspection is also a feature that allows clients to ask a GraphQL server what GraphQL features it supports (e.g. defer/stream or subscriptions).
 


### PR DESCRIPTION
The GraphQL Code Generator hyperlink seems to be broken. The actual link that is working is: https://the-guild.dev/graphql/codegen