### PR TITLE
defer-stream.mdx typos

### DIFF
--- a/website/src/pages/docs/features/defer-stream.mdx
+++ b/website/src/pages/docs/features/defer-stream.mdx
@@ -1,6 +1,6 @@
 ---
 description:
-  Stream and defer are directives that allow you to improve latency for clients by sending data the
+  Stream and defer are directives that allow you to improve latency for clients by sending the
   most important data as soon as it's ready.
 ---
 
@@ -8,10 +8,10 @@ import { Callout } from '@theguild/components'
 
 # Defer and Stream
 
-Stream and defer are directives that allow you to improve latency for clients by sending data the
+Stream and defer are directives that allow you to improve latency for clients by sending the
 most important data as soon as it's ready.
 
-As applications grow, the GraphQL operation documents can get bigger.. The server will only send the
+As applications grow, the GraphQL operation documents can get bigger. The server will only send the
 response back once all the data requested in the query is ready. However, not all requested data is
 of equal importance, and the client may not need all of the data at once. To remedy this, GraphQL
 specification working group is working on


### PR DESCRIPTION
Fixing 2 minor typos in Defer and Stream documentation