### PR TITLE
Start SSE stream with a ping

### DIFF
--- a/packages/graphql-yoga/__tests__/graphql-sse.spec.ts
+++ b/packages/graphql-yoga/__tests__/graphql-sse.spec.ts
@@ -52,16 +52,18 @@ describe('GraphQL over SSE', () => {
       });
       expect(res.ok).toBeTruthy();
       await expect(res.text()).resolves.toMatchInlineSnapshot(`
-        ":
+":
 
-        :
+:
 
-        :
+:
 
-        event: complete
+:
 
-        "
-      `);
+event: complete
+
+"
+`);
     });
 
     it('should support single result operations', async () => {
@@ -170,13 +172,15 @@ describe('GraphQL over SSE', () => {
       });
       expect(res.ok).toBeTruthy();
       await expect(res.text()).resolves.toMatchInlineSnapshot(`
-        "event: next
-        data: {"errors":[{"message":"Cannot query field \\"nope\\" on type \\"Query\\".","locations":[{"line":1,"column":2}]}]}
+":
 
-        event: complete
+event: next
+data: {"errors":[{"message":"Cannot query field \\"nope\\" on type \\"Query\\".","locations":[{"line":1,"column":2}]}]}
 
-        "
-      `);
+event: complete
+
+"
+`);
     });
 
     it('accept: application/graphql-response+json, application/json,  multipart/mixed, text/event-stream', async () => {

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -297,16 +297,18 @@ describe('Subscription', () => {
     const text = await response.text();
 
     expect(text).toMatchInlineSnapshot(`
-      "event: next
-      data: {"data":{"hi":"hi"}}
+":
 
-      event: next
-      data: {"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":11}]}]}
+event: next
+data: {"data":{"hi":"hi"}}
 
-      event: complete
+event: next
+data: {"errors":[{"message":"Unexpected error.","locations":[{"line":2,"column":11}]}]}
 
-      "
-    `);
+event: complete
+
+"
+`);
 
     expect(logging.error).toBeCalledTimes(1);
     expect(logging.error.mock.calls[0]).toMatchInlineSnapshot(`
@@ -363,16 +365,18 @@ describe('Subscription', () => {
     const text = await response.text();
 
     expect(text).toMatchInlineSnapshot(`
-      "event: next
-      data: {"data":{"hi":"hi"}}
+":
 
-      event: next
-      data: {"errors":[{"message":"hi","locations":[{"line":2,"column":11}]}]}
+event: next
+data: {"data":{"hi":"hi"}}
 
-      event: complete
+event: next
+data: {"errors":[{"message":"hi","locations":[{"line":2,"column":11}]}]}
 
-      "
-    `);
+event: complete
+
+"
+`);
 
     expect(logging.error).toBeCalledTimes(0);
   });

--- a/packages/graphql-yoga/src/plugins/result-processor/sse.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/sse.ts
@@ -29,6 +29,10 @@ export function getSSEProcessor(): ResultProcessor {
     const textEncoder = new fetchAPI.TextEncoder();
     const readableStream = new fetchAPI.ReadableStream({
       start(controller) {
+        // always start with a ping because some browsers dont accept a header flush
+        // causing the fetch to stall until something is streamed through the response
+        controller.enqueue(textEncoder.encode(':\n\n'));
+
         // ping client every 12 seconds to keep the connection alive
         pingInterval = setInterval(() => {
           if (!controller.desiredSize) {

--- a/packages/nestjs/__tests__/subscriptions.spec.ts
+++ b/packages/nestjs/__tests__/subscriptions.spec.ts
@@ -32,23 +32,25 @@ it('should subscribe using sse', async () => {
   });
 
   await expect(sub.text()).resolves.toMatchInlineSnapshot(`
-    "event: next
-    data: {"data":{"greetings":"Hi"}}
+":
 
-    event: next
-    data: {"data":{"greetings":"Bonjour"}}
+event: next
+data: {"data":{"greetings":"Hi"}}
 
-    event: next
-    data: {"data":{"greetings":"Hola"}}
+event: next
+data: {"data":{"greetings":"Bonjour"}}
 
-    event: next
-    data: {"data":{"greetings":"Ciao"}}
+event: next
+data: {"data":{"greetings":"Hola"}}
 
-    event: next
-    data: {"data":{"greetings":"Zdravo"}}
+event: next
+data: {"data":{"greetings":"Ciao"}}
 
-    event: complete
+event: next
+data: {"data":{"greetings":"Zdravo"}}
 
-    "
-  `);
+event: complete
+
+"
+`);
 });


### PR DESCRIPTION
Supersedes [#5492](https://github.com/ardatan/graphql-tools/pull/5492)

Some browsers don't accept a header flush as a beginning of the stream causing `fetch` to stall until something is streamed.

By starting with a ping, we allow for fetch to resolve the response as soon as possible.