### PR TITLE
docs: fix table layout in comparison.mdx

### DIFF
--- a/website/src/pages/docs/comparison.mdx
+++ b/website/src/pages/docs/comparison.mdx
@@ -14,16 +14,14 @@ This comparison highlights the main differences when using Yoga instead of Apoll
 ### Better runtime performance
 
 GraphQL Yoga has significantly less latency and much higher requests rate than Apollo Server in all
-[popular benchmarks](https://github.com/graphql-crystal/benchmarks). including when using Apollo
-Federation - see benchmarks
-[here](https://github.com/ardatan/benchmarks/tree/federation#apollo-federation-server-benchmarks) |
-Name | Language | Server | Latency avg | Requests | | ---------------------------- | ------------- |
---------------- | ---------------- | ------------- | |
-[GraphQL Yoga with Response Cache](https://github.com/dotansimha/graphql-yoga) | Node.js | http |
-46.54ms | 2.2kps | | [GraphQL Yoga with JIT](https://github.com/dotansimha/graphql-yoga) | Node.js |
-http | 764.83ms | 120ps | | [GraphQL Yoga](https://github.com/dotansimha/graphql-yoga) | Node.js |
-http | 916.90ms | 100ps | | [Apollo Server](https://github.com/apollographql/apollo-server) |
-Node.js | Express | 1,234.12ms | 64ps |
+[popular benchmarks](https://github.com/graphql-crystal/benchmarks), including when using Apollo Federation - see benchmarks [here](https://github.com/ardatan/benchmarks/tree/federation#apollo-federation-server-benchmarks).
+
+| Name                                                                           | Language | Server  | Latency avg | Requests |
+| ------------------------------------------------------------------------------ | -------- | ------- | ----------: | -------: |
+| [GraphQL Yoga with Response Cache](https://github.com/dotansimha/graphql-yoga) | Node.js  | http    |     46.54ms |   2.2kps |
+| [GraphQL Yoga with JIT](https://github.com/dotansimha/graphql-yoga)            | Node.js  | http    |    764.83ms |    120ps |
+| [GraphQL Yoga](https://github.com/dotansimha/graphql-yoga)                     | Node.js  | http    |    916.90ms |    100ps |
+| [Apollo Server](https://github.com/apollographql/apollo-server)                | Node.js  | Express |  1,234.12ms |     64ps |
 
 ### No Framework-specific Packages
 


### PR DESCRIPTION
The table of comparison between runtime performances is not formated properly and displays raw markdown in the docs.