### PR TITLE
feat: Support NestJS `filter` function for subscriptions

### DIFF
--- a/.changeset/fluffy-queens-lick.md
+++ b/.changeset/fluffy-queens-lick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/nestjs': minor
+---
+
+Support for NestJS @Subscription.filter method in YogaDriver.

--- a/packages/nestjs/__tests__/fixtures/graphql/cats/cats.resolvers.ts
+++ b/packages/nestjs/__tests__/fixtures/graphql/cats/cats.resolvers.ts
@@ -53,4 +53,17 @@ export class CatsResolvers {
       yield { greetings: hi };
     }
   }
+
+  @Subscription('filteredGreetings', {
+    filter: (payload, variables) => {
+      return payload.filteredGreetings
+        .toLowerCase()
+        .startsWith(variables.firstLetter.toLowerCase());
+    },
+  })
+  async *filteredGreetings() {
+    for (const hi of ['Hi', 'Bonjour', 'Hola', 'Ciao', 'Zdravo']) {
+      yield { filteredGreetings: hi };
+    }
+  }
 }

--- a/packages/nestjs/__tests__/fixtures/graphql/cats/cats.types.graphql
+++ b/packages/nestjs/__tests__/fixtures/graphql/cats/cats.types.graphql
@@ -10,6 +10,7 @@ type Mutation {
 type Subscription {
   catCreated: Cat
   greetings: String
+  filteredGreetings(firstLetter: String!): String
 }
 
 type Cat {

--- a/packages/nestjs/__tests__/subscriptions.spec.ts
+++ b/packages/nestjs/__tests__/subscriptions.spec.ts
@@ -54,3 +54,33 @@ event: complete
 "
 `);
 });
+
+it("should execute Nest Subscription decorator's filter function on each emitted value", async () => {
+  const sub = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        subscription {
+          filteredGreetings(firstLetter: "H")
+        }
+      `,
+    }),
+  });
+
+  await expect(sub.text()).resolves.toMatchInlineSnapshot(`
+":
+
+event: next
+data: {"data":{"filteredGreetings":"Hi"}}
+
+event: next
+data: {"data":{"filteredGreetings":"Hola"}}
+
+event: complete
+
+"
+`);
+});


### PR DESCRIPTION
NestJS subscriptions' resolvers have a `filter` and a `resolve` function in the @Subscription decorator. Currently only the `resolve` is supported by the YogaDriver for NestJS.

This commit adds support for the `filter` method. The implementation is similar to NestJS Apollo plugin, but it uses Yoga's own async iterator utils (pipe, filter) instead of Apollo's utils.