### PR TITLE
fix contributing pnpm version

### DIFF
--- a/packages/graphql-yoga/README.md
+++ b/packages/graphql-yoga/README.md
@@ -115,7 +115,7 @@ before you get started off.
 For this project in particular, to get started on `stage/2-failing-test`:
 
 1. Install [Node.js](https://nodejs.org/)
-2. Run in your terminal: `npm i -g pnpm@7 && pnpm install && pnpm build`
+2. Run in your terminal: `npm i -g pnpm@8 && pnpm install && pnpm build`
 3. Add tests to `packages/graphql-yoga/__tests__` using [Jest](https://jestjs.io/docs/api) APIs
 4. Run the tests with `pnpm test`
 


### PR DESCRIPTION
Unable to run contributing steps due to:

```pnpm i
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/Users/ryan/Code/graphql-yoga".

Expected version: >=8.6.1
Got: 7.33.6

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.
```

This will bump the pnpm version to 8 in the steps for creating a failing test case.