### PR TITLE
Allow to customize persisted operations errors

### DIFF
--- a/.changeset/spotty-singers-suffer.md
+++ b/.changeset/spotty-singers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-persisted-operations': minor
+---
+
+allow to customize errors

--- a/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
@@ -19,6 +19,17 @@ describe('Persisted Operations', () => {
       expect(error.message).toBe('Not found')
     })
 
+    it('should allow to customize not found error message with error options', async () => {
+      const error = await generateNotFoundError({
+        notFound: {
+          message: 'Not found',
+          extensions: { code: 'NOT_FOUND' },
+        },
+      })
+      expect(error.message).toBe('Not found')
+      expect(error.extensions.code).toBe('NOT_FOUND')
+    })
+
     it('should allow to customize error when key is not found with a string', async () => {
       const error = await generateKeyNotFoundError({
         keyNotFound: 'Key not found',
@@ -26,11 +37,33 @@ describe('Persisted Operations', () => {
       expect(error.message).toBe('Key not found')
     })
 
+    it('should allow to customize error when key is not found with error options', async () => {
+      const error = await generateKeyNotFoundError({
+        keyNotFound: {
+          message: 'Key not found',
+          extensions: { code: 'KEY_NOT_FOUND' },
+        },
+      })
+      expect(error.message).toBe('Key not found')
+      expect(error.extensions.code).toBe('KEY_NOT_FOUND')
+    })
+
     it('should allow to customize persisted query only error with a string', async () => {
       const error = await generatePersistedQueryOnlyError({
         persistedQueryOnly: 'Persisted query only',
       })
       expect(error.message).toBe('Persisted query only')
+    })
+
+    it('should allow to customize persisted query only error with error options', async () => {
+      const error = await generatePersistedQueryOnlyError({
+        persistedQueryOnly: {
+          message: 'Persisted query only',
+          extensions: { code: 'PERSISTED_ONLY' },
+        },
+      })
+      expect(error.message).toBe('Persisted query only')
+      expect(error.extensions.code).toBe('PERSISTED_ONLY')
     })
   })
 })

--- a/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
@@ -2,7 +2,7 @@ import {
   CustomPersistedQueryErrors,
   usePersistedOperations,
 } from '@graphql-yoga/plugin-persisted-operations'
-import { createSchema, createYoga } from 'graphql-yoga'
+import { createSchema, createYoga, createGraphQLError } from 'graphql-yoga'
 
 const schema = createSchema({
   typeDefs: /* GraphQL */ `
@@ -30,6 +30,17 @@ describe('Persisted Operations', () => {
       expect(error.extensions.code).toBe('NOT_FOUND')
     })
 
+    it('should allow to customize not found error message with a function', async () => {
+      const error = await generateNotFoundError({
+        notFound: () =>
+          createGraphQLError('Not found', {
+            extensions: { code: 'NOT_FOUND' },
+          }),
+      })
+      expect(error.message).toBe('Not found')
+      expect(error.extensions.code).toBe('NOT_FOUND')
+    })
+
     it('should allow to customize error when key is not found with a string', async () => {
       const error = await generateKeyNotFoundError({
         keyNotFound: 'Key not found',
@@ -48,6 +59,17 @@ describe('Persisted Operations', () => {
       expect(error.extensions.code).toBe('KEY_NOT_FOUND')
     })
 
+    it('should allow to customize error when key is not found with a function', async () => {
+      const error = await generateKeyNotFoundError({
+        keyNotFound: () =>
+          createGraphQLError('Key not found', {
+            extensions: { code: 'KEY_NOT_FOUND' },
+          }),
+      })
+      expect(error.message).toBe('Key not found')
+      expect(error.extensions.code).toBe('KEY_NOT_FOUND')
+    })
+
     it('should allow to customize persisted query only error with a string', async () => {
       const error = await generatePersistedQueryOnlyError({
         persistedQueryOnly: 'Persisted query only',
@@ -61,6 +83,17 @@ describe('Persisted Operations', () => {
           message: 'Persisted query only',
           extensions: { code: 'PERSISTED_ONLY' },
         },
+      })
+      expect(error.message).toBe('Persisted query only')
+      expect(error.extensions.code).toBe('PERSISTED_ONLY')
+    })
+
+    it('should allow to customize persisted query only error with a function', async () => {
+      const error = await generatePersistedQueryOnlyError({
+        persistedQueryOnly: () =>
+          createGraphQLError('Persisted query only', {
+            extensions: { code: 'PERSISTED_ONLY' },
+          }),
       })
       expect(error.message).toBe('Persisted query only')
       expect(error.extensions.code).toBe('PERSISTED_ONLY')

--- a/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations-errors.spec.ts
@@ -1,0 +1,156 @@
+import {
+  CustomPersistedQueryErrors,
+  usePersistedOperations,
+} from '@graphql-yoga/plugin-persisted-operations'
+import { createSchema, createYoga } from 'graphql-yoga'
+
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      _: String
+    }
+  `,
+})
+
+describe('Persisted Operations', () => {
+  describe('Custom Errors', () => {
+    it('should allow to customize not found error message with a string', async () => {
+      const error = await generateNotFoundError({ notFound: 'Not found' })
+      expect(error.message).toBe('Not found')
+    })
+
+    it('should allow to customize error when key is not found with a string', async () => {
+      const error = await generateKeyNotFoundError({
+        keyNotFound: 'Key not found',
+      })
+      expect(error.message).toBe('Key not found')
+    })
+
+    it('should allow to customize persisted query only error with a string', async () => {
+      const error = await generatePersistedQueryOnlyError({
+        persistedQueryOnly: 'Persisted query only',
+      })
+      expect(error.message).toBe('Persisted query only')
+    })
+  })
+})
+
+async function generateNotFoundError(customErrors: CustomPersistedQueryErrors) {
+  const yoga = createYoga({
+    plugins: [
+      usePersistedOperations({
+        getPersistedOperation() {
+          return null
+        },
+        customErrors,
+      }),
+    ],
+    schema,
+  })
+
+  const response = await yoga.fetch('http://yoga/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      extensions: {
+        persistedQuery: {
+          version: 1,
+          sha256Hash:
+            'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
+        },
+      },
+    }),
+  })
+
+  const body = await response.json()
+  expect(body.errors).toBeDefined()
+  return body.errors[0]
+}
+
+async function generateKeyNotFoundError(
+  customErrors: CustomPersistedQueryErrors,
+) {
+  const store = new Map<string, string>()
+
+  const yoga = createYoga({
+    plugins: [
+      usePersistedOperations({
+        getPersistedOperation(key) {
+          return store.get(key) || null
+        },
+        extractPersistedOperationId() {
+          return null
+        },
+        customErrors,
+      }),
+    ],
+    schema,
+  })
+
+  const persistedQueryEntry = {
+    version: 1,
+    sha256Hash:
+      'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
+  }
+  store.set(persistedQueryEntry.sha256Hash, '{__typename}')
+
+  const response = await yoga.fetch('http://yoga/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      extensions: {
+        persistedQuery: {
+          version: 1,
+          sha256Hash:
+            'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
+        },
+      },
+    }),
+  })
+
+  const body = await response.json()
+  expect(body.errors).toBeDefined()
+  return body.errors[0]
+}
+
+async function generatePersistedQueryOnlyError(
+  customErrors: CustomPersistedQueryErrors,
+) {
+  const store = new Map<string, string>()
+
+  const yoga = createYoga({
+    plugins: [
+      usePersistedOperations({
+        getPersistedOperation(key: string) {
+          return store.get(key) || null
+        },
+        customErrors,
+      }),
+    ],
+    schema,
+  })
+  const persistedQueryEntry = {
+    version: 1,
+    sha256Hash:
+      'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
+  }
+  store.set(persistedQueryEntry.sha256Hash, '{__typename}')
+
+  const response = await yoga.fetch('http://yoga/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: '{__typename}',
+    }),
+  })
+
+  const body = await response.json()
+  expect(body.errors).toBeDefined()
+  return body.errors[0]
+}

--- a/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
@@ -1,7 +1,4 @@
-import {
-  CustomPersistedQueryErrors,
-  usePersistedOperations,
-} from '@graphql-yoga/plugin-persisted-operations'
+import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operations'
 import { DocumentNode, parse, validate } from 'graphql'
 import { createSchema, createYoga, GraphQLParams } from 'graphql-yoga'
 
@@ -362,43 +359,4 @@ describe('Persisted Operations', () => {
 
     expect(validateFn).not.toHaveBeenCalled()
   })
-
-  it('should allow to customize not found error message with a string', async () => {
-    const error = await generateNotFoundError({ notFound: 'Not found' })
-    expect(error.message).toBe('Not found')
-  })
 })
-
-async function generateNotFoundError(customErrors: CustomPersistedQueryErrors) {
-  const yoga = createYoga({
-    plugins: [
-      usePersistedOperations({
-        getPersistedOperation() {
-          return null
-        },
-        customErrors,
-      }),
-    ],
-    schema,
-  })
-
-  const response = await yoga.fetch('http://yoga/graphql', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      extensions: {
-        persistedQuery: {
-          version: 1,
-          sha256Hash:
-            'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
-        },
-      },
-    }),
-  })
-
-  const body = await response.json()
-  expect(body.errors).toBeDefined()
-  return body.errors[0]
-}

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -50,6 +50,20 @@ export type UsePersistedOperationsOptions = {
    * Whether to skip validation of the persisted operation
    */
   skipDocumentValidation?: boolean
+
+  /**
+   * Custom errors to be thrown
+   */
+  customErrors?: CustomPersistedQueryErrors
+}
+
+export type CustomErrorFactory = string
+
+export type CustomPersistedQueryErrors = {
+  /**
+   * Error to be thrown when the persisted operation is not found
+   */
+  notFound?: CustomErrorFactory
 }
 
 export function usePersistedOperations<
@@ -60,6 +74,7 @@ export function usePersistedOperations<
   extractPersistedOperationId = defaultExtractPersistedOperationId,
   getPersistedOperation,
   skipDocumentValidation = false,
+  customErrors,
 }: UsePersistedOperationsOptions): Plugin<TPluginContext> {
   const operationASTByRequest = new WeakMap<Request, DocumentNode>()
   const persistedOperationRequest = new WeakSet<Request>()
@@ -84,7 +99,9 @@ export function usePersistedOperations<
 
       const persistedQuery = await getPersistedOperation(persistedOperationKey)
       if (persistedQuery == null) {
-        throw createGraphQLError('PersistedQueryNotFound')
+        throw createGraphQLError(
+          customErrors?.notFound ?? 'PersistedQueryNotFound',
+        )
       }
 
       if (typeof persistedQuery === 'object') {

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -60,6 +60,7 @@ export type UsePersistedOperationsOptions = {
 export type CustomErrorFactory =
   | string
   | (GraphQLErrorOptions & { message: string })
+  | (() => Error)
 
 export type CustomPersistedQueryErrors = {
   /**
@@ -160,6 +161,9 @@ function createPersistedOperationError(
 ) {
   if (typeof options === 'string') {
     return createGraphQLError(options)
+  }
+  if (typeof options === 'function') {
+    return options()
   }
   return createGraphQLError(options?.message ?? defaultMessage, options)
 }

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -274,3 +274,49 @@ server.listen(4000, () => {
   console.info('Server is running on http://localhost:4000/graphql')
 })
 ```
+
+## Customize errors
+
+This plugin can throw three different types of errors::
+
+- `PersistedOperationNotFound`: The persisted operation cannot be found.
+- `PersistedOperationKeyNotFound`: The persistence key cannot be extracted from the request.
+- `PersistedOperationOnly`: An arbitrary operation is rejected because only persisted operations are allowed.
+
+Each error can be customized to change the HTTP status or add a translation message ID, for example.
+
+```ts filename="Customize errors"
+import { createYoga } from 'graphql-yoga'
+import { createServer } from 'node:http'
+import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operations'
+import { CustomErrorClass } from './custom-error-class'
+
+const yoga = createYoga({
+  plugins: [
+    usePersistedOperations({
+      customErrors: {
+        // You can change the error message
+        notFound: 'Not Found',
+        // Or customize the error with a GraphqlError options object, allowing you to add extensions
+        keyNotFound: {
+          message: 'Key Not Found',
+          extensions: {
+            http: {
+              status: 404
+            }
+          }
+        },
+        // Or customize with a factory function allowing you to use your own error class or format
+        onlyPersisted: () => {
+          return new CustomErrorClass('Only Persisted Operations are allowed')
+        }
+      }
+    })
+  ]
+})
+
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -307,7 +307,7 @@ const yoga = createYoga({
           }
         },
         // Or customize with a factory function allowing you to use your own error class or format
-        onlyPersisted: () => {
+        persistedQueryOnly: () => {
           return new CustomErrorClass('Only Persisted Operations are allowed')
         }
       }


### PR DESCRIPTION
## Description

This PR aims to allow the customization of errors in Persisted Operations plugin.

## Issue

fixes #2047 

## Concerns

I have implemented multiple ways to customize errors with polymorphic options. I'm not sure if this wanted, since it seems this pattern is not heavily used in the code base. But I think it can be a good DX, since the most general use-case will probably to add a static extensions such as HTTP status.

Don't hesitate If you have suggestion about option names, I'm not totally satisfied.

I also give access to the payload of the `onParams` function to the error factory. Perhaps I should filter to avoid passing setters and only give access to `params` and `request` ?

 ## Usage example

```ts filename="Customize errors"
import { createYoga } from 'graphql-yoga'
import { createServer } from 'node:http'
import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operations'
import { CustomErrorClass } from './custom-error-class'

const yoga = createYoga({
  plugins: [
    usePersistedOperations({
      customErrors: {
        // You can change the error message
        notFound: 'Not Found',
        // Or customize the error with a GraphqlError options object, allowing you to add extensions
        keyNotFound: {
          message: 'Key Not Found',
          extensions: {
            http: {
              status: 404
            }
          }
        },
        // Or customize with a factory function allowing you to use your own error class or format
        persistedQueryOnly: () => {
          return new CustomErrorClass('Only Persisted Operations are allowed')
        }
      }
    })
  ]
})

const server = createServer(yoga)
server.listen(4000, () => {
  console.info('Server is running on http://localhost:4000/graphql')
})
```