### PR TITLE
do not overwrite existing status on validation, if any

### DIFF
--- a/.changeset/purple-ravens-train.md
+++ b/.changeset/purple-ravens-train.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Avoid overriding http status on extensions when using a plugin that modifies error prop

--- a/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
@@ -1,3 +1,4 @@
+import { AfterValidateEventPayload } from '@envelop/core'
 import { createSchema } from '../../schema.js'
 import { createYoga } from '../../server.js'
 
@@ -23,7 +24,11 @@ describe('useHTTPValidationError', () => {
         plugins: [
           {
             onValidate() {
-              return ({ valid, result }) => {
+              return ({
+                valid,
+                result,
+              }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              AfterValidateEventPayload<Record<string, any>>) => {
                 if (!valid) {
                   for (const error of result) {
                     error.extensions.http = {

--- a/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
@@ -1,0 +1,52 @@
+import { createSchema } from '../../schema.js'
+import { createYoga } from '../../server.js'
+
+describe('useHTTPValidationError', () => {
+  describe('when doing a request with an invalid query', () => {
+    it('does not overrite status code set on custom plugin', async () => {
+      const schemaFactory = async () => {
+        return createSchema({
+          typeDefs: /* GraphQL */ `
+            type Query {
+              foo: String
+            }
+          `,
+          resolvers: {
+            Query: {
+              foo: () => 'bar',
+            },
+          },
+        })
+      }
+      const yoga = createYoga({
+        schema: schemaFactory,
+        plugins: [
+          {
+            onValidate() {
+              return ({ valid, result }) => {
+                if (!valid) {
+                  for (const error of result) {
+                    error.extensions.http = {
+                      status: 400,
+                      spec: false,
+                    }
+                  }
+                }
+              }
+            },
+          },
+        ],
+      })
+      const result = await yoga.fetch('http://yoga/graphql', {
+        method: 'POST',
+        body: JSON.stringify({
+          query: 'query{bar}',
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      expect(result.status).toEqual(400)
+    })
+  })
+})

--- a/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.spec.ts
@@ -29,6 +29,9 @@ describe('useHTTPValidationError', () => {
                     error.extensions.http = {
                       status: 400,
                       spec: false,
+                      headers: {
+                        'custom-header': 'custom-value',
+                      },
                     }
                   }
                 }
@@ -47,6 +50,7 @@ describe('useHTTPValidationError', () => {
         },
       })
       expect(result.status).toEqual(400)
+      expect(result.headers.get('custom-header')).toEqual('custom-value')
     })
   })
 })

--- a/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.ts
@@ -10,8 +10,8 @@ export function useHTTPValidationError<
         if (!valid) {
           for (const error of result) {
             error.extensions.http = {
-              spec: true,
-              status: 400,
+              spec: error.extensions.http?.spec ?? true,
+              status: error.extensions.http?.status ?? 400,
             }
           }
         }

--- a/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-http-validation-error.ts
@@ -10,6 +10,7 @@ export function useHTTPValidationError<
         if (!valid) {
           for (const error of result) {
             error.extensions.http = {
+              ...error.extensions.http,
               spec: error.extensions.http?.spec ?? true,
               status: error.extensions.http?.status ?? 400,
             }


### PR DESCRIPTION
my intention here is to throw 400 error on validation errors, but the native `useHTTPValidationError` is overriding my error, so this won't work on my side:

```js
await createYoga({
  plugins: [
    {
      onValidate() {
        return ({ valid, result }) => {
          if (!valid) {
            for (const error of result) {
              error.extensions.http = {
                status: 400,
                spec: false
              };
            }
          }
        };
      }
    }
  ],
  ...the rest of the configuration
})
```

notice that this is an exact copy of `useHTTPValidationError` but with `spec: false` set.

On the other side, I am not finding what is the "spec" prop for, and I am not finding documentation for it. I would appreciate if you can enlight me on that topic.