### PR TITLE
Make the warn log a debug log

### DIFF
--- a/.changeset/kind-news-agree.md
+++ b/.changeset/kind-news-agree.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-response-cache': patch
+---
+
+Stop excessive/incorrect warn level log

--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -1006,8 +1006,8 @@ describe('shouldCacheResult', () => {
           ...expectedResponsePayload,
           ...cacheSkip,
         });
-        expect(logging.warn).toHaveBeenCalledWith(
-          '[useResponseCache] Failed to cache due to errors',
+        expect(logging.debug).toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
         );
       });
     });
@@ -1034,7 +1034,9 @@ describe('shouldCacheResult', () => {
           // NOTE: This actually returns the unmasked error DUMMY instead of the original "Unexpected error."
           errors: expect.arrayContaining([expect.objectContaining({ message: 'DUMMY' })]),
         });
-        expect(logging.warn).not.toHaveBeenCalled();
+        expect(logging.debug).not.toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
+        );
       });
     });
 
@@ -1058,9 +1060,8 @@ describe('shouldCacheResult', () => {
           ...expectedResponsePayload,
           ...cacheSkip,
         });
-        // NOTE: This should not be logged! Documenting current behavior.
-        expect(logging.warn).toHaveBeenCalledWith(
-          '[useResponseCache] Failed to cache due to errors',
+        expect(logging.debug).not.toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
         );
       });
     });
@@ -1092,7 +1093,9 @@ describe('shouldCacheResult', () => {
           ...expectedResponsePayload,
           ...cacheHit,
         });
-        expect(logging.warn).not.toHaveBeenCalled();
+        expect(logging.debug).not.toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
+        );
       });
     });
 
@@ -1116,7 +1119,9 @@ describe('shouldCacheResult', () => {
           ...expectedResponsePayload,
           ...cacheHit,
         });
-        expect(logging.warn).not.toHaveBeenCalled();
+        expect(logging.debug).not.toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
+        );
       });
     });
 
@@ -1140,9 +1145,8 @@ describe('shouldCacheResult', () => {
           ...expectedResponsePayload,
           ...cacheSkip,
         });
-        // NOTE: This should not be logged! Documenting current behavior.
-        expect(logging.warn).toHaveBeenCalledWith(
-          '[useResponseCache] Failed to cache due to errors',
+        expect(logging.debug).not.toHaveBeenCalledWith(
+          '[useResponseCache] Decided not to cache the response because it contains errors',
         );
       });
     });

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -47,7 +47,7 @@
     "graphql-yoga": "^5.0.2"
   },
   "dependencies": {
-    "@envelop/response-cache": "^6.1.0"
+    "@envelop/response-cache": "^6.1.2"
   },
   "devDependencies": {
     "graphql": "^16.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1943,8 +1943,8 @@ importers:
   packages/plugins/response-cache:
     dependencies:
       '@envelop/response-cache':
-        specifier: ^6.1.0
-        version: 6.1.0(@envelop/core@5.0.0)(graphql@16.6.0)
+        specifier: ^6.1.2
+        version: 6.1.2(@envelop/core@5.0.0)(graphql@16.6.0)
       graphql-yoga:
         specifier: ^5.0.2
         version: link:../../graphql-yoga/dist
@@ -6715,8 +6715,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@envelop/response-cache@6.1.0(@envelop/core@5.0.0)(graphql@16.6.0):
-    resolution: {integrity: sha512-yE1H85jju/OGlbFTFfUx0dXAScewWES2UBe8UhFrMMRFTVsNwnOHFaVWQw7mwnMZjQOzahRiXPlG2Z0dxBQ6GQ==}
+  /@envelop/response-cache@6.1.2(@envelop/core@5.0.0)(graphql@16.6.0):
+    resolution: {integrity: sha512-vBX6z/TxBZSNReVn69VJVkdGHpGzHyeQNMz9LXobczl55KCZaf2inBWguSdGq+vx6PlB068GhLeg+a7kseiF1Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@envelop/core': ^5.0.0
@@ -8312,7 +8312,7 @@ packages:
       '@whatwg-node/fetch': 0.9.12
       graphql: 16.6.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
       value-or-promise: 1.0.12
       ws: 8.13.0
     transitivePeerDependencies:
@@ -20650,6 +20650,7 @@ packages:
 
   /figgy-pudding@3.5.2:
     resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
     dev: false
 
   /figures@1.7.0:


### PR DESCRIPTION
Fixes #3110 

Contains a NOTE: 
- https://github.com/dotansimha/graphql-yoga/pull/3135/files#diff-3767b3f7edc61174419a72a31a871482483efcc3ffa506f5785aec14a68dc7b3R1034
- This might be worth opening a new issue for? IDK if it seems correct, I did sure not expect it