### PR TITLE
Update integration-with-deno.mdx

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-deno.mdx
+++ b/website/src/pages/docs/integrations/integration-with-deno.mdx
@@ -38,7 +38,10 @@ const yoga = createYoga({
         hello: () => 'Hello Deno!'
       }
     }
-  })
+  }),
+  fetchAPI: {
+    Response
+  }
 })
 
 serve(yoga, {


### PR DESCRIPTION
Without this, graphql-yoga responds to a `Request` with a `PonyfillResponse` object which browsers can't detect. Adding this fixes the issue.