### PR TITLE
add documentation to handle files as binary instead of text

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2919,6 +2919,7 @@ packages:
       '@aws-cdk/core': 1.201.0
       '@aws-cdk/custom-resources': 1.201.0(@aws-cdk/aws-ec2@1.201.0)(@aws-cdk/aws-iam@1.201.0)(@aws-cdk/aws-lambda@1.201.0)(@aws-cdk/aws-logs@1.201.0)(@aws-cdk/aws-s3@1.201.0)(@aws-cdk/core@1.201.0)(@aws-cdk/cx-api@1.201.0)(constructs@3.4.127)
       constructs: 3.4.127
+      punycode: 2.3.0
     transitivePeerDependencies:
       - '@aws-cdk/aws-ec2'
       - '@aws-cdk/aws-logs'
@@ -3224,6 +3225,9 @@ packages:
   /@aws-cdk/cloud-assembly-schema@1.201.0:
     resolution: {integrity: sha512-s/W9GvkoaJytySiflMtelW5B/H00dpi503XwG8l1XD3RVzlpT2RU4PGKCho3+uZna4G4468TpgnnxqDY/a4IjA==}
     engines: {node: '>= 14.15.0'}
+    dependencies:
+      jsonschema: 1.4.1
+      semver: 7.5.1
     dev: false
     bundledDependencies:
       - jsonschema
@@ -3289,6 +3293,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.201.0
+      semver: 7.5.1
     dev: false
     bundledDependencies:
       - semver
@@ -13363,7 +13368,7 @@ packages:
       debug: 4.3.4(supports-color@9.2.3)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -13384,7 +13389,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -13405,7 +13410,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -13466,7 +13471,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.0.4)
       eslint: 8.40.0
       eslint-scope: 5.1.1
-      semver: 7.3.8
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19603,7 +19608,7 @@ packages:
       proxy-addr: 2.0.7
       rfdc: 1.3.0
       secure-json-parse: 2.5.0
-      semver: 7.3.8
+      semver: 7.5.1
       tiny-lru: 10.0.0
     transitivePeerDependencies:
       - supports-color
@@ -23466,7 +23471,6 @@ packages:
 
   /jsonschema@1.4.1:
     resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
-    dev: true
 
   /jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
@@ -30529,7 +30533,7 @@ packages:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.11.0
-      semver: 7.3.8
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
 

--- a/website/src/pages/docs/features/file-uploads.mdx
+++ b/website/src/pages/docs/features/file-uploads.mdx
@@ -31,6 +31,7 @@ const yoga = createYoga({
 
       type Mutation {
         readTextFile(file: File!): String!
+        saveFile(file: File!): Boolean!
       }
     `,
     resolvers: {
@@ -42,6 +43,19 @@ const yoga = createYoga({
           const textContent = await file.text()
           return textContent
         }
+
+        saveFile: async (_, { file }: { file: File }) => {
+          try {
+            const fileArrayBuffer = await file.arrayBuffer()
+            await fs.promises.writeFile(
+              path.join(__dirname, file.name),
+              Buffer.from(fileArrayBuffer),
+            )
+          } catch (e) {
+            return false
+          }
+          return true
+        },
       }
     }
   })
@@ -143,6 +157,58 @@ const schema = makeSchema({
 
 const yoga = createYoga({
   schema: schema
+})
+
+// Start the server and explore http://localhost:4000/graphql
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
+
+### Usage with S3
+
+Amazon S3 is a popular object storage service. You can use GraphQL Yoga to upload files to S3.
+In this example, we will use the [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/).
+
+Note that S3 is a common protocol and you can use other storage providers than AWS.
+
+```ts filename="file-upload-example.ts" {8, 15, 23-26}
+import { createYoga } from 'graphql-yoga'
+import { createServer } from 'http'
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+
+const client = new S3Client({})
+
+// Provide your schema
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs: /* GraphQL */ `
+      scalar File
+
+      type Mutation {
+        upload(file: File!): Boolean!
+      }
+    `,
+    resolvers: {
+      Mutation: {
+        upload: async (_, { file }: { file: File }) => {
+          try {
+            await client.send(
+              new PutObjectCommand({
+                Bucket: 'test-bucket',
+                Key: file.name,
+                Body: Buffer.from(await file.arrayBuffer())
+              })
+            )
+            return true
+          } catch (e) {
+            return false
+          }
+        }
+      }
+    }
+  })
 })
 
 // Start the server and explore http://localhost:4000/graphql


### PR DESCRIPTION
Improve the File upload quick start with a file upload to show how to get a Buffer containing the content of the file instead of just text handling.

I've also added a quick example showcasing an S3 file upload as it's a pretty common task.

fixes #2763