### PR TITLE
useJWT plugin: allow overriding any JwksClient options

### DIFF
--- a/.changeset/lovely-ladybugs-build.md
+++ b/.changeset/lovely-ladybugs-build.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-jwt': major
+---
+
+Add the possibility to customize JwksClient options

--- a/.changeset/lovely-ladybugs-build.md
+++ b/.changeset/lovely-ladybugs-build.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-yoga/plugin-jwt': major
+'@graphql-yoga/plugin-jwt': minor
 ---
 
 Add the possibility to customize JwksClient options

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -1,6 +1,6 @@
 import { createGraphQLError, Plugin } from 'graphql-yoga';
 import jsonwebtoken, { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
-import { JwksClient } from 'jwks-rsa';
+import { JwksClient, Options as JwksClientOptions } from 'jwks-rsa';
 
 const { decode } = jsonwebtoken;
 
@@ -40,6 +40,10 @@ export interface JwtPluginOptionsBase extends VerifyOptions {
 
 export interface JwtPluginOptionsWithJWKS extends JwtPluginOptionsBase {
   /**
+   * Options to be passed to the jwks-rsa client.
+   */
+  jwksOpts?: JwksClientOptions;
+  /**
    * The endpoint to fetch keys from.
    *
    * For example: https://example.com/.well-known/jwks.json
@@ -54,6 +58,7 @@ export interface JwtPluginOptionsWithSigningKey extends JwtPluginOptionsBase {
    * You can also use the jwks option to fetch the key from a JWKS endpoint
    */
   signingKey: string;
+  jwksOpts?: never;
   jwksUri?: never;
 }
 
@@ -77,6 +82,7 @@ export function useJWT(options: JwtPluginOptions): Plugin {
       rateLimit: true,
       jwksRequestsPerMinute: 5,
       jwksUri: options.jwksUri,
+      ...options.jwksOpts,
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,25 @@ importers:
         specifier: ^0.9.17
         version: 0.9.17
 
+  examples/bun-yoga-ws:
+    dependencies:
+      bun-types:
+        specifier: ^1.0.0
+        version: 1.0.0
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      graphql-ws:
+        specifier: ^5.14.1
+        version: 5.14.1(graphql@16.6.0)
+      graphql-yoga:
+        specifier: ^4.0.5
+        version: 4.0.5(graphql@16.6.0)
+    devDependencies:
+      '@whatwg-node/fetch':
+        specifier: ^0.9.0
+        version: 0.9.17
+
   examples/cloudflare-advanced:
     dependencies:
       '@cloudflare/workers-types':
@@ -7540,6 +7559,31 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
+
+  /@graphql-yoga/logger@1.0.0:
+    resolution: {integrity: sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@graphql-yoga/subscription@4.0.0:
+    resolution: {integrity: sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@graphql-yoga/typed-event-target': 2.0.0
+      '@repeaterjs/repeater': 3.0.4
+      '@whatwg-node/events': 0.1.0
+      tslib: 2.6.2
+    dev: false
+
+  /@graphql-yoga/typed-event-target@2.0.0:
+    resolution: {integrity: sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@repeaterjs/repeater': 3.0.4
+      tslib: 2.6.2
+    dev: false
 
   /@grpc/grpc-js@1.8.11:
     resolution: {integrity: sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==}
@@ -20853,6 +20897,35 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.6.0
+
+  /graphql-ws@5.14.1(graphql@16.6.0):
+    resolution: {integrity: sha512-aqkls1espsygP1PfkAuuLIV96IbztQ6EaADse97pw8wRIMT3+AL/OYfS8V2iCRkc0gzckitoDRGCQEdnySggiA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 16.6.0
+    dev: false
+
+  /graphql-yoga@4.0.5(graphql@16.6.0):
+    resolution: {integrity: sha512-vIbJU9QX5RP4PoxbMCHcfOlt/3EsC/0uLdAOlKaiUvlwJDTFCaIHo2X10vL4i/27Gw8g90ECIwm2YbmeLDwcqg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+    dependencies:
+      '@envelop/core': 4.0.0
+      '@graphql-tools/executor': 1.2.5(graphql@16.6.0)
+      '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
+      '@graphql-yoga/logger': 1.0.0
+      '@graphql-yoga/subscription': 4.0.0
+      '@whatwg-node/fetch': 0.9.17
+      '@whatwg-node/server': 0.9.33
+      dset: 3.1.2
+      graphql: 16.6.0
+      lru-cache: 10.0.0
+      tslib: 2.6.2
+    dev: false
 
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}


### PR DESCRIPTION
I noticed the `JwksClient` from `jwks-rsa` has quite a few options which are not made available in the `useJWT` config properties. For my particular use case, I was wanting access to [`getKeysInterceptor`](https://github.com/auth0/node-jwks-rsa/blob/4fe372be935c2aa0882e0f1e58d33eead4be966d/EXAMPLES.md?plain=1#L30) so that I could intercept jwks loading in my test suite.

However, rather than attempt to add support for just one or all of these options, I thought it would be best to allow the user to specify _any_ of these client options by directly referencing its type and merging those props with the props passed to the `JwksClient` constructor.

I wasn't clear on whether I could easily add test coverage for this, because it doesn't appear that any of the coverage is directly using a real jwks setup atm.