### PR TITLE
fix: Apply CSRF prevention validation only to GET requests

### DIFF
--- a/.changeset/long-weeks-rest.md
+++ b/.changeset/long-weeks-rest.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-csrf-prevention": patch
+---
+
+fix: Apply CSRF prevention validation only to GET requests

--- a/packages/plugins/csrf-prevention/__tests__/csrf-prevention.spec.ts
+++ b/packages/plugins/csrf-prevention/__tests__/csrf-prevention.spec.ts
@@ -53,7 +53,7 @@ describe('csrf-prevention', () => {
     await expect(res.text()).resolves.toMatchInlineSnapshot(`"{"data":{"hello":"world"}}"`);
   });
 
-  it('should allow all POST requests', async () => {
+  it('should allow POST requests with application/json content type', async () => {
     const res = await yoga.fetch('http://yoga/graphql?query={hello}', {
       method: 'POST',
       headers: {
@@ -65,5 +65,29 @@ describe('csrf-prevention', () => {
     });
     expect(res.status).toBe(200);
     await expect(res.text()).resolves.toMatchInlineSnapshot(`"{"data":{"hello":"world"}}"`);
+  });
+
+  it('should allow POST requests with multipart/form-data content with required header', async () => {
+    const formData = new FormData();
+    formData.append('operations', JSON.stringify({ query: '{ hello }' }));
+    const res = await yoga.fetch('http://yoga/graphql?query={hello}', {
+      method: 'POST',
+      headers: {
+        'x-graphql-yoga-csrf': 'whatevs',
+      },
+      body: formData,
+    });
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toMatchInlineSnapshot(`"{"data":{"hello":"world"}}"`);
+  });
+
+  it('should not allow requests with multipart/form-data content without required header', async () => {
+    const formData = new FormData();
+    formData.append('operations', JSON.stringify({ query: '{ hello }' }));
+    const res = await yoga.fetch('http://yoga/graphql?query={hello}', {
+      method: 'POST',
+      body: formData,
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/plugins/csrf-prevention/__tests__/csrf-prevention.spec.ts
+++ b/packages/plugins/csrf-prevention/__tests__/csrf-prevention.spec.ts
@@ -52,4 +52,18 @@ describe('csrf-prevention', () => {
     expect(res.status).toBe(200);
     await expect(res.text()).resolves.toMatchInlineSnapshot(`"{"data":{"hello":"world"}}"`);
   });
+
+  it('should allow all POST requests', async () => {
+    const res = await yoga.fetch('http://yoga/graphql?query={hello}', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: '{ hello }',
+      }),
+    });
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toMatchInlineSnapshot(`"{"data":{"hello":"world"}}"`);
+  });
 });

--- a/packages/plugins/csrf-prevention/src/index.ts
+++ b/packages/plugins/csrf-prevention/src/index.ts
@@ -26,7 +26,10 @@ export function useCSRFPrevention(
   const { requestHeaders = ['x-graphql-yoga-csrf'] } = options;
   return {
     async onRequestParse({ request }) {
-      if (!requestHeaders.some(headerName => request.headers.has(headerName))) {
+      if (
+        request.method === 'GET' &&
+        !requestHeaders.some(headerName => request.headers.has(headerName))
+      ) {
         throw createGraphQLError('Required CSRF header(s) not present', {
           extensions: {
             http: {


### PR DESCRIPTION
The current version of the CSRF prevention plugin requires special headers to be present on all requests. However in order to prevent CSRF attacks the check must only be done on some requests. For POST requests the browser does automatic preflight checks already for all content types not matching `application/x-www-form-urlencoded`,   `multipart/form-data`, `text/plain` 