### PR TITLE
Add reference to graphql-workers-subscriptions

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-cloudflare-workers.mdx
+++ b/website/src/pages/docs/integrations/integration-with-cloudflare-workers.mdx
@@ -145,10 +145,14 @@ export default { fetch: yoga.fetch }
 
 ## Enabling Subscriptions
 
-In order to enable Server Sent Events based subscriptions with Cloudflare Workers, you should add a compatibility flag in your wrangler configuration file like below;
+For a library enabling topic-based subscriptions using GraphQL Yoga, `graphql-ws`, see [graphql-workers-subscriptions](https://github.com/bubblydoo/graphql-workers-subscriptions). This library uses Durable Objects and D1 to manage the subscriptions state.
+
+### Compatibility for Server Sent Events
+
+In order to enable Server Sent Events based subscriptions with Cloudflare Workers, make sure you have set the compatibility date in your wrangler configuration file to a date after 2022-11-30 (if that's not possible, add compatibility flag `streams_enable_constructors`).
 
 ```toml
-compatibility_flags = ["streams_enable_constructors"]
+compatibility_date = "2022-11-30"
 ```
 
 ## Debug Logging

--- a/website/src/pages/tutorial/advanced/02-subscriptions.mdx
+++ b/website/src/pages/tutorial/advanced/02-subscriptions.mdx
@@ -542,3 +542,12 @@ mutation {
   }
 }
 ```
+
+### Shared subscriptions in a distributed/serverless environment
+
+The approach above won't work if you want to publish from one GraphQL process to another GraphQL process, e.g. when using topic-based subscriptions like in chat rooms in a serverless environment.
+In order to use a global subscriptions pool, you'll have to keep track of the subscriptions in a database.
+
+See [graphql-workers-subscriptions](https://github.com/bubblydoo/graphql-workers-subscriptions) for an example on such an approach in Cloudflare Workers.
+This library uses an SQLite database (Cloudflare D1) to keep track of subscriptions, and Cloudflare Durable Objects to manage the WebSocket connections.
+It sits on top of GraphQL Yoga and handles the subscriptions separately.


### PR DESCRIPTION
As mentioned in https://github.com/dotansimha/graphql-yoga/pull/2324#issuecomment-1387439123 🙂 

I also added a note about shared subscriptions to the subscriptions doc, as I was very confused at first on how to set up a chat-room like app with Yoga.