### PR TITLE
feat: expose React in the window object

### DIFF
--- a/.changeset/wet-emus-bake.md
+++ b/.changeset/wet-emus-bake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/graphiql': minor 
+---
+
+make React available in the window object

--- a/packages/graphiql/src/bundle.tsx
+++ b/packages/graphiql/src/bundle.tsx
@@ -5,3 +5,5 @@ import { YogaGraphiQL, YogaGraphiQLProps } from './YogaGraphiQL.js';
 export function renderYogaGraphiQL(element: Element, opts?: YogaGraphiQLProps) {
   ReactDOM.render(<YogaGraphiQL {...opts} />, element);
 }
+
+globalThis.window.React = React;

--- a/packages/graphiql/src/bundle.tsx
+++ b/packages/graphiql/src/bundle.tsx
@@ -6,4 +6,4 @@ export function renderYogaGraphiQL(element: Element, opts?: YogaGraphiQLProps) {
   ReactDOM.render(<YogaGraphiQL {...opts} />, element);
 }
 
-globalThis.window.React = React;
+window.React = React;

--- a/packages/graphiql/src/bundle.tsx
+++ b/packages/graphiql/src/bundle.tsx
@@ -6,4 +6,4 @@ export function renderYogaGraphiQL(element: Element, opts?: YogaGraphiQLProps) {
   ReactDOM.render(<YogaGraphiQL {...opts} />, element);
 }
 
-window.React = React;
+globalThis.React = React;


### PR DESCRIPTION
we are already bundling `React` part of this package. I want to pass in the `logo` prop to customize the looks and just using HTML, this will make it so I don't have to improve `React` additionally from CDN I can just use it directly.