### PR TITLE
Fix utils@9.2.1

### DIFF
--- a/.changeset/plugin-persisted-operations-dependencies.md
+++ b/.changeset/plugin-persisted-operations-dependencies.md
@@ -1,0 +1,10 @@
+---
+"@graphql-yoga/plugin-persisted-operations": patch
+---
+
+dependencies updates:
+  - Updated dependency [`@graphql-tools/utils@^9.2.1` ↗︎](https://www.npmjs.com/package/@graphql-yoga/plugin-persisted-operations) (from `^9.0.1`, in `dependencies`)
+
+motivation:
+  - conflicting peer dependency: 
+    @graphql-tools/utils@9.2.1 node_modules/@graphql-tools/utils peer @graphql-tools/utils@"^9.0.1" from @graphql-yoga/plugin-persisted-operations@1.7.0

--- a/packages/plugins/persisted-operations/package.json
+++ b/packages/plugins/persisted-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-yoga/plugin-persisted-operations",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Persisted Operations plugin for GraphQL Yoga.",
   "repository": {
     "type": "git",

--- a/packages/plugins/persisted-operations/package.json
+++ b/packages/plugins/persisted-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-yoga/plugin-persisted-operations",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "description": "Persisted Operations plugin for GraphQL Yoga.",
   "repository": {
     "type": "git",

--- a/packages/plugins/persisted-operations/package.json
+++ b/packages/plugins/persisted-operations/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@graphql-tools/utils": "^9.0.1",
+    "@graphql-tools/utils": "^9.2.1",
     "graphql": "^15.2.0 || ^16.0.0",
     "graphql-yoga": "^3.7.0"
   },


### PR DESCRIPTION
Fix @graphql-tools/utils peerDependencies compatibility 9.2.1

conflicting peer dependency: @graphql-tools/utils@9.2.1 node_modules/@graphql-tools/utils
  peer @graphql-tools/utils@"^9.0.1" from @graphql-yoga/plugin-persisted-operations@1.7.0