### PR TITLE
remove high cardinality labels and fix bug for operationName

### DIFF
--- a/.changeset/dull-numbers-work.md
+++ b/.changeset/dull-numbers-work.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-yoga/plugin-prometheus': patch
+'@graphql-yoga/plugin-prometheus': major
 ---
 
 Removed labels that cause high cardinality

--- a/.changeset/two-beds-listen.md
+++ b/.changeset/two-beds-listen.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-prometheus': patch
+---
+
+Removed labels that cause high cardinality

--- a/packages/plugins/prometheus/package.json
+++ b/packages/plugins/prometheus/package.json
@@ -42,7 +42,7 @@
     "prom-client": "^15.0.0"
   },
   "dependencies": {
-    "@envelop/prometheus": "^9.2.0"
+    "@envelop/prometheus": "^9.3.1"
   },
   "devDependencies": {
     "prom-client": "15.0.0"

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -37,7 +37,14 @@ export function usePrometheus(options: PrometheusTracingPluginConfig): Plugin {
   }
 
   if (options.http) {
-    const labelNames = ['url', 'method', 'statusCode', 'statusText'];
+    const labelNames = ['method', 'statusCode'];
+
+    if (labelExists('url')) {
+      labelNames.push('url');
+    }
+    if (labelExists('statusText')) {
+      labelNames.push('statusText');
+    }
     if (labelExists('operationName')) {
       labelNames.push('operationName');
     }
@@ -62,12 +69,15 @@ export function usePrometheus(options: PrometheusTracingPluginConfig): Plugin {
             }),
             fillLabelsFn(params, { request, response }) {
               const labels: Record<string, string> = {
-                operationName: params.operationName || 'Anonymous',
-                url: request.url,
                 method: request.method,
                 statusCode: response.status,
-                statusText: response.statusText,
               };
+              if (labelExists('url')) {
+                labels.url = request.url;
+              }
+              if (labelExists('statusText')) {
+                labels.statusText = request.statusText;
+              }
               if (labelExists('operationType') && params.operationType) {
                 labels.operationType = params.operationType;
               }

--- a/website/src/pages/docs/integrations/integration-with-bun.mdx
+++ b/website/src/pages/docs/integrations/integration-with-bun.mdx
@@ -40,8 +40,8 @@ const yoga = createYoga({
 })
 
 const server = Bun.serve({
-  fetch: yoga,
-});
+  fetch: yoga
+})
 
 console.info(
   `Server is running on ${new URL(


### PR DESCRIPTION
### Summary
Prometheus has issues with cardinality where metrics with many labels causes a large number of data points and impacts performance, for this reason its generally good practice not to include unbounded labels in metrics. 

This PR addresses two issues: 
1. A bug in the plugin where if operationName was not added as a label the server errors on requests.
2. Remove metrics that will result in a label cardinality issue. 

This does mean, `url`, `statusText`, `http headers` will no longer be labels in metrics. 
