### PR TITLE
Fix documentation for using Persisted Queries with Relay

### DIFF
--- a/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
+++ b/packages/plugins/persisted-operations/__tests__/persisted-operations.spec.ts
@@ -196,9 +196,9 @@ describe('Persisted Operations', () => {
             return store.get(key) || null
           },
           extractPersistedOperationId(
-            params: GraphQLParams & { doc_id?: string },
+            params: GraphQLParams & { doc_id?: unknown },
           ) {
-            return params.doc_id ?? null
+            return typeof params.doc_id === 'string' ? params.doc_id : null
           },
         }),
       ],

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -220,10 +220,7 @@ const yoga = createYoga({
   plugins: [
     usePersistedOperations({
       extractPersistedOperationId(params: GraphqlParams & { doc_id?: unknown }) {
-        if (typeof params.doc_id === 'string') {
-          return params.doc_id
-        }
-        return null
+        return typeof params.doc_id === 'string' ? params.doc_id : null
       }
       getPersistedOperation(key: string) {
         return store[key]

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -219,7 +219,7 @@ const yoga = createYoga({
   }),
   plugins: [
     usePersistedOperations({
-      extractPersistedOperationId(params: GraphqlParams & { doc_id?: string }) {
+      extractPersistedOperationId(params: GraphqlParams & { doc_id?: unknown }) {
         if (typeof params.doc_id === 'string') {
           return params.doc_id
         }

--- a/website/src/pages/docs/features/persisted-operations.mdx
+++ b/website/src/pages/docs/features/persisted-operations.mdx
@@ -219,9 +219,9 @@ const yoga = createYoga({
   }),
   plugins: [
     usePersistedOperations({
-      extractPersistedOperationId(params: Record<string, unknown>) {
-        if (typeof payload.doc_id === 'string') {
-          return payload.doc_id
+      extractPersistedOperationId(params: GraphqlParams & { doc_id?: string }) {
+        if (typeof params.doc_id === 'string') {
+          return params.doc_id
         }
         return null
       }


### PR DESCRIPTION
The Relay usage of Persisted Query is broken and the type used for `params` is misleading.

fixes #2756 