### PR TITLE
feat: Implementing Conditional Schema Support in @graphql-yoga/nestjs

### DIFF
--- a/.changeset/old-wolves-arrive.md
+++ b/.changeset/old-wolves-arrive.md
@@ -2,4 +2,4 @@
 '@graphql-yoga/nestjs': minor
 ---
 
-Adding support of conditionalSchema option.
+Adding support of conditionalSchema option. (Currently without support for WebSocket subscriptions)

--- a/.changeset/old-wolves-arrive.md
+++ b/.changeset/old-wolves-arrive.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/nestjs': minor
+---
+
+Adding support of conditionalSchema option.

--- a/.changeset/red-lemons-prove.md
+++ b/.changeset/red-lemons-prove.md
@@ -2,4 +2,4 @@
 'graphql-yoga': minor
 ---
 
-Export YogaSchemaDefinition
+Export YogaSchemaDefinition and mergeSchemas

--- a/.changeset/red-lemons-prove.md
+++ b/.changeset/red-lemons-prove.md
@@ -1,0 +1,6 @@
+---
+'graphql-yoga': minor
+'@graphql-yoga/nestjs': minor
+---
+
+Adding support of conditionalSchema option.

--- a/.changeset/red-lemons-prove.md
+++ b/.changeset/red-lemons-prove.md
@@ -1,6 +1,5 @@
 ---
 'graphql-yoga': minor
-'@graphql-yoga/nestjs': minor
 ---
 
-Adding support of conditionalSchema option.
+Export YogaSchemaDefinition

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -12,6 +12,7 @@ export * from './types.js';
 export { maskError } from './utils/mask-error.js';
 export { type OnParamsEventPayload } from './plugins/types.js';
 export { createLRUCache } from './utils/create-lru-cache.js';
+export { mergeSchemas } from '@graphql-tools/schema';
 export {
   // Handy type utils
   type Maybe,

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -4,7 +4,7 @@ export { type Plugin } from './plugins/types.js';
 export { type GraphiQLOptions } from './plugins/use-graphiql.js';
 export { renderGraphiQL, shouldRenderGraphiQL } from './plugins/use-graphiql.js';
 export { useReadinessCheck } from './plugins/use-readiness-check.js';
-export { useSchema } from './plugins/use-schema.js';
+export { YogaSchemaDefinition, useSchema } from './plugins/use-schema.js';
 export * from './schema.js';
 export * from './server.js';
 export * from './subscription.js';

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -4,7 +4,7 @@ export { type Plugin } from './plugins/types.js';
 export { type GraphiQLOptions } from './plugins/use-graphiql.js';
 export { renderGraphiQL, shouldRenderGraphiQL } from './plugins/use-graphiql.js';
 export { useReadinessCheck } from './plugins/use-readiness-check.js';
-export { YogaSchemaDefinition, useSchema } from './plugins/use-schema.js';
+export { type YogaSchemaDefinition, useSchema } from './plugins/use-schema.js';
 export * from './schema.js';
 export * from './server.js';
 export * from './subscription.js';

--- a/packages/nestjs/__tests__/graphql.spec.ts
+++ b/packages/nestjs/__tests__/graphql.spec.ts
@@ -1,3 +1,11 @@
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from 'graphql';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { fetch } from '@whatwg-node/fetch';
@@ -7,7 +15,44 @@ let app: INestApplication, url: string;
 
 beforeAll(async () => {
   const module = await Test.createTestingModule({
-    imports: [AppModule.forRoot()],
+    imports: [
+      AppModule.forRoot({
+        conditionalSchema: async () => {
+          const DogObjectType = new GraphQLObjectType({
+            name: 'Dog',
+            fields: {
+              id: {
+                type: new GraphQLNonNull(GraphQLID),
+              },
+              name: {
+                type: new GraphQLNonNull(GraphQLString),
+              },
+              breed: {
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+          });
+
+          return new GraphQLSchema({
+            query: new GraphQLObjectType({
+              name: 'Query',
+              fields: {
+                getDogs: {
+                  type: new GraphQLList(new GraphQLNonNull(DogObjectType)),
+                  resolve: () => [
+                    {
+                      id: '1',
+                      name: 'Bingo',
+                      breed: 'Dalmatian',
+                    },
+                  ],
+                },
+              },
+            }),
+          });
+        },
+      }),
+    ],
   }).compile();
   app = module.createNestApplication();
   await app.listen(0);
@@ -42,6 +87,39 @@ it('should return query result', async () => {
             "color": "black",
             "id": 1,
             "weight": 5,
+          },
+        ],
+      },
+    }
+  `);
+});
+
+it('should return query result for conditional schema', async () => {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        {
+          getDogs {
+            id
+            name
+            breed
+          }
+        }
+      `,
+    }),
+  });
+  await expect(res.json()).resolves.toMatchInlineSnapshot(`
+    {
+      "data": {
+        "getDogs": [
+          {
+            "breed": "Dalmatian",
+            "id": "1",
+            "name": "Bingo",
           },
         ],
       },

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -51,6 +51,9 @@
     "graphql": "^15.0.0 || ^16.0.0",
     "graphql-yoga": "^5.0.2"
   },
+  "dependencies": {
+    "@graphql-tools/schema": "^10.0.0"
+  },
   "devDependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -51,9 +51,6 @@
     "graphql": "^15.0.0 || ^16.0.0",
     "graphql-yoga": "^5.0.2"
   },
-  "dependencies": {
-    "@graphql-tools/schema": "^10.0.0"
-  },
   "devDependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -4,10 +4,8 @@ import { GraphQLSchema, printSchema } from 'graphql';
 import {
   createYoga,
   filter,
-  GraphQLSchemaWithContext,
   pipe,
-  PromiseOrValue,
-  YogaInitialContext,
+  YogaSchemaDefinition,
   YogaServerInstance,
   YogaServerOptions,
 } from 'graphql-yoga';
@@ -20,12 +18,6 @@ import {
   GqlSubscriptionService,
   SubscriptionConfig,
 } from '@nestjs/graphql';
-
-export type YogaSchemaDefinition<TContext> =
-  | PromiseOrValue<GraphQLSchemaWithContext<TContext>>
-  | ((
-      context: TContext & YogaInitialContext,
-    ) => PromiseOrValue<GraphQLSchemaWithContext<TContext>>);
 
 export type YogaDriverPlatform = 'express' | 'fastify';
 
@@ -44,7 +36,7 @@ export type YogaDriverServerOptions<Platform extends YogaDriverPlatform> = Omit<
   YogaServerOptions<YogaDriverServerContext<Platform>, never>,
   'context' | 'schema'
 > & {
-  conditionalSchema?: YogaSchemaDefinition<YogaDriverServerContext<Platform>> | undefined;
+  conditionalSchema?: YogaSchemaDefinition<YogaDriverServerContext<Platform>, never> | undefined;
 };
 
 export type YogaDriverServerInstance<Platform extends YogaDriverPlatform> = YogaServerInstance<

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -4,13 +4,13 @@ import { GraphQLSchema, printSchema } from 'graphql';
 import {
   createYoga,
   filter,
+  mergeSchemas,
   pipe,
   YogaSchemaDefinition,
   YogaServerInstance,
   YogaServerOptions,
 } from 'graphql-yoga';
 import type { ExecutionParams } from 'subscriptions-transport-ws';
-import { mergeSchemas } from '@graphql-tools/schema';
 import { Injectable, Logger } from '@nestjs/common';
 import {
   AbstractGraphQLDriver,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1669,6 +1669,10 @@ importers:
     publishDirectory: dist
 
   packages/nestjs:
+    dependencies:
+      '@graphql-tools/schema':
+        specifier: ^10.0.0
+        version: 10.0.0(graphql@16.6.0)
     devDependencies:
       '@nestjs/common':
         specifier: ^10.0.0
@@ -8266,7 +8270,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/merge': 9.0.0(graphql@16.6.0)
-      '@graphql-tools/utils': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.3
       value-or-promise: 1.0.12
@@ -21996,7 +22000,7 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-tools/schema': 9.0.17(graphql@16.6.0)
+      '@graphql-tools/schema': 9.0.19(graphql@16.6.0)
       '@graphql-tools/wrap': 9.3.8(graphql@16.6.0)
       '@graphql-typed-document-node/core': 3.1.2(graphql@16.6.0)
       graphql: 16.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1669,14 +1669,10 @@ importers:
     publishDirectory: dist
 
   packages/nestjs:
-    dependencies:
-      '@graphql-tools/schema':
-        specifier: ^10.0.0
-        version: 10.0.0(graphql@16.6.0)
     devDependencies:
       '@nestjs/common':
         specifier: ^10.0.0
-        version: 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+        version: 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core':
         specifier: ^10.0.0
         version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
@@ -9766,6 +9762,26 @@ packages:
       uid: 2.0.2
     dev: true
 
+  /@nestjs/common@10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0):
+    resolution: {integrity: sha512-Fa2GDQJrO5TTTcpISWfm0pdPS62V+8YbxeG5CA01zMUI+dCO3v3oFf+BSjqCGUUo7GDNzDsjAejwGXuqA54RPw==}
+    peerDependencies:
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      iterare: 1.2.1
+      reflect-metadata: 0.1.13
+      rxjs: 7.8.0
+      tslib: 2.5.3
+      uid: 2.0.2
+    dev: true
+
   /@nestjs/common@10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1):
     resolution: {integrity: sha512-Fa2GDQJrO5TTTcpISWfm0pdPS62V+8YbxeG5CA01zMUI+dCO3v3oFf+BSjqCGUUo7GDNzDsjAejwGXuqA54RPw==}
     peerDependencies:
@@ -9837,7 +9853,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -9998,9 +10014,9 @@ packages:
       '@graphql-tools/merge': 9.0.0(graphql@16.6.0)
       '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
-      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
       chokidar: 3.5.3
       fast-glob: 3.2.12
       graphql: 16.6.0
@@ -10034,6 +10050,23 @@ packages:
       '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       class-transformer: 0.5.1
       class-validator: 0.14.0
+      reflect-metadata: 0.1.13
+    dev: true
+
+  /@nestjs/mapped-types@1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13):
+    resolution: {integrity: sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.8 || ^8.0.0 || ^9.0.0
+      class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0
+      class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       reflect-metadata: 0.1.13
     dev: true
 
@@ -10094,7 +10127,7 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       body-parser: 1.20.2
       cors: 2.8.5
@@ -10121,7 +10154,7 @@ packages:
       '@fastify/cors': 8.3.0
       '@fastify/formbody': 7.4.0
       '@fastify/middie': 8.3.0
-      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       fastify: 4.18.0
       light-my-request: 5.10.0
@@ -10177,7 +10210,7 @@ packages:
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       tslib: 2.5.3
@@ -15623,7 +15656,7 @@ packages:
     resolution: {integrity: sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==}
     dependencies:
       archy: 1.0.0
-      debug: 4.3.4(supports-color@9.2.3)
+      debug: 4.3.4
       fastq: 1.13.0
     transitivePeerDependencies:
       - supports-color
@@ -15632,7 +15665,7 @@ packages:
     resolution: {integrity: sha512-TAlMYvOuwGyLK3PfBb5WKBXZmXz2fVCgv23d6zZFdle/q3gPjmxBaeuC0pY0Dzs5PWMSgfqqEZkrye19GlDTgw==}
     dependencies:
       archy: 1.0.0
-      debug: 4.3.4(supports-color@9.2.3)
+      debug: 4.3.4
       fastq: 1.13.0
     transitivePeerDependencies:
       - supports-color
@@ -18345,6 +18378,17 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@9.2.3):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}


### PR DESCRIPTION
### Problem
In the current implementation of graphql-yoga, users have the flexibility to pass a function to the schema property, facilitating the setup of a conditional schema. Unfortunately, this functionality is not mirrored in the @graphql-yoga/nestjs package, creating a limitation when working with frameworks like Nest.JS, which appears to have restricted support for conditional schemas in the GraphQLModule.

At [Twenty](https://github.com/twentyhq/twenty), we have a specific requirement to determine schemas dynamically based on the tenant to [enable custom objects for our customers](https://github.com/twentyhq/twenty/discussions/1142). The absence of this feature in the @graphql-yoga/nestjs package hinders our ability to provide a more personalized and scalable service.

### Solution
To bridge this gap, I have introduced a new option called conditionalSchema. This option allows for the merging of conditional schema directives with the existing schema property, thereby enhancing flexibility and functionality. This enhancement not only preserves the autoSchemaFile option but also introduces the possibility to incorporate conditional schemas within the generated ones.

Changes Made:
- Introduced a conditionalSchema option in the @graphql-yoga/nestjs package.
- Ensured compatibility with the existing schema property.
- Facilitated the integration of conditional schema elements within generated schemas.

### Request for Feedback
I'm requiring your feedback on this implementation. Specifically, I am keen to understand potential edge cases or concerns that might arise with this enhancement.