### PR TITLE
Fix code example - integration-with-aws-lambda.mdx

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-aws-lambda.mdx
+++ b/website/src/pages/docs/integrations/integration-with-aws-lambda.mdx
@@ -48,7 +48,6 @@ export async function handler(
   const response = await yoga.fetch(
     event.path + '?' + new URLSearchParams(event.queryStringParameters as Record<string, string> || {}).toString(),
     {
-    {
       method: event.httpMethod,
       headers: event.headers as HeadersInit,
       body: event.body


### PR DESCRIPTION
There was typo (duplicate bracket in the code example) for https://the-guild.dev/graphql/yoga-server/docs/integrations/integration-with-aws-lambda#example