### PR TITLE
Add reason to error JWT message

### DIFF
--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -133,7 +133,7 @@ function verify(
       { ...options, algorithms: options?.algorithms ?? ['RS256'] },
       (err, result) => {
         if (err) {
-          reject(unauthorizedError('Failed to decode authentication token. Verification failed.'));
+          reject(unauthorizedError('Failed to decode authentication token. Verification failed. Reason: ' + err.message));
         } else {
           resolve(result as JwtPayload);
         }


### PR DESCRIPTION
JWT verification can fail for multiple reason, surface the underlying cause to aid debugging.