### PR TITLE
[response-cache] update @envelop/response-cache with support of scope, defer and stream

### DIFF
--- a/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-yoga/plugin-response-cache': patch
+---
+dependencies updates:
+  - Updated dependency [`@envelop/response-cache@5.3.0-alpha-20230908121255-f3c216b2`
+    ↗︎](https://www.npmjs.com/package/@envelop/response-cache/v/5.3.0) (from `^5.1.0`, in
+    `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
@@ -2,6 +2,6 @@
 '@graphql-yoga/plugin-response-cache': patch
 ---
 dependencies updates:
-  - Updated dependency [`@envelop/response-cache@5.3.0-alpha-20230908123930-b9f3fef4`
+  - Updated dependency [`@envelop/response-cache@5.3.0`
     ↗︎](https://www.npmjs.com/package/@envelop/response-cache/v/5.3.0) (from `^5.1.0`, in
     `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
@@ -2,6 +2,6 @@
 '@graphql-yoga/plugin-response-cache': patch
 ---
 dependencies updates:
-  - Updated dependency [`@envelop/response-cache@5.3.0`
+  - Updated dependency [`@envelop/response-cache@^5.3.0`
     ↗︎](https://www.npmjs.com/package/@envelop/response-cache/v/5.3.0) (from `^5.1.0`, in
     `dependencies`)

--- a/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-response-cache-2993-dependencies.md
@@ -2,6 +2,6 @@
 '@graphql-yoga/plugin-response-cache': patch
 ---
 dependencies updates:
-  - Updated dependency [`@envelop/response-cache@5.3.0-alpha-20230908121255-f3c216b2`
+  - Updated dependency [`@envelop/response-cache@5.3.0-alpha-20230908123930-b9f3fef4`
     ↗︎](https://www.npmjs.com/package/@envelop/response-cache/v/5.3.0) (from `^5.1.0`, in
     `dependencies`)

--- a/.changeset/curly-walls-pretend.md
+++ b/.changeset/curly-walls-pretend.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-response-cache': minor
+---
+
+support @cacheControl(scope: CacheControlScope), allowing to reinforce cache depending on session

--- a/.changeset/curly-walls-pretend.md
+++ b/.changeset/curly-walls-pretend.md
@@ -2,4 +2,4 @@
 '@graphql-yoga/plugin-response-cache': minor
 ---
 
-support @cacheControl(scope: CacheControlScope), allowing to reinforce cache depending on session
+support @cacheControl(scope: CacheControlScope), allowing to enforce cache depending on session

--- a/.changeset/fifty-drinks-judge.md
+++ b/.changeset/fifty-drinks-judge.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-response-cache': minor
+---
+
+Add support for @stream and @defer directives

--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -1,5 +1,6 @@
 import { createSchema, createYoga } from 'graphql-yoga';
 import { cacheControlDirective } from '@envelop/response-cache';
+import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createInMemoryCache, useResponseCache } from '@graphql-yoga/plugin-response-cache';
 
 const schema = createSchema({
@@ -648,6 +649,129 @@ describe('should support scope', () => {
     expect(body).toMatchObject({
       data: {
         __typename: 'Query',
+      },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+  });
+});
+
+describe('should support async results', () => {
+  it('should cache queries using @stream', async () => {
+    const spy = jest.fn(async function* () {
+      yield 'first';
+      yield 'second';
+      await new Promise(process.nextTick);
+      yield 'third';
+    });
+
+    const yoga = createYoga({
+      schema: createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            streaming: [String]!
+          }
+        `,
+        resolvers: {
+          Query: {
+            streaming: spy,
+          },
+        },
+      }),
+      plugins: [
+        useDeferStream(),
+        useResponseCache({
+          session: () => null,
+          includeExtensionMetadata: true,
+        }),
+      ],
+    });
+    function fetch() {
+      return yoga.fetch('http://localhost:3000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ query: '{ streaming @stream }' }),
+      });
+    }
+
+    let response = await fetch();
+
+    expect(response.status).toEqual(200);
+    //wait for the response to be complete
+    await response.text();
+
+    response = await fetch();
+    expect(response.status).toEqual(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      data: {
+        streaming: ['first', 'second', 'third'],
+      },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+  });
+  it('should cache queries using @defer', async () => {
+    const spy = jest.fn(async function* () {
+      yield 'first';
+      yield 'second';
+      await new Promise(process.nextTick);
+      yield 'third';
+    });
+
+    const yoga = createYoga({
+      schema: createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            streaming: [String]!
+          }
+        `,
+        resolvers: {
+          Query: {
+            streaming: spy,
+          },
+        },
+      }),
+      plugins: [
+        useDeferStream(),
+        useResponseCache({
+          session: () => null,
+          includeExtensionMetadata: true,
+        }),
+      ],
+    });
+    function fetch() {
+      return yoga.fetch('http://localhost:3000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: '{ ... on Query @defer { streaming } }',
+        }),
+      });
+    }
+
+    let response = await fetch();
+
+    expect(response.status).toEqual(200);
+    //wait for the response to be complete
+    await response.text();
+
+    response = await fetch();
+    expect(response.status).toEqual(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      data: {
+        streaming: ['first', 'second', 'third'],
       },
       extensions: {
         responseCache: {

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -47,7 +47,7 @@
     "graphql-yoga": "^4.0.4"
   },
   "dependencies": {
-    "@envelop/response-cache": "^5.1.0"
+    "@envelop/response-cache": "5.3.0-alpha-20230908121255-f3c216b2"
   },
   "devDependencies": {
     "graphql": "^16.6.0"

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -47,7 +47,7 @@
     "graphql-yoga": "^4.0.4"
   },
   "dependencies": {
-    "@envelop/response-cache": "5.3.0"
+    "@envelop/response-cache": "^5.3.0"
   },
   "devDependencies": {
     "graphql": "^16.6.0",

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -50,7 +50,8 @@
     "@envelop/response-cache": "5.3.0-alpha-20230908123930-b9f3fef4"
   },
   "devDependencies": {
-    "graphql": "^16.6.0"
+    "graphql": "^16.6.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "directory": "dist",

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -47,7 +47,7 @@
     "graphql-yoga": "^4.0.4"
   },
   "dependencies": {
-    "@envelop/response-cache": "5.3.0-alpha-20230908123930-b9f3fef4"
+    "@envelop/response-cache": "5.3.0"
   },
   "devDependencies": {
     "graphql": "^16.6.0",

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -47,7 +47,7 @@
     "graphql-yoga": "^4.0.4"
   },
   "dependencies": {
-    "@envelop/response-cache": "5.3.0-alpha-20230908121255-f3c216b2"
+    "@envelop/response-cache": "5.3.0-alpha-20230908123930-b9f3fef4"
   },
   "devDependencies": {
     "graphql": "^16.6.0"

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -7,6 +7,7 @@ import {
   createInMemoryCache as envelopCreateInMemoryCache,
   ResponseCacheExtensions as EnvelopResponseCacheExtensions,
   GetDocumentStringFunction,
+  resultWithMetadata,
   useResponseCache as useEnvelopResponseCache,
   UseResponseCacheParameter as UseEnvelopResponseCacheParameter,
 } from '@envelop/response-cache';
@@ -157,15 +158,7 @@ export function useResponseCache(options: UseResponseCacheParameter): Plugin {
         const cachedResponse = await cache.get(operationId);
         if (cachedResponse) {
           if (options.includeExtensionMetadata) {
-            setResult({
-              ...cachedResponse,
-              extensions: {
-                ...cachedResponse.extensions,
-                responseCache: {
-                  hit: true,
-                },
-              },
-            });
+            setResult(resultWithMetadata(cachedResponse, { hit: true }));
           } else {
             setResult(cachedResponse);
           }

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -13,7 +13,9 @@ import {
 } from '@envelop/response-cache';
 
 export type BuildResponseCacheKeyFunction = (
-  params: Omit<Parameters<EnvelopBuildResponseCacheKeyFunction>[0], 'context'>,
+  params: Omit<Parameters<EnvelopBuildResponseCacheKeyFunction>[0], 'context'> & {
+    request: Request;
+  },
 ) => ReturnType<EnvelopBuildResponseCacheKeyFunction>;
 
 export type UseResponseCacheParameter = Omit<
@@ -151,6 +153,7 @@ export function useResponseCache(options: UseResponseCacheParameter): Plugin {
         variableValues: params.variables,
         operationName: params.operationName,
         sessionId,
+        request,
       });
       operationIdByRequest.set(request, operationId);
       sessionByRequest.set(request, sessionId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1463,7 +1463,7 @@ importers:
         version: 1.0.0(@apollo/client@3.7.15)(graphql@16.6.0)
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
+        version: 1.0.0(graphql@16.6.0)
       graphql:
         specifier: ^15.2.0 || ^16.0.0
         version: 16.6.0
@@ -1483,7 +1483,7 @@ importers:
     dependencies:
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
+        version: 1.0.0(graphql@16.6.0)
       '@graphql-tools/executor-urql-exchange':
         specifier: ^1.0.0
         version: 1.0.0(@urql/core@4.0.10)(graphql@16.6.0)(wonka@6.3.2)
@@ -1545,7 +1545,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.0
-        version: 8.0.0(@types/node@18.16.16)(graphql@16.6.0)
+        version: 8.0.0(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@0.20.2)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -1841,7 +1841,7 @@ importers:
     devDependencies:
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
+        version: 1.0.0(graphql@16.6.0)
       '@whatwg-node/fetch':
         specifier: ^0.9.7
         version: 0.9.12
@@ -1940,7 +1940,7 @@ importers:
   packages/plugins/response-cache:
     dependencies:
       '@envelop/response-cache':
-        specifier: 5.3.0
+        specifier: ^5.3.0
         version: 5.3.0(@envelop/core@4.0.1)(graphql@16.6.0)
       graphql-yoga:
         specifier: ^4.0.4
@@ -8004,6 +8004,25 @@ packages:
       extract-files: 11.0.0
       graphql: 16.6.0
       meros: 1.2.1(@types/node@18.16.16)
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@graphql-tools/executor-http@1.0.0(graphql@16.6.0):
+    resolution: {integrity: sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@repeaterjs/repeater': 3.0.4
+      '@whatwg-node/fetch': 0.9.12
+      dset: 3.1.2
+      extract-files: 11.0.0
+      graphql: 16.6.0
+      meros: 1.2.1(@types/node@18.16.16)
       tslib: 2.5.3
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -8336,6 +8355,34 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: true
+
+  /@graphql-tools/url-loader@8.0.0(graphql@16.6.0):
+    resolution: {integrity: sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/sync-fetch': 0.0.1
+      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-http': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
+      '@types/ws': 8.5.4
+      '@whatwg-node/fetch': 0.9.12
+      graphql: 16.6.0
+      isomorphic-ws: 5.0.0(ws@8.13.0)
+      tslib: 2.5.3
+      value-or-promise: 1.0.12
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1463,7 +1463,7 @@ importers:
         version: 1.0.0(@apollo/client@3.7.15)(graphql@16.6.0)
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(graphql@16.6.0)
+        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
       graphql:
         specifier: ^15.2.0 || ^16.0.0
         version: 16.6.0
@@ -1483,7 +1483,7 @@ importers:
     dependencies:
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(graphql@16.6.0)
+        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/executor-urql-exchange':
         specifier: ^1.0.0
         version: 1.0.0(@urql/core@4.0.10)(graphql@16.6.0)(wonka@6.3.2)
@@ -1545,7 +1545,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.0
-        version: 8.0.0(graphql@16.6.0)
+        version: 8.0.0(@types/node@18.16.16)(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@0.20.2)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -1841,7 +1841,7 @@ importers:
     devDependencies:
       '@graphql-tools/executor-http':
         specifier: ^1.0.0
-        version: 1.0.0(graphql@16.6.0)
+        version: 1.0.0(@types/node@18.16.16)(graphql@16.6.0)
       '@whatwg-node/fetch':
         specifier: ^0.9.7
         version: 0.9.12
@@ -8004,25 +8004,6 @@ packages:
       extract-files: 11.0.0
       graphql: 16.6.0
       meros: 1.2.1(@types/node@18.16.16)
-      tslib: 2.6.2
-      value-or-promise: 1.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@graphql-tools/executor-http@1.0.0(graphql@16.6.0):
-    resolution: {integrity: sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
-      '@repeaterjs/repeater': 3.0.4
-      '@whatwg-node/fetch': 0.9.12
-      dset: 3.1.2
-      extract-files: 11.0.0
-      graphql: 16.6.0
-      meros: 1.2.1(@types/node@18.16.16)
       tslib: 2.5.3
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -8355,34 +8336,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: true
-
-  /@graphql-tools/url-loader@8.0.0(graphql@16.6.0):
-    resolution: {integrity: sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-http': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
-      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
-      '@types/ws': 8.5.4
-      '@whatwg-node/fetch': 0.9.12
-      graphql: 16.6.0
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.5.3
-      value-or-promise: 1.0.12
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,8 +1940,8 @@ importers:
   packages/plugins/response-cache:
     dependencies:
       '@envelop/response-cache':
-        specifier: ^5.1.0
-        version: 5.1.0(@envelop/core@4.0.0)(graphql@16.6.0)
+        specifier: 5.3.0-alpha-20230908121255-f3c216b2
+        version: 5.3.0-alpha-20230908121255-f3c216b2(@envelop/core@4.0.1)(graphql@16.6.0)
       graphql-yoga:
         specifier: ^4.0.4
         version: link:../../graphql-yoga/dist
@@ -6744,15 +6744,15 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@envelop/response-cache@5.1.0(@envelop/core@4.0.0)(graphql@16.6.0):
-    resolution: {integrity: sha512-G81MF9XCQdmyZWgTkZa09rBusXNXhvjPMDjP4cfOpr8g1DEvEsxskEGT08f22hvl9Fg+G2wlVXBsHPLEr798Lg==}
+  /@envelop/response-cache@5.3.0-alpha-20230908121255-f3c216b2(@envelop/core@4.0.1)(graphql@16.6.0):
+    resolution: {integrity: sha512-iILikdZJ/g3DAM85fmIoAz26Vuw/tTkFFo+yh/cJDBB54HDibbct8nyUXX00nycIqImsEDtgdAfp3WfKH9/o6w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@envelop/core': ^4.0.0
+      '@envelop/core': ^4.0.1
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@envelop/core': 4.0.0
-      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@envelop/core': 4.0.1
+      '@graphql-tools/utils': 10.0.6(graphql@16.6.0)
       '@whatwg-node/fetch': 0.9.12
       fast-json-stable-stringify: 2.1.0
       graphql: 16.6.0
@@ -8353,6 +8353,18 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.3
+
+  /@graphql-tools/utils@10.0.6(graphql@16.6.0):
+    resolution: {integrity: sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
+      dset: 3.1.2
+      graphql: 16.6.0
+      tslib: 2.5.3
+    dev: false
 
   /@graphql-tools/utils@8.13.1(graphql@16.6.0):
     resolution: {integrity: sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,8 +1940,8 @@ importers:
   packages/plugins/response-cache:
     dependencies:
       '@envelop/response-cache':
-        specifier: 5.3.0-alpha-20230908121255-f3c216b2
-        version: 5.3.0-alpha-20230908121255-f3c216b2(@envelop/core@4.0.1)(graphql@16.6.0)
+        specifier: 5.3.0-alpha-20230908123930-b9f3fef4
+        version: 5.3.0-alpha-20230908123930-b9f3fef4(@envelop/core@4.0.1)(graphql@16.6.0)
       graphql-yoga:
         specifier: ^4.0.4
         version: link:../../graphql-yoga/dist
@@ -6744,8 +6744,8 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@envelop/response-cache@5.3.0-alpha-20230908121255-f3c216b2(@envelop/core@4.0.1)(graphql@16.6.0):
-    resolution: {integrity: sha512-iILikdZJ/g3DAM85fmIoAz26Vuw/tTkFFo+yh/cJDBB54HDibbct8nyUXX00nycIqImsEDtgdAfp3WfKH9/o6w==}
+  /@envelop/response-cache@5.3.0-alpha-20230908123930-b9f3fef4(@envelop/core@4.0.1)(graphql@16.6.0):
+    resolution: {integrity: sha512-CYzqN0+QTTZ7+KpRhxenb3wcOydcTDfH6daWLEUj3FSTdLWDnIGaHfnqiLdvgrQV2jVn+tioCkQnzVkvCrvwvA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@envelop/core': ^4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1949,6 +1949,9 @@ importers:
       graphql:
         specifier: 16.6.0
         version: 16.6.0
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
     publishDirectory: dist
 
   packages/plugins/sofa:
@@ -3657,7 +3660,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3700,7 +3703,7 @@ packages:
       '@aws-sdk/util-utf8': 3.310.0
       '@smithy/protocol-http': 1.0.1
       '@smithy/types': 1.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3742,7 +3745,7 @@ packages:
       '@aws-sdk/util-utf8': 3.310.0
       '@smithy/protocol-http': 1.0.1
       '@smithy/types': 1.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3784,7 +3787,7 @@ packages:
       '@aws-sdk/util-utf8': 3.310.0
       '@smithy/protocol-http': 1.0.1
       '@smithy/types': 1.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3830,7 +3833,7 @@ packages:
       '@smithy/protocol-http': 1.0.1
       '@smithy/types': 1.0.0
       fast-xml-parser: 4.1.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3843,7 +3846,7 @@ packages:
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-config-provider': 3.310.0
       '@aws-sdk/util-middleware': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3854,7 +3857,7 @@ packages:
       '@aws-sdk/client-cognito-identity': 3.341.0
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3866,7 +3869,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3878,7 +3881,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/url-parser': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3894,7 +3897,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3913,7 +3916,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3926,7 +3929,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3939,7 +3942,7 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/token-providers': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3951,7 +3954,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3973,7 +3976,7 @@ packages:
       '@aws-sdk/credential-provider-web-identity': 3.341.0
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -3986,7 +3989,7 @@ packages:
       '@aws-sdk/querystring-builder': 3.341.0
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-base64': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -3997,7 +4000,7 @@ packages:
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-buffer-from': 3.310.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4005,7 +4008,7 @@ packages:
     resolution: {integrity: sha512-1GNk+J/Q76bzuj27OqPOqTmFGEYXtyB02afn0cIeadDf0qbjo3G7qkRd3jrJrBIdHNg+DYbBYEHfFB5EuK1s8g==}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4013,7 +4016,7 @@ packages:
     resolution: {integrity: sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4023,7 +4026,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4035,7 +4038,7 @@ packages:
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/url-parser': 3.341.0
       '@aws-sdk/util-middleware': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4045,7 +4048,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4054,7 +4057,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4064,7 +4067,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4077,7 +4080,7 @@ packages:
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-middleware': 3.341.0
       '@aws-sdk/util-retry': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       uuid: 8.3.2
     dev: true
     optional: true
@@ -4088,7 +4091,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-signing': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4097,7 +4100,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4110,7 +4113,7 @@ packages:
       '@aws-sdk/signature-v4': 3.341.0
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-middleware': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4118,7 +4121,7 @@ packages:
     resolution: {integrity: sha512-pBAN9T4tBSHp7gJKu0Ma0MepZqP3GvecEh7eZWwTrJrRMgY1k8M1zpUOXBFG6EVRzVdyy7A4DWSuD4kcXE+BIw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4129,7 +4132,7 @@ packages:
       '@aws-sdk/protocol-http': 3.341.0
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-endpoints': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4140,7 +4143,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4152,7 +4155,7 @@ packages:
       '@aws-sdk/protocol-http': 3.341.0
       '@aws-sdk/querystring-builder': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4161,7 +4164,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4170,7 +4173,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4180,7 +4183,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.341.0
       '@aws-sdk/util-uri-escape': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4189,7 +4192,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4204,7 +4207,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4218,7 +4221,7 @@ packages:
       '@aws-sdk/util-middleware': 3.341.0
       '@aws-sdk/util-uri-escape': 3.310.0
       '@aws-sdk/util-utf8': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4228,7 +4231,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-stack': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4240,7 +4243,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/shared-ini-file-loader': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -4250,7 +4253,7 @@ packages:
     resolution: {integrity: sha512-2KJf64BhJly/Ty35oWKlCElIqUP4kQ0LA+meSrgAmwl7oE0AYuO7V0ar1nsTGlsubYkLRvOuEhMcuNuumaUdoQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4259,7 +4262,7 @@ packages:
     dependencies:
       '@aws-sdk/querystring-parser': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4268,14 +4271,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/util-buffer-from': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
   /@aws-sdk/util-body-length-browser@3.310.0:
     resolution: {integrity: sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4283,7 +4286,7 @@ packages:
     resolution: {integrity: sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4292,7 +4295,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/is-array-buffer': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4300,7 +4303,7 @@ packages:
     resolution: {integrity: sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4311,7 +4314,7 @@ packages:
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
       bowser: 2.11.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4324,7 +4327,7 @@ packages:
       '@aws-sdk/node-config-provider': 3.341.0
       '@aws-sdk/property-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4333,7 +4336,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4341,7 +4344,7 @@ packages:
     resolution: {integrity: sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4349,7 +4352,7 @@ packages:
     resolution: {integrity: sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4357,7 +4360,7 @@ packages:
     resolution: {integrity: sha512-JsuZGZw9pMYMHzaJW31Y3Zl1Dh/R2PNVxnlQPsPy37RhHoSLPZ6wR9G828Y1ZY2thBpR+DU3D/VfNJOxBmWGkw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4366,7 +4369,7 @@ packages:
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@aws-sdk/service-error-classification': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4374,7 +4377,7 @@ packages:
     resolution: {integrity: sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4383,7 +4386,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.341.0
       bowser: 2.11.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4398,14 +4401,14 @@ packages:
     dependencies:
       '@aws-sdk/node-config-provider': 3.341.0
       '@aws-sdk/types': 3.341.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
   /@aws-sdk/util-utf8-browser@3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4414,7 +4417,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/util-buffer-from': 3.310.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -4422,7 +4425,7 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/core-auth@1.4.0:
@@ -4430,7 +4433,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/core-client@1.6.1:
@@ -4443,7 +4446,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4465,14 +4468,14 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/logger': 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/core-paging@1.3.0:
     resolution: {integrity: sha512-H6Tg9eBm0brHqLy0OSAGzxIh1t4UL8eZVrSUMJ60Ra9cwq2pOskFqVpz2pYoHDsBY1jZ4V/P8LRGb5D5pmC6rg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/core-rest-pipeline@1.9.2:
@@ -4487,7 +4490,7 @@ packages:
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1(supports-color@9.2.3)
-      tslib: 2.5.3
+      tslib: 2.6.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -4497,7 +4500,7 @@ packages:
     resolution: {integrity: sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/core-util@1.1.1:
@@ -4505,7 +4508,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/functions@4.0.0:
@@ -4534,7 +4537,7 @@ packages:
       jws: 4.0.0
       open: 8.4.0
       stoppable: 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -4554,7 +4557,7 @@ packages:
       '@azure/core-tracing': 1.0.1
       '@azure/core-util': 1.1.1
       '@azure/logger': 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4563,7 +4566,7 @@ packages:
     resolution: {integrity: sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@azure/msal-browser@2.30.0:
@@ -4615,7 +4618,7 @@ packages:
       debug: 4.3.4(supports-color@9.2.3)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6606,7 +6609,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@envelop/types': 4.0.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@envelop/disable-introspection@5.0.1(@envelop/core@4.0.0)(graphql@16.6.0):
@@ -6631,7 +6634,7 @@ packages:
       '@envelop/core': 4.0.1
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@envelop/generic-auth@6.0.1(@envelop/core@4.0.1)(graphql@16.6.0):
@@ -6757,20 +6760,20 @@ packages:
       fast-json-stable-stringify: 2.1.0
       graphql: 16.6.0
       lru-cache: 10.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@envelop/types@4.0.0:
     resolution: {integrity: sha512-dmBK16VVfKCkqYYemvE+gt1cPBP0d9CbYO4yjNhSSYy9K+w6+Lw48wOLK238mSR339PNAvwj/JW/qzNy2llggA==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@envelop/types@4.0.1:
     resolution: {integrity: sha512-ULo27/doEsP7uUhm2iTnElx13qTO6I5FKvmLoX41cpfuw8x6e0NUFknoqhEsLzAbgz8xVS5mjwcxGCXh4lDYzg==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@esbuild-kit/cjs-loader@2.4.2:
@@ -7470,7 +7473,7 @@ packages:
     resolution: {integrity: sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==}
     dependencies:
       '@firebase/util': 1.9.3
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@firebase/database-compat@0.3.4:
     resolution: {integrity: sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==}
@@ -7480,7 +7483,7 @@ packages:
       '@firebase/database-types': 0.10.4
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@firebase/database-types@0.10.4:
     resolution: {integrity: sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==}
@@ -7496,17 +7499,17 @@ packages:
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       faye-websocket: 0.11.4
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@firebase/logger@0.4.0:
     resolution: {integrity: sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@firebase/util@1.9.3:
     resolution: {integrity: sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -7881,7 +7884,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@whatwg-node/fetch': 0.9.12
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -7894,7 +7897,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       dataloader: 2.2.2
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -7907,7 +7910,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       dataloader: 2.2.2
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
 
   /@graphql-tools/code-file-loader@8.0.0(@babel/core@7.22.1)(graphql@16.6.0):
@@ -7920,7 +7923,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       globby: 11.1.0
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       unixify: 1.0.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -7939,7 +7942,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       dataloader: 2.2.2
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
 
   /@graphql-tools/delegate@9.0.28(graphql@16.6.0):
@@ -7953,7 +7956,7 @@ packages:
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       dataloader: 2.2.2
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -7982,7 +7985,7 @@ packages:
       graphql: 16.6.0
       graphql-ws: 5.13.1(graphql@16.6.0)
       isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
       ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
@@ -8016,7 +8019,7 @@ packages:
       '@types/ws': 8.5.4
       graphql: 16.6.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
       ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
@@ -8046,7 +8049,7 @@ packages:
       '@graphql-typed-document-node/core': 3.1.2(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.4
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -8074,7 +8077,7 @@ packages:
       graphql: 16.6.0
       is-glob: 4.0.3
       micromatch: 4.0.5
-      tslib: 2.5.3
+      tslib: 2.6.2
       unixify: 1.0.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -8093,7 +8096,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@whatwg-node/fetch': 0.9.12
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@babel/core'
@@ -8112,7 +8115,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       globby: 11.1.0
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       unixify: 1.0.0
     dev: true
 
@@ -8128,7 +8131,7 @@ packages:
       '@babel/types': 7.22.15
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8143,7 +8146,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
       resolve-from: 5.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@graphql-tools/json-file-loader@8.0.0(graphql@16.6.0):
@@ -8155,7 +8158,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       globby: 11.1.0
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       unixify: 1.0.0
     dev: true
 
@@ -8181,7 +8184,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
       p-limit: 3.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@graphql-tools/merge@8.4.0(graphql@16.6.0):
@@ -8191,7 +8194,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@graphql-tools/merge@8.4.2(graphql@16.6.0):
@@ -8201,7 +8204,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@graphql-tools/merge@9.0.0(graphql@16.6.0):
@@ -8212,7 +8215,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@graphql-tools/optimize@2.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
@@ -8221,7 +8224,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@graphql-tools/prisma-loader@8.0.0(@types/node@18.16.16)(graphql@16.6.0):
@@ -8247,7 +8250,7 @@ packages:
       json-stable-stringify: 1.0.1
       lodash: 4.17.21
       scuid: 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
       - '@types/node'
@@ -8266,7 +8269,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8292,7 +8295,7 @@ packages:
       '@graphql-tools/merge': 8.4.0(graphql@16.6.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -8304,7 +8307,7 @@ packages:
       '@graphql-tools/merge': 8.4.2(graphql@16.6.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -8342,7 +8345,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@graphql-tools/utils@10.0.1(graphql@16.6.0):
     resolution: {integrity: sha512-i1FozbDGHgdsFA47V/JvQZ0FE8NAy0Eiz7HGCJO2MkNdZAKNnwei66gOq0JWYVFztwpwbVQ09GkKhq7Kjcq5Cw==}
@@ -8352,7 +8355,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@graphql-tools/utils@10.0.6(graphql@16.6.0):
     resolution: {integrity: sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==}
@@ -8363,7 +8366,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       dset: 3.1.2
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@graphql-tools/utils@8.13.1(graphql@16.6.0):
@@ -8372,7 +8375,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@graphql-tools/utils@9.2.1(graphql@16.6.0):
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
@@ -8381,7 +8384,7 @@ packages:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@graphql-tools/wrap@10.0.0(graphql@16.6.0):
@@ -8394,7 +8397,7 @@ packages:
       '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
 
   /@graphql-tools/wrap@9.3.8(graphql@16.6.0):
@@ -8406,7 +8409,7 @@ packages:
       '@graphql-tools/schema': 9.0.17(graphql@16.6.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     dev: false
 
@@ -9892,7 +9895,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
       chokidar: 3.5.3
       fast-glob: 3.2.12
       graphql: 16.6.0
@@ -9983,7 +9986,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
       chokidar: 3.5.3
       fast-glob: 3.2.12
       graphql: 16.6.0
@@ -10017,6 +10020,23 @@ packages:
       '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       class-transformer: 0.5.1
       class-validator: 0.14.0
+      reflect-metadata: 0.1.13
+    dev: true
+
+  /@nestjs/mapped-types@1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13):
+    resolution: {integrity: sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.8 || ^8.0.0 || ^9.0.0
+      class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0
+      class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
       reflect-metadata: 0.1.13
     dev: true
 
@@ -11935,14 +11955,14 @@ packages:
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@peculiar/json-schema@1.1.12:
     resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@peculiar/webcrypto@1.4.3:
@@ -11952,7 +11972,7 @@ packages:
       '@peculiar/asn1-schema': 2.3.6
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.2
-      tslib: 2.5.3
+      tslib: 2.6.2
       webcrypto-core: 1.7.7
     dev: true
 
@@ -11972,7 +11992,7 @@ packages:
       open: 8.4.0
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@pnpm/network.ca-file@1.0.1:
     resolution: {integrity: sha512-gkINruT2KUhZLTaiHxwCOh1O4NVnFT0wLjWFBHmTz9vpKag/C/noIMJXBxFe4F0mYpUVX2puLwAieLYFg2NvoA==}
@@ -12618,7 +12638,7 @@ packages:
       '@reach/utils': 0.17.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/combobox@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12636,7 +12656,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/descendants@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12648,7 +12668,7 @@ packages:
       '@reach/utils': 0.17.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/dialog@0.17.0(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
@@ -12664,7 +12684,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-focus-lock: 2.9.1(@types/react@18.2.8)(react@18.2.0)
       react-remove-scroll: 2.5.5(@types/react@18.2.8)(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -12681,7 +12701,7 @@ packages:
       '@reach/utils': 0.17.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/listbox@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12710,7 +12730,7 @@ packages:
       '@xstate/fsm': 1.4.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/menu-button@0.17.0(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0):
@@ -12728,7 +12748,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/observe-rect@1.2.0:
@@ -12747,7 +12767,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 4.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/portal@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12760,7 +12780,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/rect@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12775,7 +12795,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/tooltip@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12793,7 +12813,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/utils@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12805,7 +12825,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tiny-warning: 1.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@reach/visually-hidden@0.17.0(react-dom@18.2.0)(react@18.2.0):
@@ -12817,7 +12837,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@repeaterjs/repeater@3.0.4:
@@ -12926,7 +12946,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 1.0.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -12934,7 +12954,7 @@ packages:
     resolution: {integrity: sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
     optional: true
 
@@ -13112,7 +13132,7 @@ packages:
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@szmarczak/http-timer@5.0.1:
@@ -14589,14 +14609,14 @@ packages:
     resolution: {integrity: sha512-Tw6r2flAHYeio6ivBrERhOzkgZGXJSP7tlJIeFQhkjaBiRBz9W1Gc8zs73aq7DKC3ZAGSOdl8jlF+LztSq98cg==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@whatwg-node/cookie-store@0.2.0:
     resolution: {integrity: sha512-eksorZxQubxicFIn36eBgAXswejlrQnCMsdmmvWi/6I43bn++4K3wP3CUMs+rHl5NNuPcupYsJR1O5S6ALJkkQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@whatwg-node/events@0.0.3:
@@ -14639,7 +14659,7 @@ packages:
       busboy: 1.6.0
       fast-querystring: 1.1.1
       fast-url-parser: 1.1.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@whatwg-node/node-fetch@0.4.0:
@@ -14650,7 +14670,7 @@ packages:
       busboy: 1.6.0
       fast-querystring: 1.1.1
       fast-url-parser: 1.1.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@whatwg-node/node-fetch@0.4.18:
@@ -14661,7 +14681,7 @@ packages:
       busboy: 1.6.0
       fast-querystring: 1.1.1
       fast-url-parser: 1.1.3
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.1):
     resolution: {integrity: sha512-o0MqK6H4Yhxht+J+cgZIpEhdb4SID1grFWfOiMdni3csNHBKZ+MKAFhxS+6wAJsarHN7BEZ0QMu4PG09Uwhr2g==}
@@ -14679,7 +14699,7 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       '@whatwg-node/fetch': 0.9.12
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /@whatwg-node/server@0.9.1:
@@ -14694,38 +14714,38 @@ packages:
     resolution: {integrity: sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@wry/context@0.7.3:
     resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@wry/equality@0.5.3:
     resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@wry/equality@0.5.6:
     resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@wry/trie@0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@wry/trie@0.4.3:
     resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /@xhmikosr/archive-type@6.0.1:
     resolution: {integrity: sha512-PB3NeJL8xARZt52yDBupK0dNPn8uIVQDe15qNehUpoeeLWCZyAOam4vGXnoZGz2N9D1VXtjievJuCsXam2TmbQ==}
@@ -15457,7 +15477,7 @@ packages:
     dependencies:
       pvtsutils: 1.3.2
       pvutils: 1.1.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /assert-plus@1.0.0:
@@ -15488,7 +15508,7 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /astral-regex@2.0.0:
@@ -16109,7 +16129,7 @@ packages:
       lodash.get: 4.4.2
       p-limit: 4.0.0
       resolve.exports: 2.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
       typescript: 5.1.6
       yargs: 17.7.2
       zod: 3.21.4
@@ -16571,7 +16591,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /camelcase-css@2.0.1:
@@ -16618,7 +16638,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
       upper-case-first: 2.0.2
     dev: true
 
@@ -16626,7 +16646,7 @@ packages:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
     dependencies:
       debug: 4.3.4(supports-color@9.2.3)
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16739,7 +16759,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /char-regex@1.0.2:
@@ -17459,7 +17479,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
       upper-case: 2.0.2
     dev: true
 
@@ -18710,7 +18730,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -19293,7 +19313,7 @@ packages:
       remark-parse: 10.0.1
       remark-stringify: 10.0.2
       synckit: 0.8.5
-      tslib: 2.5.3
+      tslib: 2.6.2
       unified: 10.1.2
       unified-engine: 10.1.0
       unist-util-visit: 4.1.2
@@ -19580,7 +19600,7 @@ packages:
       remark-mdx: 2.3.0
       remark-parse: 10.0.1
       remark-stringify: 10.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
       unified: 10.1.2
       vfile: 5.3.7
     transitivePeerDependencies:
@@ -20606,7 +20626,7 @@ packages:
       hotscript: 1.0.11
       json-schema-to-ts: 2.8.0
       openapi-types: 12.1.0
-      tslib: 2.5.3
+      tslib: 2.6.2
       zod: 3.22.2
       zod-to-json-schema: 3.21.0(zod@3.22.2)
     dev: false
@@ -20983,7 +21003,7 @@ packages:
     resolution: {integrity: sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /focus-trap-react@10.2.1(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
@@ -21898,7 +21918,7 @@ packages:
       jiti: 1.18.2
       minimatch: 4.2.3
       string-env-interpolation: 1.0.1
-      tslib: 2.5.3
+      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -22412,7 +22432,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /heap-js@2.2.0:
@@ -23254,7 +23274,7 @@ packages:
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /is-map@2.0.2:
@@ -23465,7 +23485,7 @@ packages:
   /is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /is-url-superb@4.0.0:
@@ -25525,13 +25545,13 @@ packages:
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
@@ -27773,7 +27793,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /node-abi@3.40.0:
     resolution: {integrity: sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==}
@@ -28367,7 +28387,7 @@ packages:
     dependencies:
       '@wry/context': 0.7.3
       '@wry/trie': 0.4.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /optionator@0.8.3:
@@ -28685,7 +28705,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -28801,7 +28821,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /pascalcase@0.1.1:
@@ -28820,7 +28840,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /path-dirname@1.0.2:
@@ -30046,7 +30066,7 @@ packages:
   /pvtsutils@1.3.2:
     resolution: {integrity: sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /pvutils@1.1.3:
@@ -30306,7 +30326,7 @@ packages:
       '@types/react': 18.2.8
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.8)(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.8)(react@18.2.0):
@@ -30323,7 +30343,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.4(@types/react@18.2.8)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.8)(react@18.2.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
       use-callback-ref: 1.3.0(@types/react@18.2.8)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.8)(react@18.2.0)
     dev: false
@@ -30342,7 +30362,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /react@18.2.0:
@@ -31143,7 +31163,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /sade@1.8.1:
@@ -31377,7 +31397,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
       upper-case-first: 2.0.2
     dev: true
 
@@ -31449,7 +31469,7 @@ packages:
     resolution: {integrity: sha512-MW/ZsCYTu11EIYYTSZcfAgMFszAodCmQVB27XssHoIN6L4EG0KSA3h32x8whaSOKuYBX5wz9EybfnPBUFQMCKA==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.6.2
     dev: true
 
   /sha.js@2.4.11:
@@ -31627,7 +31647,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /snapdragon-node@2.1.1:
@@ -31735,7 +31755,7 @@ packages:
       openapi-types: 12.1.0
       param-case: 3.0.4
       title-case: 3.0.3
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /sonic-boom@3.2.0:
@@ -31890,7 +31910,7 @@ packages:
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /sprintf-js@1.0.3:
@@ -32592,7 +32612,7 @@ packages:
   /swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /symbol-observable@1.2.0:
@@ -32609,7 +32629,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /tabbable@4.0.0:
     resolution: {integrity: sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==}
@@ -33043,7 +33063,7 @@ packages:
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /title@3.5.3:
     resolution: {integrity: sha512-20JyowYglSEeCvZv3EZ0nZ046vLarO37prvV0mbtQV7C8DJPGgN967r8SJkqd3XK3K3lD3/Iyfp3avjfil8Q2Q==}
@@ -33248,7 +33268,7 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
   /ts-jest@29.0.3(@babel/core@7.22.1)(babel-jest@29.2.0)(esbuild@0.16.3)(jest@29.2.0)(typescript@5.1.6):
     resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
@@ -33387,7 +33407,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.19
-      acorn: 8.8.2
+      acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -33490,9 +33510,8 @@ packages:
   /tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
-  /tslib@2.6.0:
-    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
-    dev: true
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -34114,13 +34133,13 @@ packages:
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /uri-js@4.4.1:
@@ -34176,7 +34195,7 @@ packages:
     dependencies:
       '@types/react': 18.2.8
       react: 18.2.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /use-debounce@9.0.4(react@18.2.0):
@@ -34201,7 +34220,7 @@ packages:
       '@types/react': 18.2.8
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: false
 
   /use-url-search-params@2.5.1(react@18.2.0):
@@ -34576,7 +34595,7 @@ packages:
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /webidl-conversions@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9895,7 +9895,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
       chokidar: 3.5.3
       fast-glob: 3.2.12
       graphql: 16.6.0
@@ -9986,7 +9986,7 @@ packages:
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
       chokidar: 3.5.3
       fast-glob: 3.2.12
       graphql: 16.6.0
@@ -10020,23 +10020,6 @@ packages:
       '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       class-transformer: 0.5.1
       class-validator: 0.14.0
-      reflect-metadata: 0.1.13
-    dev: true
-
-  /@nestjs/mapped-types@1.2.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13):
-    resolution: {integrity: sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==}
-    peerDependencies:
-      '@nestjs/common': ^7.0.8 || ^8.0.0 || ^9.0.0
-      class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0
-      class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0 || ^0.14.0
-      reflect-metadata: ^0.1.12
-    peerDependenciesMeta:
-      class-transformer:
-        optional: true
-      class-validator:
-        optional: true
-    dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
       reflect-metadata: 0.1.13
     dev: true
 
@@ -33407,7 +33390,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.19
-      acorn: 8.9.0
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,8 +1940,8 @@ importers:
   packages/plugins/response-cache:
     dependencies:
       '@envelop/response-cache':
-        specifier: 5.3.0-alpha-20230908123930-b9f3fef4
-        version: 5.3.0-alpha-20230908123930-b9f3fef4(@envelop/core@4.0.1)(graphql@16.6.0)
+        specifier: 5.3.0
+        version: 5.3.0(@envelop/core@4.0.1)(graphql@16.6.0)
       graphql-yoga:
         specifier: ^4.0.4
         version: link:../../graphql-yoga/dist
@@ -6747,8 +6747,8 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@envelop/response-cache@5.3.0-alpha-20230908123930-b9f3fef4(@envelop/core@4.0.1)(graphql@16.6.0):
-    resolution: {integrity: sha512-CYzqN0+QTTZ7+KpRhxenb3wcOydcTDfH6daWLEUj3FSTdLWDnIGaHfnqiLdvgrQV2jVn+tioCkQnzVkvCrvwvA==}
+  /@envelop/response-cache@5.3.0(@envelop/core@4.0.1)(graphql@16.6.0):
+    resolution: {integrity: sha512-v2zwHQmtnOEnNDgP7R8hSyeaO/diBkwOdJYKn7IRmEVuC/ziatUNfJMhkxK6pNAg/1teTk15iL+hjN8uqcWEQA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@envelop/core': ^4.0.1

--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -95,6 +95,47 @@ useResponseCache({
 })
 ```
 
+### Enforce session based caching
+
+In some cases, a type or a field should only be cached if their is a session. For this, you can use
+the `scope` to indicate that the cache should only be used if a session is present.
+
+```ts filename="Response Cache configuration with scope"
+useResponseCache({
+  // cache based on the authentication header
+  session: request => request.headers.get('authentication')
+
+  // You can use configuration object to define the scope
+  scopePerSchemaCoordinate: {
+    'Query.me': 'PRIVATE', // on a field
+    'User: 'PRIVATE', // or a type
+  }
+})
+```
+
+It is also possible to use the `@cacheControl` directive to define the scope.
+
+```ts filename="Response Cache configuration with scope using @cacheControl directive"
+import { cacheControlDirective } from '@graphql-yoga/plugin-response-cache'
+
+const typeDefs = /* GraphQL */ `
+  # the directive needs to be defined in the schema
+  ${cacheControlDirective}
+
+  type Query {
+    # cache operations selecting Query.lazy for 10 seconds
+    me: User @cacheControl(scope: PRIVATE)
+  }
+
+  type User @cacheControl(scope: PRIVATE) {
+    #...
+  }
+`
+```
+
+Any query containing a type or a field with the scope `PRIVATE` will only be cached if a session is
+present.
+
 ## Time to Live (TTL)
 
 It is possible to give cached operations a time to live. Either globally, based on

--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -97,7 +97,7 @@ useResponseCache({
 
 ### Enforce session based caching
 
-In some cases, a type or a field should only be cached if their is a session. For this, you can use
+In some cases, a type or a field should only be cached if there is a session. For this, you can use
 the `scope` to indicate that the cache should only be used if a session is present.
 
 ```ts filename="Response Cache configuration with scope"


### PR DESCRIPTION
Adds support for the `scope` feature from Apollo's response cache plugin.

This PR is updating the underlying envelop plugin and fixes a bug preventing Envelop plugin to detect the presence of a session or not.

Fixes #3021