### PR TITLE
Nextjs example: Update to support CORS

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-nextjs.mdx
+++ b/website/src/pages/docs/integrations/integration-with-nextjs.mdx
@@ -43,7 +43,7 @@ const { handleRequest } = createYoga({
   fetchAPI: { Response }
 })
 
-export { handleRequest as GET, handleRequest as POST }
+export { handleRequest as GET, handleRequest as POST, handleRequest as OPTIONS }
 ```
 
 > You can also check a full example on our GitHub repository


### PR DESCRIPTION
This will solve that when you use the `cors` options, nextjs will pick up on the preflight request