### PR TITLE
Pass request to get persisted operations function

### DIFF
--- a/.changeset/sweet-cheetahs-shop.md
+++ b/.changeset/sweet-cheetahs-shop.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-persisted-operations': minor
+---
+
+Provide request argument to getPersistedOperation callback

--- a/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
@@ -361,14 +361,14 @@ describe('Persisted Operations', () => {
   })
 
   it('uses a persisted query from the store based on request header', async () => {
-    const store = new Map<string, string>();
-    const clientOneStore = new Map<string, string>();
+    const store = new Map<string, string>()
+    const clientOneStore = new Map<string, string>()
 
     const yoga = createYoga({
       plugins: [
         usePersistedOperations({
           getPersistedOperation(key: string, request: Request) {
-            if(request.headers.get('client-name') === 'ClientOne') {
+            if (request.headers.get('client-name') === 'ClientOne') {
               return clientOneStore.get(key) || null
             }
 
@@ -385,13 +385,13 @@ describe('Persisted Operations', () => {
         'ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38',
     }
 
-    clientOneStore.set(persistedQueryEntry.sha256Hash, '{__typename}');
+    clientOneStore.set(persistedQueryEntry.sha256Hash, '{__typename}')
 
     const response = await yoga.fetch('http://yoga/graphql', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'client-name': 'ClientOne'
+        'client-name': 'ClientOne',
       },
       body: JSON.stringify({
         extensions: {

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -37,7 +37,7 @@ export type UsePersistedOperationsOptions = {
    */
   getPersistedOperation(
     key: string,
-    request: Request
+    request: Request,
   ): PromiseOrValue<DocumentNode | string | null>
   /**
    * Whether to allow execution of arbitrary GraphQL operations aside from persisted operations.
@@ -128,7 +128,10 @@ export function usePersistedOperations<
         throw keyNotFoundErrorFactory(payload)
       }
 
-      const persistedQuery = await getPersistedOperation(persistedOperationKey, request)
+      const persistedQuery = await getPersistedOperation(
+        persistedOperationKey,
+        request,
+      )
       if (persistedQuery == null) {
         throw notFoundErrorFactory(payload)
       }

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -37,6 +37,7 @@ export type UsePersistedOperationsOptions = {
    */
   getPersistedOperation(
     key: string,
+    request: Request
   ): PromiseOrValue<DocumentNode | string | null>
   /**
    * Whether to allow execution of arbitrary GraphQL operations aside from persisted operations.
@@ -127,7 +128,7 @@ export function usePersistedOperations<
         throw keyNotFoundErrorFactory(payload)
       }
 
-      const persistedQuery = await getPersistedOperation(persistedOperationKey)
+      const persistedQuery = await getPersistedOperation(persistedOperationKey, request)
       if (persistedQuery == null) {
         throw notFoundErrorFactory(payload)
       }

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -275,6 +275,37 @@ server.listen(4000, () => {
 })
 ```
 
+## Using multiple Persisted Operation Stores
+
+You can vary the persisted operations store you read from by switching based on the request.
+
+An example of this may be to use request headers.
+
+```ts filename="Use parsed GraphQL documents as AST"
+import {
+  usePersistedOperations,
+  PersistedOperationType
+} from '@graphql-yoga/plugin-persisted-operations'
+import { parse } from 'graphql'
+
+const persistedOperationsStores = {
+  'ClientOne': {
+    'my-key': parse(/* GraphQL */ `
+      query {
+        __typename
+      }
+    `)
+  }
+}
+
+const plugin = usePersistedOperations({
+  getPersistedOperation(key: string, request: Request) {
+    const store = persistedOperationsStores[request.headers.get('client-name')];
+    return store && store[key] || null;
+  }
+})
+```
+
 ## Customize errors
 
 This plugin can throw three different types of errors::

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -289,7 +289,7 @@ import {
 import { parse } from 'graphql'
 
 const persistedOperationsStores = {
-  'ClientOne': {
+  ClientOne: {
     'my-key': parse(/* GraphQL */ `
       query {
         __typename
@@ -300,8 +300,8 @@ const persistedOperationsStores = {
 
 const plugin = usePersistedOperations({
   getPersistedOperation(key: string, request: Request) {
-    const store = persistedOperationsStores[request.headers.get('client-name')];
-    return store && store[key] || null;
+    const store = persistedOperationsStores[request.headers.get('client-name')]
+    return (store && store[key]) || null
   }
 })
 ```


### PR DESCRIPTION
I have a requirement to support multiple persisted operation stores, dictated by a request header.

**_Change:_**

Pass `request` to `getPersistedOperation`