### PR TITLE
fix: Typos found in graphiql.mdx and response-caching.mdx

### DIFF
--- a/website/src/pages/docs/features/graphiql.mdx
+++ b/website/src/pages/docs/features/graphiql.mdx
@@ -102,7 +102,7 @@ import { createYoga } from 'graphql-yoga'
 const yoga = createYoga({
   graphiql(request, { req, res }) {
     // access something attached to the request object
-    // e.g. an user object added by an auth middleware.
+    // e.g. a user object added by an auth middleware.
     if (req.user.role === 'admin') {
       return true
     }

--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -122,7 +122,7 @@ useResponseCache({
 })
 ```
 
-### Using Schema directive directive `@cacheControl`
+### Using Schema directive `@cacheControl`
 
 For a schema first approach, the `@cacheControl` directive can be used to define the TTL.
 


### PR DESCRIPTION
Changed "...**an** user..." to "...**a** user..." in graphiql.mdx and removed duplicate "directive" in response-caching.mdx