### PR TITLE
feat: add served from response cache symbol to response cache

### DIFF
--- a/.changeset/big-tables-clean.md
+++ b/.changeset/big-tables-clean.md
@@ -1,0 +1,7 @@
+---
+'@graphql-yoga/plugin-response-cache': minor
+---
+
+Add `servedFromResponseCache` symbol property to responses served from the response cache in order
+to allow other plugins to determine, whether a response was served from the cache and apply custom
+logic based on that.

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -170,10 +170,14 @@ export function useResponseCache(options: UseResponseCacheParameter): Plugin {
       if (enabled(request)) {
         const cachedResponse = await cache.get(operationId);
         if (cachedResponse) {
+          const responseWithSymbol = {
+            ...cachedResponse,
+            [Symbol.for('servedFromResponseCache')]: true,
+          };
           if (options.includeExtensionMetadata) {
-            setResult(resultWithMetadata(cachedResponse, { hit: true }));
+            setResult(resultWithMetadata(responseWithSymbol, { hit: true }));
           } else {
-            setResult(cachedResponse);
+            setResult(responseWithSymbol);
           }
           return;
         }


### PR DESCRIPTION
Add `servedFromResponseCache` symbol property to responses served from the response cache in order
to allow other plugins to determine, whether a response was served from the cache and apply custom
logic based on that.

This is required for solving https://github.com/kamilkisiela/graphql-hive/issues/3807