### PR TITLE
[response-cache] Proposal: give access to the context in the params

### DIFF
--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -114,6 +114,8 @@ export interface OnParamsEventPayload {
   setParams: (params: GraphQLParams) => void;
   setResult: (result: ExecutionResult) => void;
   fetchAPI: FetchAPI;
+  context: YogaInitialContext;
+  extendContext: (partialContext: Record<string, unknown>) => void;
 }
 
 export type OnResultProcess = (payload: OnResultProcessEventPayload) => PromiseOrValue<void>;

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -16,7 +16,7 @@ export type UseResponseCacheParameter = Omit<
   'getDocumentString' | 'session' | 'cache' | 'enabled'
 > & {
   cache?: Cache;
-  session: (request: Request) => PromiseOrValue<Maybe<string>>;
+  session: (request: Request, context: YogaInitialContext) => PromiseOrValue<Maybe<string>>;
   enabled?: (request: Request) => boolean;
 };
 
@@ -129,12 +129,12 @@ export function useResponseCache(options: UseResponseCacheParameter): Plugin {
         }
       }
     },
-    async onParams({ params, request, setResult }) {
+    async onParams({ params, request, setResult, context }) {
       const operationId = await buildResponseCacheKey({
         documentString: params.query || '',
         variableValues: params.variables,
         operationName: params.operationName,
-        sessionId: await options.session(request),
+        sessionId: await options.session(request, context),
       });
       operationIdByRequest.set(request, operationId);
       if (enabled(request)) {


### PR DESCRIPTION
This proposal aims to give access to the context early in the request execution process, allowing access and extension in the params parsing phase.

As an example of usage, I've included a changement to the response-cache plugin to give access to the context in the session factory.

Fixes #2909 