### PR TITLE
(docs): Add documentation for Cloudflare KV cache

### DIFF
--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -273,8 +273,10 @@ cache.invalidate([
 
 By default, the response cache stores all the cached query results in memory.
 
-If you want a cache that is shared between multiple server instances you can use the Redis cache
-implementation, which is available as a separate package.
+If you want a cache that is shared between multiple server instances you can use one of many
+`envelop` plugins that provide a cache implementation for a specific cache provider.
+
+### Redis Cache
 
 <Callout>The Redis cache currently only works in Node.js environments.</Callout>
 
@@ -301,6 +303,54 @@ useResponseCache({
   session: () => null,
   cache
 })
+```
+
+### Cloudflare KV Cache
+
+<Callout>
+  The Cloudflare KV cache only works when running the graphql server on Cloudflare Workers.
+</Callout>
+
+```sh npm2yarn
+npm i @envelop/response-cache-cloudflare-kv
+```
+
+```ts filename="Use Graphql Yoga with Cloudflare KV Cache in Cloudflare Workers"
+import { createSchema, createYoga, YogaInitialContext } from 'graphql-yoga'
+import { useResponseCache } from '@envelop/response-cache'
+import { createKvCache } from '@envelop/response-cache-cloudflare-kv'
+import { resolvers } from './graphql-schema/resolvers.generated'
+import { typeDefs } from './graphql-schema/typeDefs.generated'
+
+export type Env = {
+  GRAPHQL_RESPONSE_CACHE: KVNamespace
+}
+export type GraphQLContext = YogaInitialContext & Env & ExecutionContext
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const kvCache = createKvCache({
+      KV: env.GRAPHQL_RESPONSE_CACHE,
+      ctx,
+      keyPrefix: 'graphql' // optional
+      cacheReadTTL: 1000 * 60, // 1 minute
+    })
+
+    const graphqlServer = createYoga<GraphQLContext>({
+      schema: createSchema({ typeDefs, resolvers }),
+      plugins: [
+        useResponseCache({
+          cache: kvCache,
+          session: () => null,
+          includeExtensionMetadata: true,
+          ttl: 1000 * 60 // 1 minute
+        })
+      ]
+    })
+
+    return graphqlServer.fetch(request, env, ctx)
+  }
+}
 ```
 
 ## HTTP Caching via `ETag` and `If-None-Match` headers


### PR DESCRIPTION
We are close to releasing `@envelop/response-cache-cloudflare-kv`
See issue - https://github.com/n1ru4l/envelop/issues/2055
Pull request - https://github.com/n1ru4l/envelop/pull/2057

This PR updates the graphql yoga documentation to showcase the soon to be released plugin. These docs would be very helpful for those using graphql on Cloudflare Workers and looking for a cache solution.

> [!WARNING]  
> Don't merge this PR until the linked PR for Envelop has been merged and deployed. 