### PR TITLE
Replace LRU caching with lazy URL construction, avoid unnecessary `parse` and `validate` invocation and CORS

### DIFF
--- a/.changeset/@graphql-yoga_graphiql-2425-dependencies.md
+++ b/.changeset/@graphql-yoga_graphiql-2425-dependencies.md
@@ -1,5 +1,0 @@
----
-'@graphql-yoga/graphiql': patch
----
-dependencies updates:
-  - Updated dependency [`@graphql-tools/url-loader@7.17.12` ↗︎](https://www.npmjs.com/package/@graphql-tools/url-loader/v/7.17.12) (from `7.17.11`, in `dependencies`)

--- a/.changeset/@graphql-yoga_graphiql-2425-dependencies.md
+++ b/.changeset/@graphql-yoga_graphiql-2425-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/graphiql': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/url-loader@7.17.12` ↗︎](https://www.npmjs.com/package/@graphql-tools/url-loader/v/7.17.12) (from `7.17.11`, in `dependencies`)

--- a/benchmark/hello-world/k6.js
+++ b/benchmark/hello-world/k6.js
@@ -54,11 +54,9 @@ export function handleSummary(data) {
 }
 
 export default function () {
-  const res = http.get(
-    `http://localhost:4000/graphql?query=${encodeURIComponent(
-      '{ greetings }',
-    )}`,
-  )
+  const res = http.post(`http://localhost:4000/graphql`, {
+    query: '{ greetings }',
+  })
 
   check(res, {
     no_errors: (resp) => !('errors' in resp.json()),

--- a/packages/graphql-yoga/src/plugins/requestParser/GET.ts
+++ b/packages/graphql-yoga/src/plugins/requestParser/GET.ts
@@ -1,10 +1,13 @@
 import { GraphQLParams } from '../../types.js'
 import { handleURLSearchParams } from './utils.js'
+import { URLSearchParams } from '@whatwg-node/fetch'
 
 export function isGETRequest(request: Request) {
   return request.method === 'GET'
 }
 
-export function parseGETRequest(_request: Request, url: URL): GraphQLParams {
-  return handleURLSearchParams(url.searchParams)
+export function parseGETRequest(request: Request): GraphQLParams {
+  const [, queryString = ''] = request.url.split('?')
+  const searchParams = new URLSearchParams(queryString)
+  return handleURLSearchParams(searchParams)
 }

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -94,7 +94,6 @@ export type OnRequestParseHook<TServerContext> = (
 
 export type RequestParser = (
   request: Request,
-  url: URL,
 ) => PromiseOrValue<GraphQLParams> | PromiseOrValue<GraphQLParams[]>
 
 export interface OnRequestParseEventPayload<TServerContext> {

--- a/packages/graphql-yoga/src/plugins/useCORS.ts
+++ b/packages/graphql-yoga/src/plugins/useCORS.ts
@@ -52,11 +52,14 @@ export function getCORSHeadersByRequestAndOptions(
     // If there is only one origin defined in the array, consider it as a single one
     if (corsOptions.origin.length === 1) {
       headers['Access-Control-Allow-Origin'] = corsOptions.origin[0]
-    } else {
+    } else if (corsOptions.origin.includes(currentOrigin)) {
       // If origin is available in the headers, use it
       headers['Access-Control-Allow-Origin'] = currentOrigin
       // Vary by origin because there are multiple origins
       headers['Vary'] = 'Origin'
+    } else {
+      // There is no origin found in the headers, so we should return null
+      headers['Access-Control-Allow-Origin'] = 'null'
     }
   }
 

--- a/packages/graphql-yoga/src/plugins/useCORS.ts
+++ b/packages/graphql-yoga/src/plugins/useCORS.ts
@@ -29,12 +29,12 @@ export type CORSOptionsFactory<TServerContext> = (
 export function getCORSHeadersByRequestAndOptions(
   request: Request,
   corsOptions: CORSOptions,
-): Record<string, string> {
-  const headers: Record<string, string> = {}
-
-  if (corsOptions === false) {
-    return headers
+): Record<string, string> | null {
+  const currentOrigin = request.headers.get('origin')
+  if (corsOptions === false || currentOrigin == null) {
+    return null
   }
+  const headers: Record<string, string> = {}
 
   // If defined origins have '*' or undefined by any means, we should allow all origins
   if (
@@ -42,15 +42,9 @@ export function getCORSHeadersByRequestAndOptions(
     corsOptions.origin.length === 0 ||
     corsOptions.origin.includes('*')
   ) {
-    const currentOrigin = request.headers.get('origin')
-    // If origin is available in the headers, use it
-    if (currentOrigin != null) {
-      headers['Access-Control-Allow-Origin'] = currentOrigin
-      // Vary by origin because there are multiple origins
-      headers['Vary'] = 'Origin'
-    } else {
-      headers['Access-Control-Allow-Origin'] = '*'
-    }
+    headers['Access-Control-Allow-Origin'] = currentOrigin
+    // Vary by origin because there are multiple origins
+    headers['Vary'] = 'Origin'
   } else if (typeof corsOptions.origin === 'string') {
     // If there is one specific origin is specified, use it directly
     headers['Access-Control-Allow-Origin'] = corsOptions.origin
@@ -59,16 +53,10 @@ export function getCORSHeadersByRequestAndOptions(
     if (corsOptions.origin.length === 1) {
       headers['Access-Control-Allow-Origin'] = corsOptions.origin[0]
     } else {
-      const currentOrigin = request.headers.get('origin')
-      if (currentOrigin != null && corsOptions.origin.includes(currentOrigin)) {
-        // If origin is available in the headers, use it
-        headers['Access-Control-Allow-Origin'] = currentOrigin
-        // Vary by origin because there are multiple origins
-        headers['Vary'] = 'Origin'
-      } else {
-        // There is no origin found in the headers, so we should return null
-        headers['Access-Control-Allow-Origin'] = 'null'
-      }
+      // If origin is available in the headers, use it
+      headers['Access-Control-Allow-Origin'] = currentOrigin
+      // Vary by origin because there are multiple origins
+      headers['Vary'] = 'Origin'
     }
   }
 
@@ -165,8 +153,10 @@ export function useCORS<TServerContext extends Record<string, any>>(
         corsOptionsFactory,
         serverContext,
       )
-      for (const headerName in headers) {
-        response.headers.set(headerName, headers[headerName])
+      if (headers != null) {
+        for (const headerName in headers) {
+          response.headers.set(headerName, headers[headerName])
+        }
       }
     },
   }

--- a/packages/graphql-yoga/src/plugins/useCors.spec.ts
+++ b/packages/graphql-yoga/src/plugins/useCors.spec.ts
@@ -7,7 +7,6 @@ import { CORSOptions, getCORSHeadersByRequestAndOptions } from './useCORS.js'
 describe('CORS', () => {
   describe('OPTIONS call', () => {
     it('should respond with correct status & headers', async () => {
-      // eslint-disable-next-line @typescript-eslint/require-await
       const schemaFactory = async () => {
         return createSchema({
           typeDefs: /* GraphQL */ `
@@ -48,7 +47,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithNoOrigins,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBe('*')
+      expect(headers?.['Access-Control-Allow-Origin']).toBe('*')
     })
     it('should return the origin if it is sent with header', () => {
       const origin = 'http://localhost:4000'
@@ -63,7 +62,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithNoOrigins,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBe(origin)
+      expect(headers?.['Access-Control-Allow-Origin']).toBe(origin)
     })
   })
   describe('Single allowed origin', () => {
@@ -82,7 +81,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithSingleOrigin,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBe(
+      expect(headers?.['Access-Control-Allow-Origin']).toBe(
         'http://localhost:4000',
       )
     })
@@ -103,7 +102,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithMultipleOrigins,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBe(
+      expect(headers?.['Access-Control-Allow-Origin']).toBe(
         'http://localhost:4001',
       )
     })
@@ -119,7 +118,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithMultipleOrigins,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBe('null')
+      expect(headers?.['Access-Control-Allow-Origin']).toBe('null')
     })
   })
   describe('Disabled CORS', () => {
@@ -136,7 +135,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithDisabledCORS,
       )
-      expect(headers['Access-Control-Allow-Origin']).toBeUndefined()
+      expect(headers?.['Access-Control-Allow-Origin']).toBeUndefined()
     })
   })
 })

--- a/packages/graphql-yoga/src/plugins/useCors.spec.ts
+++ b/packages/graphql-yoga/src/plugins/useCors.spec.ts
@@ -36,7 +36,7 @@ describe('CORS', () => {
   })
   describe('No origins specified', () => {
     const corsOptionsWithNoOrigins = {}
-    it('should return the wildcard if no origin is sent with header', () => {
+    it('should not return any CORS header if no origin is sent with header', () => {
       const request = new Request('http://localhost:4000/graphql', {
         method: 'POST',
         headers: {
@@ -47,7 +47,7 @@ describe('CORS', () => {
         request,
         corsOptionsWithNoOrigins,
       )
-      expect(headers?.['Access-Control-Allow-Origin']).toBe('*')
+      expect(headers?.['Access-Control-Allow-Origin']).toBeUndefined()
     })
     it('should return the origin if it is sent with header', () => {
       const origin = 'http://localhost:4000'

--- a/packages/graphql-yoga/src/plugins/useHealthCheck.ts
+++ b/packages/graphql-yoga/src/plugins/useHealthCheck.ts
@@ -13,8 +13,8 @@ export function useHealthCheck({
   endpoint = '/health',
 }: HealthCheckPluginOptions = {}): Plugin {
   return {
-    onRequest({ endResponse, fetchAPI, request, url }) {
-      if (request.url.endsWith(endpoint) || url.pathname === endpoint) {
+    onRequest({ endResponse, fetchAPI, request }) {
+      if (request.url.endsWith(endpoint)) {
         logger.debug('Responding Health Check')
         const response = new fetchAPI.Response(null, {
           status: 200,

--- a/packages/graphql-yoga/src/plugins/useHealthCheck.ts
+++ b/packages/graphql-yoga/src/plugins/useHealthCheck.ts
@@ -10,23 +10,11 @@ export interface HealthCheckPluginOptions {
 export function useHealthCheck({
   id = Date.now().toString(),
   logger = console,
-  endpoint: optsEndpoint,
+  endpoint = '/health',
 }: HealthCheckPluginOptions = {}): Plugin {
-  // No need to create a URLPattern if we have a static endpoint
-  // Later we can remove URLPattern here completely and stop accepting a pattern
-  let urlPattern: URLPattern | undefined
-  let endpoint: string
   return {
-    onYogaInit({ yoga }) {
-      if (optsEndpoint) {
-        endpoint = optsEndpoint
-        urlPattern = new yoga.fetchAPI.URLPattern({ pathname: optsEndpoint })
-      } else {
-        endpoint = '/health'
-      }
-    },
-    onRequest({ endResponse, fetchAPI, url }) {
-      if (url.pathname === endpoint || urlPattern?.test(url)) {
+    onRequest({ endResponse, fetchAPI, request, url }) {
+      if (request.url.endsWith(endpoint) || url.pathname === endpoint) {
         logger.debug('Responding Health Check')
         const response = new fetchAPI.Response(null, {
           status: 200,

--- a/packages/graphql-yoga/src/plugins/useParserAndValidationCache.ts
+++ b/packages/graphql-yoga/src/plugins/useParserAndValidationCache.ts
@@ -1,5 +1,11 @@
-import { memoize2of4 } from '@graphql-tools/utils'
-import type { DocumentNode, parse, validate } from 'graphql'
+import type { AfterValidateHook } from '@envelop/core'
+import type {
+  DocumentNode,
+  GraphQLError,
+  GraphQLSchema,
+  validate,
+  ValidationRule,
+} from 'graphql'
 import { createLRUCache } from '../utils/create-lru-cache.js'
 import type { Plugin } from './types.js'
 
@@ -20,54 +26,63 @@ export function useParserAndValidationCache({
   validationCache = true,
 }: // eslint-disable-next-line @typescript-eslint/ban-types
 ParserAndValidationCacheOptions): Plugin<{}> {
-  const memoizedValidateByRules =
-    typeof validationCache === 'boolean'
-      ? createLRUCache<typeof validate>()
-      : validationCache
+  const validationCacheByRules =
+    createLRUCache<
+      WeakMap<GraphQLSchema, WeakMap<DocumentNode, GraphQLError[]>>
+    >()
   return {
-    onParse({
-      parseFn,
-      setParseFn,
-    }: {
-      parseFn: typeof parse
-      setParseFn: (fn: typeof parse) => void
-    }) {
-      setParseFn(function memoizedParse(source) {
-        const strDocument = typeof source === 'string' ? source : source.body
-        let document = documentCache.get(strDocument)
-        if (!document) {
-          const parserError = errorCache.get(strDocument)
-          if (parserError) {
-            throw parserError
+    onParse({ params, setParsedDocument }) {
+      const strDocument = params.source.toString()
+      const document = documentCache.get(strDocument)
+      if (document) {
+        setParsedDocument(document)
+        return
+      }
+      const parserError = errorCache.get(strDocument)
+      if (parserError) {
+        throw parserError
+      }
+      return ({ result }) => {
+        if (result != null) {
+          if (result instanceof Error) {
+            errorCache.set(strDocument, result)
+          } else {
+            documentCache.set(strDocument, result)
           }
-          try {
-            document = parseFn(source)
-          } catch (e) {
-            errorCache.set(strDocument, e)
-            throw e
-          }
-          documentCache.set(strDocument, document)
         }
-        return document
-      })
+      }
     },
     onValidate({
-      validateFn,
-      setValidationFn,
-    }: {
-      validateFn: typeof validate
-      setValidationFn: (fn: typeof validate) => void
-    }) {
+      params: { schema, documentAST, rules },
+      setResult,
+      // eslint-disable-next-line @typescript-eslint/ban-types
+    }): void | AfterValidateHook<{}> {
       if (validationCache !== false) {
-        setValidationFn(function memoizedValidateFn(schema, document, rules) {
-          const rulesKey = rules?.map((rule) => rule.name).join(',') || ''
-          let memoizedValidateFnForRules = memoizedValidateByRules.get(rulesKey)
-          if (!memoizedValidateFnForRules) {
-            memoizedValidateFnForRules = memoize2of4(validateFn)
-            memoizedValidateByRules.set(rulesKey, memoizedValidateFnForRules)
+        const rulesKey =
+          rules?.map((rule: ValidationRule) => rule.name).join(',') || ''
+        let validationCacheBySchema = validationCacheByRules.get(rulesKey)
+        if (!validationCacheBySchema) {
+          validationCacheBySchema = new WeakMap()
+          validationCacheByRules.set(rulesKey, validationCacheBySchema)
+        }
+        let validationCacheByDocument = validationCacheBySchema.get(schema)
+        if (!validationCacheByDocument) {
+          validationCacheByDocument = new WeakMap()
+          validationCacheBySchema.set(schema, validationCacheByDocument)
+        }
+        const cachedResult = validationCacheByDocument.get(documentAST)
+        if (cachedResult) {
+          setResult(cachedResult)
+          return
+        }
+        return ({ result }) => {
+          if (result != null) {
+            validationCacheByDocument?.set(
+              documentAST,
+              result as GraphQLError[],
+            )
           }
-          return memoizedValidateFnForRules(schema, document, rules)
-        })
+        }
       }
     },
   }

--- a/packages/graphql-yoga/src/plugins/useReadinessCheck.ts
+++ b/packages/graphql-yoga/src/plugins/useReadinessCheck.ts
@@ -40,7 +40,11 @@ export function useReadinessCheck({
       urlPattern = new yoga.fetchAPI.URLPattern({ pathname: endpoint })
     },
     async onRequest({ request, endResponse, fetchAPI, url }) {
-      if (url.pathname === endpoint || urlPattern.test(url)) {
+      if (
+        request.url.endsWith(endpoint) ||
+        url.pathname === endpoint ||
+        urlPattern.test(url)
+      ) {
         let response: Response
         try {
           const readyOrResponse = await check({ request, fetchAPI })

--- a/packages/graphql-yoga/src/plugins/useRequestParser.ts
+++ b/packages/graphql-yoga/src/plugins/useRequestParser.ts
@@ -4,10 +4,9 @@ import { GraphQLParams } from '../types.js'
 import { Plugin } from './types.js'
 
 interface RequestParserPluginOptions {
-  match?(request: Request, url: URL): boolean
+  match?(request: Request): boolean
   parse(
     request: Request,
-    url: URL,
   ): PromiseOrValue<GraphQLParams> | PromiseOrValue<GraphQLParams[]>
 }
 
@@ -16,8 +15,8 @@ const DEFAULT_MATCHER = () => true
 export function useRequestParser(options: RequestParserPluginOptions): Plugin {
   const matchFn = options.match || DEFAULT_MATCHER
   return {
-    onRequestParse({ request, setRequestParser, url }) {
-      if (matchFn(request, url)) {
+    onRequestParse({ request, setRequestParser }) {
+      if (matchFn(request)) {
         setRequestParser(options.parse)
       }
     },

--- a/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
+++ b/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
@@ -1,4 +1,5 @@
 import landingPageBody from '../landing-page-html.js'
+import { FetchAPI } from '../types.js'
 import type { Plugin } from './types.js'
 
 export function useUnhandledRoute(args: {
@@ -6,14 +7,18 @@ export function useUnhandledRoute(args: {
   showLandingPage: boolean
 }): Plugin {
   let urlPattern: URLPattern
+  function getUrlPattern({ URLPattern }: FetchAPI) {
+    urlPattern ||= new URLPattern({
+      pathname: args.graphqlEndpoint,
+    })
+    return urlPattern
+  }
   return {
-    onYogaInit({ yoga }) {
-      urlPattern = new yoga.fetchAPI.URLPattern({
-        pathname: args.graphqlEndpoint,
-      })
-    },
     onRequest({ request, fetchAPI, endResponse, url }) {
-      if (url.pathname !== args.graphqlEndpoint && !urlPattern.test(url)) {
+      if (
+        url.pathname !== args.graphqlEndpoint &&
+        !getUrlPattern(fetchAPI).test(url)
+      ) {
         if (
           args.showLandingPage === true &&
           request.method === 'GET' &&

--- a/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
+++ b/packages/graphql-yoga/src/plugins/useUnhandledRoute.ts
@@ -16,6 +16,7 @@ export function useUnhandledRoute(args: {
   return {
     onRequest({ request, fetchAPI, endResponse, url }) {
       if (
+        !request.url.endsWith(args.graphqlEndpoint) &&
         url.pathname !== args.graphqlEndpoint &&
         !getUrlPattern(fetchAPI).test(url)
       ) {

--- a/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
+++ b/packages/plugins/graphql-sse/__tests__/graphql-sse.spec.ts
@@ -233,6 +233,9 @@ describe('graphql-sse', () => {
 
     const res = await yoga.fetch('http://yoga/graphql/stream', {
       method: 'OPTIONS',
+      headers: {
+        origin: 'http://yoga',
+      },
     })
 
     const headersObj = {}

--- a/packages/plugins/prometheus/tests/prometheus.spec.ts
+++ b/packages/plugins/prometheus/tests/prometheus.spec.ts
@@ -127,7 +127,7 @@ describe('Prometheus', () => {
     expect(metrics).toContain('statusCode="200"')
     expect(metrics).toContain('statusText="OK"')
     expect(metrics).toContain(
-      `responseHeaders="{\\"content-type\\":\\"application/json; charset=utf-8\\",\\"content-length\\\":\\"33\\",\\"access-control-allow-origin\\":\\"*\\"}"}`,
+      `responseHeaders="{\\"content-type\\":\\"application/json; charset=utf-8\\",\\"content-length\\\":\\"33\\"}"}`,
     )
   })
   it('endpoint should work', async () => {


### PR DESCRIPTION
Also benchmarks will use `POST` just like graphql-crystal's benchmarks. And `POST` doesn't use `URL` in this basic example so it never uses URL parsing.