### PR TITLE
fix: Fixed typo found in GraphQL Schema page of the features docs

### DIFF
--- a/website/src/pages/docs/features/schema.mdx
+++ b/website/src/pages/docs/features/schema.mdx
@@ -14,7 +14,7 @@ a `GraphQLSchema` to `schema`, you can pass it to GraphQL Yoga.
 
 ## Providing a Schema
 
-Simply pass an schema to the `schema` option:
+Simply pass a schema to the `schema` option:
 
 ```ts filename="Provide a conditional schema"
 import { createServer } from 'node:http'


### PR DESCRIPTION
Corrected "Simply pass **an** schema..." to "Simply pass *a* schema..."