### PR TITLE
Hapi example to support GraphiQL

### DIFF
--- a/examples/hapi/__integration-tests__/hapi.spec.ts
+++ b/examples/hapi/__integration-tests__/hapi.spec.ts
@@ -80,4 +80,16 @@ event: complete
 "
 `);
   });
+
+  it('should render graphiql page', async () => {
+    const res = await fetch(`http://localhost:${port}/graphql`, {
+      method: 'GET',
+      headers: {
+        accept: 'text/html',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
+  });
 });

--- a/examples/hapi/src/app.ts
+++ b/examples/hapi/src/app.ts
@@ -53,21 +53,20 @@ export async function startApp(port: number) {
       },
     },
     handler: async (req, h) => {
-      const { status, headers, body } = await yoga.handleNodeRequest(
-        // will be an incoming message because the payload output option is stream
-        req.payload as http.IncomingMessage,
-        { req, h },
+      const { status, headers, body } = await yoga.handleNodeRequest(req.raw.req, { req, h });
+
+      const res = h.response(
+        Readable.from(body, {
+          // hapi needs the stream not to be in object mode
+          objectMode: false,
+        }),
       );
 
-      const res = h.response().code(status);
       for (const [key, val] of headers) {
         res.header(key, val);
       }
 
-      return Readable.from(body, {
-        // hapi needs the stream not to be in object mode
-        objectMode: false,
-      });
+      return res.code(status);
     },
   });
 

--- a/website/src/pages/docs/integrations/integration-with-hapi.mdx
+++ b/website/src/pages/docs/integrations/integration-with-hapi.mdx
@@ -45,21 +45,20 @@ server.route({
     }
   },
   handler: async (req, h) => {
-    const { status, headers, body } = await yoga.handleNodeRequest(
-      // will be an incoming message because the payload output option is stream
-      req.payload as http.IncomingMessage,
-      { req, h }
+    const { status, headers, body } = await yoga.handleNodeRequest(req.raw.req, { req, h })
+
+    const res = h.response(
+      Readable.from(body, {
+        // hapi needs the stream not to be in object mode
+        objectMode: false
+      })
     )
 
-    const res = h.response().code(status)
     for (const [key, val] of headers) {
       res.header(key, val)
     }
 
-    return Readable.from(body, {
-      // stream cannot be in object mode
-      objectMode: false
-    })
+    return res.code(status)
   }
 })
 


### PR DESCRIPTION
Fixes #2962

This PR implements the following:

1. Passing the entire raw `IncomingMessage` [request.raw](https://hapi.dev/api/?v=21.3.2#-requestraw) from hapi to `handleNodeRequest` instead of request.payload.

While request.payload works when graphQL API is queried directly using a POST request it does not work when `handleNodeRequest` tries to handle a GET request for a graphiql page.

2. Creates a hapi response that contains the `Readable` stream rather than directly returning a raw Readable stream.

Technically the previous implementation works it isn't how hapi response are usually formed. The previous implementation means that the headers are not returned in the response which results in `application/octet-stream` headers for GET request. (Meaning html page is just downloaded rather than rendered)

3. Updates documentation with the aforementioned fixes.