### PR TITLE
docs: Update integration-with-deno.mdx

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-deno.mdx
+++ b/website/src/pages/docs/integrations/integration-with-deno.mdx
@@ -16,12 +16,12 @@ We will use `graphql-yoga` which has an agnostic HTTP handler using
 
 ## Example
 
-Create a `import_map.json` file.
+Create a `deno.json` file.
 [Learn more about import maps](https://deno.land/manual/basics/import_maps)
 
 Create a `deno-yoga.ts` file:
 
-```json filename="import_map.json" {3}
+```json filename="deno.json" {3}
 {
   "imports": {
     "graphql-yoga": "npm:graphql-yoga@^3.7.3"
@@ -58,7 +58,7 @@ serve(yoga, {
 And run it:
 
 ```bash
-deno run --allow-net --import-map ./import_map.json index.ts
+deno run --allow-net index.ts
 ```
 
 > You can also check a full example on our GitHub repository

--- a/website/src/pages/docs/integrations/integration-with-deno.mdx
+++ b/website/src/pages/docs/integrations/integration-with-deno.mdx
@@ -50,7 +50,7 @@ const yoga = createYoga({
 
 serve(yoga, {
   onListen({ hostname, port }) {
-    console.log(`Listening on http://${hostname}:${port}/${yoga.graphqlEndpoint}}`)
+    console.log(`Listening on http://${hostname}:${port}/${yoga.graphqlEndpoint}`)
   }
 })
 ```


### PR DESCRIPTION
Hi, I tried GraphQL Yoga with Deno runtime.

I found that we can define the import map in the `deno.json` file.
https://deno.land/manual@v1.36.4/basics/import_maps#import-maps

I have updated the documentation to align with the current Deno specifications.

And, I have ensured the code is working appropriately.
https://github.com/motoya-k/deno-blog-sample/tree/main/packages/api