### PR TITLE
feat: execution cancelation

### DIFF
--- a/.changeset/@graphql-yoga_plugin-apollo-inline-trace-3197-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-inline-trace-3197-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-yoga/plugin-apollo-inline-trace': patch
+---
+dependencies updates:
+  - Updated dependency [`@whatwg-node/fetch@^0.9.17`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.9.17) (from `^0.9.7`, in
+    `peerDependencies`)

--- a/.changeset/graphql-yoga-3197-dependencies.md
+++ b/.changeset/graphql-yoga-3197-dependencies.md
@@ -1,0 +1,7 @@
+---
+'graphql-yoga': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/executor@^1.2.1`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.1) (from `^1.0.0`, in
+    `dependencies`)

--- a/.changeset/graphql-yoga-3197-dependencies.md
+++ b/.changeset/graphql-yoga-3197-dependencies.md
@@ -2,9 +2,12 @@
 'graphql-yoga': patch
 ---
 dependencies updates:
-  - Updated dependency [`@graphql-tools/executor@^1.2.1`
-    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.1) (from `^1.0.0`, in
+  - Updated dependency [`@graphql-tools/executor@^1.2.3`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.3) (from `^1.2.2`, in
     `dependencies`)
-  - Updated dependency [`@whatwg-node/server@^0.9.27`
-    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.27) (from `^0.9.1`, in
+  - Updated dependency [`@whatwg-node/fetch@^0.9.17`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.9.17) (from `^0.9.7`, in
+    `dependencies`)
+  - Updated dependency [`@whatwg-node/server@^0.9.31`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.31) (from `^0.9.1`, in
     `dependencies`)

--- a/.changeset/graphql-yoga-3197-dependencies.md
+++ b/.changeset/graphql-yoga-3197-dependencies.md
@@ -5,3 +5,6 @@ dependencies updates:
   - Updated dependency [`@graphql-tools/executor@^1.2.1`
     ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.1) (from `^1.0.0`, in
     `dependencies`)
+  - Updated dependency [`@whatwg-node/server@^0.9.27`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.27) (from `^0.9.1`, in
+    `dependencies`)

--- a/.changeset/graphql-yoga-3197-dependencies.md
+++ b/.changeset/graphql-yoga-3197-dependencies.md
@@ -8,6 +8,6 @@ dependencies updates:
   - Updated dependency [`@whatwg-node/fetch@^0.9.17`
     ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.9.17) (from `^0.9.7`, in
     `dependencies`)
-  - Updated dependency [`@whatwg-node/server@^0.9.31`
-    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.31) (from `^0.9.1`, in
+  - Updated dependency [`@whatwg-node/server@^0.9.32`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.32) (from `^0.9.1`, in
     `dependencies`)

--- a/.changeset/graphql-yoga-3197-dependencies.md
+++ b/.changeset/graphql-yoga-3197-dependencies.md
@@ -2,8 +2,8 @@
 'graphql-yoga': patch
 ---
 dependencies updates:
-  - Updated dependency [`@graphql-tools/executor@^1.2.3`
-    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.3) (from `^1.2.2`, in
+  - Updated dependency [`@graphql-tools/executor@^1.2.5`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.2.5) (from `^1.2.2`, in
     `dependencies`)
   - Updated dependency [`@whatwg-node/fetch@^0.9.17`
     ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.9.17) (from `^0.9.7`, in

--- a/.changeset/graphql-yoga-3208-dependencies.md
+++ b/.changeset/graphql-yoga-3208-dependencies.md
@@ -1,8 +1,0 @@
----
-'graphql-yoga': patch
----
-dependencies updates:
-  - Updated dependency
-    [`@whatwg-node/server@0.9.32-alpha-20240325115716-84ad025b793c368e6cfd30cdc6fce6bc76b862d3`
-    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.32) (from `^0.9.31`, in
-    `dependencies`)

--- a/.changeset/graphql-yoga-3208-dependencies.md
+++ b/.changeset/graphql-yoga-3208-dependencies.md
@@ -1,0 +1,8 @@
+---
+'graphql-yoga': patch
+---
+dependencies updates:
+  - Updated dependency
+    [`@whatwg-node/server@0.9.32-alpha-20240325115716-84ad025b793c368e6cfd30cdc6fce6bc76b862d3`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.32) (from `^0.9.31`, in
+    `dependencies`)

--- a/.changeset/green-badgers-work.md
+++ b/.changeset/green-badgers-work.md
@@ -8,12 +8,14 @@ The execution of subsequent GraphQL resolvers is now aborted if the incoming HTT
 This reduces the load of your API in case incoming requests with deep GraphQL operation selection sets are canceled.
 
 ```ts
-import { createYoga, useExecutionCancellation } from 'graphql-yoga'
+import { createYoga, useExecutionCancelation } from 'graphql-yoga'
 
 const yoga = createYoga({
-  plugins: [useExecutionCancellation()]
+  plugins: [useExecutionCancelation()]
 })
 ```
+
+[Learn more in our docs](https://graphql-yoga.com/docs/features/execution-cancelation)
 
 **Action Required** In order to benefit from this new feature, you need to update your integration setup for Fastify, Koa and Hapi.
 

--- a/.changeset/green-badgers-work.md
+++ b/.changeset/green-badgers-work.md
@@ -8,10 +8,10 @@ The execution of subsequent GraphQL resolvers is now aborted if the incoming HTT
 This reduces the load of your API in case incoming requests with deep GraphQL operation selection sets are canceled.
 
 ```ts
-import { createYoga, useExecutionCancelation } from 'graphql-yoga'
+import { createYoga, useExecutionCancellation } from 'graphql-yoga'
 
 const yoga = createYoga({
-  plugins: [useExecutionCancelation()]
+  plugins: [useExecutionCancellation()]
 })
 ```
 

--- a/.changeset/green-badgers-work.md
+++ b/.changeset/green-badgers-work.md
@@ -1,0 +1,8 @@
+---
+'graphql-yoga': minor
+---
+
+Abort GraphQL execution when HTTP request is canceled.
+
+The execution of subsequent GraphQL resolvers is now aborted if the incoming HTTP request is canceled from the client side.
+This reduces the load of your API in case incoming requests with deep GraphQL operation selection sets are canceled.

--- a/.changeset/green-badgers-work.md
+++ b/.changeset/green-badgers-work.md
@@ -6,3 +6,15 @@ Abort GraphQL execution when HTTP request is canceled.
 
 The execution of subsequent GraphQL resolvers is now aborted if the incoming HTTP request is canceled from the client side.
 This reduces the load of your API in case incoming requests with deep GraphQL operation selection sets are canceled.
+
+**Action Required** In order to benefit from this new feature, you need to update your integration setup for Fastify, Koa and Hapi.
+
+```diff
+- const response = await yoga.handleNodeRequest(req, { ... })
++ const response = await yoga.handleNodeRequestAndResponse(req, res, { ... })
+```
+
+Please refer to the corresponding integration guides for examples.
+- [Fastify](https://graphql-yoga.com/docs/integrations/integration-with-fastify#example)
+- [Koa](https://graphql-yoga.com/docs/integrations/integration-with-koa#example)
+- [Hapi](https://graphql-yoga.com/docs/integrations/integration-with-hapi#example)

--- a/.changeset/green-badgers-work.md
+++ b/.changeset/green-badgers-work.md
@@ -2,10 +2,18 @@
 'graphql-yoga': minor
 ---
 
-Abort GraphQL execution when HTTP request is canceled.
+Experimental support for aborting GraphQL execution when the HTTP request is canceled.
 
 The execution of subsequent GraphQL resolvers is now aborted if the incoming HTTP request is canceled from the client side.
 This reduces the load of your API in case incoming requests with deep GraphQL operation selection sets are canceled.
+
+```ts
+import { createYoga, useExecutionCancellation } from 'graphql-yoga'
+
+const yoga = createYoga({
+  plugins: [useExecutionCancellation()]
+})
+```
 
 **Action Required** In order to benefit from this new feature, you need to update your integration setup for Fastify, Koa and Hapi.
 

--- a/examples/apollo-federation/package.json
+++ b/examples/apollo-federation/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@apollo/gateway": "2.4.7",
-    "@whatwg-node/fetch": "^0.9.0"
+    "@whatwg-node/fetch": "^0.9.17"
   }
 }

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -12,6 +12,6 @@
     "graphql-yoga": "5.2.0"
   },
   "devDependencies": {
-    "@whatwg-node/fetch": "^0.9.0"
+    "@whatwg-node/fetch": "^0.9.17"
   }
 }

--- a/examples/cloudflare-modules/package.json
+++ b/examples/cloudflare-modules/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20230518.0",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "typescript": "5.1.6",
     "wrangler": "3.1.0"
   }

--- a/examples/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/examples/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -2,7 +2,6 @@ import { yoga } from '../src/yoga';
 
 describe('Defer / Stream', () => {
   it('stream', async () => {
-    const start = Date.now();
     const response = await yoga.fetch('/graphql', {
       method: 'POST',
       headers: {
@@ -21,14 +20,9 @@ describe('Defer / Stream', () => {
     const contentType = response.headers.get('Content-Type');
     expect(contentType).toEqual('multipart/mixed; boundary="-"');
     const responseText = await response.text();
-    const end = Date.now();
     expect(responseText).toMatchSnapshot('stream');
-    const diff = end - start;
-    expect(diff).toBeLessThan(2650);
-    expect(diff > 2550).toBeTruthy();
   });
   it('defer', async () => {
-    const start = Date.now();
     const response = await yoga.fetch('/graphql', {
       method: 'POST',
       headers: {
@@ -50,10 +44,6 @@ describe('Defer / Stream', () => {
     const contentType = response.headers.get('Content-Type');
     expect(contentType).toEqual('multipart/mixed; boundary="-"');
     const responseText = await response.text();
-    const end = Date.now();
     expect(responseText).toMatchSnapshot('defer');
-    const diff = end - start;
-    expect(diff).toBeLessThan(1600);
-    expect(diff > 1450).toBeTruthy();
   });
 });

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "graphql": "^16.1.0",
     "graphql-yoga": "5.2.0"
   },

--- a/examples/fastify-modules/src/app.ts
+++ b/examples/fastify-modules/src/app.ts
@@ -23,7 +23,7 @@ export function createGraphQLHandler(): RouteHandlerMethod & {
   });
 
   const handler = async (req, reply) => {
-    const response = await graphQLServer.handleNodeRequest(req, {
+    const response = await graphQLServer.handleNodeRequestAndResponse(req, reply, {
       req,
       reply,
     });

--- a/examples/fastify/__integration-tests__/fastify.spec.ts
+++ b/examples/fastify/__integration-tests__/fastify.spec.ts
@@ -274,7 +274,7 @@ data"
 
     // we work with logger statements to detect when the slow field resolver is invoked and when it is canceled
     const loggerOverwrite = (part: unknown) => {
-      if (part === 'Slow resolver invoked resolved') {
+      if (part === 'Slow resolver invoked') {
         slowFieldResolverInvoked.resolve();
       }
       if (part === 'Slow field got cancelled') {
@@ -310,6 +310,7 @@ data"
       await slowFieldResolverCanceled.promise;
     } finally {
       app.log.info = info;
+      await app.close();
     }
   });
 
@@ -359,6 +360,7 @@ data"
       await cancelationIsLoggedPromise.promise;
     } finally {
       app.log.info = info;
+      await app.close();
     }
   });
 });

--- a/examples/fastify/__integration-tests__/fastify.spec.ts
+++ b/examples/fastify/__integration-tests__/fastify.spec.ts
@@ -2,17 +2,9 @@ import request from 'supertest';
 import { buildApp } from '../src/app.js';
 
 describe('fastify example integration', () => {
-  const [app] = buildApp(false);
-
-  beforeAll(async () => {
-    await app.ready();
-  });
-
-  afterAll(async () => {
-    await app.close();
-  });
-
   it('sends GraphiQL', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server).get('/graphql').set({
       accept: 'text/html',
     });
@@ -22,6 +14,8 @@ describe('fastify example integration', () => {
   });
 
   it('handles query operation via POST', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .post('/graphql')
       .set({ 'content-type': 'application/json' })
@@ -44,6 +38,8 @@ describe('fastify example integration', () => {
   });
 
   it("exposes fastify's request and reply objects", async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .post('/graphql')
       .set({ 'content-type': 'application/json' })
@@ -66,6 +62,8 @@ describe('fastify example integration', () => {
   });
 
   it('handles query operation via GET', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .get('/graphql')
       .query({
@@ -85,6 +83,8 @@ describe('fastify example integration', () => {
   });
 
   it('handles mutation operation via POST', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .post('/graphql')
       .set({ 'content-type': 'application/json' })
@@ -107,6 +107,8 @@ describe('fastify example integration', () => {
   });
 
   it('rejects mutation operation via GET with an useful error message', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .get('/graphql')
       .query({
@@ -127,6 +129,8 @@ describe('fastify example integration', () => {
   });
 
   it('handles subscription operations via GET', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .get('/graphql')
       .set({ accept: 'text/event-stream' })
@@ -177,6 +181,8 @@ data"
 `);
   });
   it('handles subscription operations via POST', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .post('/graphql')
       .set({
@@ -230,6 +236,8 @@ data"
 `);
   });
   it('should handle file uploads', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const response = await request(app.server)
       .post('/graphql')
       .field(
@@ -252,6 +260,8 @@ data"
     });
   });
   it('request cancelation', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
     const slowFieldResolverInvoked = createDeferred();
     const slowFieldResolverCanceled = createDeferred();
     const address = await app.listen({

--- a/examples/fastify/__integration-tests__/fastify.spec.ts
+++ b/examples/fastify/__integration-tests__/fastify.spec.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { eventStream } from '../../../packages/graphql-yoga/__tests__/utilities.js';
 import { buildApp } from '../src/app.js';
 
 describe('fastify example integration', () => {
@@ -180,6 +181,7 @@ event: complete
 data"
 `);
   });
+
   it('handles subscription operations via POST', async () => {
     const [app] = buildApp(false);
     await app.ready();
@@ -235,6 +237,7 @@ event: complete
 data"
 `);
   });
+
   it('should handle file uploads', async () => {
     const [app] = buildApp(false);
     await app.ready();
@@ -259,6 +262,7 @@ data"
       },
     });
   });
+
   it('request cancelation', async () => {
     const [app] = buildApp(false);
     await app.ready();
@@ -304,6 +308,55 @@ data"
       abortController.abort();
       await expect(response$).rejects.toMatchInlineSnapshot(`DOMException {}`);
       await slowFieldResolverCanceled.promise;
+    } finally {
+      app.log.info = info;
+    }
+  });
+
+  it('subscription cancelation', async () => {
+    const [app] = buildApp(false);
+    await app.ready();
+    const cancelationIsLoggedPromise = createDeferred();
+    const address = await app.listen({
+      port: 0,
+    });
+
+    // we work with logger statements to detect when the subscription source is cleaned up.
+    const loggerOverwrite = (part: unknown) => {
+      if (part === 'countdown aborted') {
+        cancelationIsLoggedPromise.resolve();
+      }
+    };
+
+    const info = app.log.info;
+    app.log.info = loggerOverwrite;
+
+    try {
+      const abortController = new AbortController();
+      const url = new URL(`${address}/graphql`);
+      url.searchParams.set(
+        'query',
+        /* GraphQL */ `
+          subscription {
+            countdown(from: 10, interval: 5)
+          }
+        `,
+      );
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'text/event-stream',
+        },
+        signal: abortController.signal,
+      });
+
+      const iterator = eventStream(response.body!);
+      const next = await iterator.next();
+      expect(next.value).toEqual({ data: { countdown: 10 } });
+      abortController.abort();
+      await expect(iterator.next()).rejects.toMatchInlineSnapshot(`DOMException {}`);
+      await cancelationIsLoggedPromise.promise;
     } finally {
       app.log.info = info;
     }

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -7,6 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
+    "@whatwg-node/fetch": "^0.9.17",
     "fastify": "4.17.0",
     "graphql-yoga": "5.2.0",
     "pino-pretty": "10.0.0"

--- a/examples/file-upload-nextjs-pothos/package.json
+++ b/examples/file-upload-nextjs-pothos/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.17",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "typescript": "5.1.6"

--- a/examples/file-upload-nexus/package.json
+++ b/examples/file-upload-nexus/package.json
@@ -12,7 +12,7 @@
     "nexus": "^1.3.0"
   },
   "devDependencies": {
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "ts-node": "10.9.1",
     "typescript": "5.1.6"
   }

--- a/examples/file-upload/package.json
+++ b/examples/file-upload/package.json
@@ -12,6 +12,6 @@
     "ts-node": "10.9.1"
   },
   "devDependencies": {
-    "@whatwg-node/fetch": "^0.9.0"
+    "@whatwg-node/fetch": "^0.9.17"
   }
 }

--- a/examples/generic-auth/package.json
+++ b/examples/generic-auth/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "18.16.16",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "cross-env": "7.0.3",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",

--- a/examples/graphql-ws/package.json
+++ b/examples/graphql-ws/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "check": "tsc --pretty --noEmit",
+    "dev": "cross-env NODE_ENV=development ts-node-dev --exit-child --respawn src/index.ts",
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
@@ -13,7 +14,9 @@
     "ws": "8.13.0"
   },
   "devDependencies": {
+    "cross-env": "7.0.3",
     "ts-node": "10.9.1",
+    "ts-node-dev": "2.0.0",
     "typescript": "5.1.6"
   }
 }

--- a/examples/graphql-ws/src/app.ts
+++ b/examples/graphql-ws/src/app.ts
@@ -6,6 +6,9 @@ import { WebSocketServer } from 'ws';
 
 export function buildApp() {
   const yoga = createYoga({
+    graphiql: {
+      subscriptionsProtocol: 'WS',
+    },
     schema: createSchema({
       typeDefs: /* GraphQL */ `
         type Query {

--- a/examples/hapi/package.json
+++ b/examples/hapi/package.json
@@ -12,7 +12,7 @@
     "graphql-yoga": "5.2.0"
   },
   "devDependencies": {
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "ts-node": "10.9.1",
     "typescript": "5.1.6"
   }

--- a/examples/hapi/src/app.ts
+++ b/examples/hapi/src/app.ts
@@ -53,7 +53,11 @@ export async function startApp(port: number) {
       },
     },
     handler: async (req, h) => {
-      const { status, headers, body } = await yoga.handleNodeRequest(req.raw.req, { req, h });
+      const { status, headers, body } = await yoga.handleNodeRequestAndResponse(
+        req.raw.req,
+        req.raw.res,
+        { req, h },
+      );
 
       const res = h.response(
         Readable.from(body, {

--- a/examples/hapi/src/app.ts
+++ b/examples/hapi/src/app.ts
@@ -1,4 +1,3 @@
-import http from 'node:http';
 import { Readable } from 'node:stream';
 import { createSchema, createYoga } from 'graphql-yoga';
 import Hapi from '@hapi/hapi';

--- a/examples/koa/src/app.ts
+++ b/examples/koa/src/app.ts
@@ -36,7 +36,7 @@ export function buildApp() {
   });
 
   app.use(async ctx => {
-    const response = await yoga.handleNodeRequest(ctx.req, ctx);
+    const response = await yoga.handleNodeRequestAndResponse(ctx.req, ctx.res, ctx);
 
     // Set status code
     ctx.status = response.status;

--- a/examples/nextjs-legacy-pages/__integration-tests__/nextjs-legacy.spec.ts
+++ b/examples/nextjs-legacy-pages/__integration-tests__/nextjs-legacy.spec.ts
@@ -35,16 +35,9 @@ describe('NextJS Legacy Pages', () => {
       ...Object.fromEntries(response.headers.entries()),
       date: null,
       'keep-alive': null,
-    }).toMatchInlineSnapshot(`
-      {
-        "connection": "close",
-        "content-length": "79",
-        "content-type": "application/json; charset=utf-8",
-        "date": null,
-        "keep-alive": null,
-        "vary": "Accept-Encoding",
-      }
-    `);
+    }).toMatchObject({
+      'content-type': 'application/json; charset=utf-8',
+    });
 
     const json = await response.json();
 

--- a/examples/request-cancelation/package.json
+++ b/examples/request-cancelation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "example-request-cancelation",
+  "version": "0.0.0",
+  "description": "",
+  "author": "Laurin Quast <laurinquast@googlemail.com>",
+  "license": "MIT",
+  "private": true,
+  "module": "commonjs",
+  "keywords": [],
+  "scripts": {
+    "check": "tsc --pretty --noEmit",
+    "dev": "cross-env NODE_ENV=development ts-node-dev --exit-child --respawn src/main.ts",
+    "start": "ts-node src/main.ts"
+  },
+  "dependencies": {
+    "graphql": "16.6.0",
+    "graphql-yoga": "5.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "18.16.16",
+    "@whatwg-node/fetch": "^0.9.17",
+    "cross-env": "7.0.3",
+    "ts-node": "10.9.1",
+    "ts-node-dev": "2.0.0",
+    "typescript": "5.1.6"
+  }
+}

--- a/examples/request-cancelation/src/main.ts
+++ b/examples/request-cancelation/src/main.ts
@@ -1,0 +1,61 @@
+import { createServer } from 'node:http';
+import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga';
+
+const logger = createLogger('debug');
+
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      user: User
+    }
+
+    type User {
+      id: ID!
+      name: String!
+      bestFriend: User
+    }
+  `,
+  resolvers: {
+    Query: {
+      async user(_, __, { request }) {
+        logger.info('resolving user');
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(resolve, 5000);
+          request.signal.addEventListener('abort', () => {
+            clearTimeout(timeout);
+            reject(request.signal.reason);
+          });
+        });
+        logger.info('resolved user');
+
+        return {
+          id: '1',
+          name: 'Chewie',
+        };
+      },
+    },
+    User: {
+      bestFriend() {
+        logger.info('resolving user best friend');
+
+        return {
+          id: '2',
+          name: 'Han Solo',
+        };
+      },
+    },
+  },
+});
+
+// Provide your schema
+const yoga = createYoga({
+  plugins: [useExecutionCancelation()],
+  schema,
+  logging: logger,
+});
+
+// Start the server and explore http://localhost:4000/graphql
+const server = createServer(yoga);
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql');
+});

--- a/examples/request-cancelation/src/main.ts
+++ b/examples/request-cancelation/src/main.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http';
-import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga';
 
 const logger = createLogger('debug');
 
@@ -49,7 +49,7 @@ const schema = createSchema({
 
 // Provide your schema
 const yoga = createYoga({
-  plugins: [useExecutionCancelation()],
+  plugins: [useExecutionCancellation()],
   schema,
   logging: logger,
 });

--- a/examples/request-cancelation/tsconfig.json
+++ b/examples/request-cancelation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "commonjs",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/response-cache/package.json
+++ b/examples/response-cache/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "18.16.16",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "cross-env": "7.0.3",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -13,7 +13,7 @@
     "graphql-yoga": "5.2.0"
   },
   "devDependencies": {
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "typescript": "5.1.6",
     "wrangler": "3.1.0"
   }

--- a/examples/uwebsockets/package.json
+++ b/examples/uwebsockets/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/ws": "8.5.4",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "ws": "8.13.0"
   }
 }

--- a/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
@@ -6,7 +6,7 @@ import {
   createSchema,
   createYoga,
   Plugin,
-  useExecutionCancelation,
+  useExecutionCancellation,
 } from '../src/index.js';
 
 describe('node-http', () => {
@@ -123,7 +123,7 @@ describe('node-http', () => {
           }
         `,
       }),
-      plugins: [plugin, useExecutionCancelation()],
+      plugins: [plugin, useExecutionCancellation()],
     });
     const server = createServer(yoga);
     await new Promise<void>(resolve => server.listen(0, resolve));
@@ -159,7 +159,7 @@ describe('node-http', () => {
 
     let didInvokedNestedField = false;
     const yoga = createYoga({
-      plugins: [useExecutionCancelation()],
+      plugins: [useExecutionCancellation()],
       schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {

--- a/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
@@ -6,7 +6,7 @@ import {
   createSchema,
   createYoga,
   Plugin,
-  useExecutionCancellation,
+  useExecutionCancelation,
 } from '../src/index.js';
 
 describe('node-http', () => {
@@ -123,7 +123,7 @@ describe('node-http', () => {
           }
         `,
       }),
-      plugins: [plugin, useExecutionCancellation()],
+      plugins: [plugin, useExecutionCancelation()],
     });
     const server = createServer(yoga);
     await new Promise<void>(resolve => server.listen(0, resolve));
@@ -159,7 +159,7 @@ describe('node-http', () => {
 
     let didInvokedNestedField = false;
     const yoga = createYoga({
-      plugins: [useExecutionCancellation()],
+      plugins: [useExecutionCancelation()],
       schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {

--- a/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
@@ -94,6 +94,8 @@ describe('node-http', () => {
       expect(response.status).toBe(status);
       expect(response.statusText).toBe(STATUS_CODES[status]);
     }
+
+    await new Promise<void>(resolve => server.close(() => resolve()));
   });
 
   it('request cancellation causes signal passed to executor to be aborted', async () => {

--- a/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
@@ -1,7 +1,13 @@
 import { createServer, IncomingMessage, ServerResponse, STATUS_CODES } from 'node:http';
 import { AddressInfo } from 'node:net';
 import { fetch } from '@whatwg-node/fetch';
-import { createGraphQLError, createSchema, createYoga, Plugin } from '../src/index.js';
+import {
+  createGraphQLError,
+  createSchema,
+  createYoga,
+  Plugin,
+  useExecutionCancellation,
+} from '../src/index.js';
 
 describe('node-http', () => {
   it('should expose Node req and res objects in the context', async () => {
@@ -117,7 +123,7 @@ describe('node-http', () => {
           }
         `,
       }),
-      plugins: [plugin],
+      plugins: [plugin, useExecutionCancellation()],
     });
     const server = createServer(yoga);
     await new Promise<void>(resolve => server.listen(0, resolve));
@@ -149,11 +155,11 @@ describe('node-http', () => {
 
   it('request cancellation causes no more resolvers being invoked', async () => {
     const didInvokeSlowResolverD = createDeferred();
-
     const didCancelD = createDeferred();
 
     let didInvokedNestedField = false;
     const yoga = createYoga({
+      plugins: [useExecutionCancellation()],
       schema: createSchema({
         typeDefs: /* GraphQL */ `
           type Query {

--- a/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/node-http.spec.ts
@@ -1,13 +1,10 @@
-import { createServer, IncomingMessage, Server, ServerResponse, STATUS_CODES } from 'node:http';
+import { createServer, IncomingMessage, ServerResponse, STATUS_CODES } from 'node:http';
 import { AddressInfo } from 'node:net';
 import { fetch } from '@whatwg-node/fetch';
-import { createGraphQLError, createSchema, createYoga } from '../src/index.js';
+import { createGraphQLError, createSchema, createYoga, Plugin } from '../src/index.js';
 
 describe('node-http', () => {
-  let server: Server;
-  let port: number;
-
-  beforeAll(async () => {
+  it('should expose Node req and res objects in the context', async () => {
     const yoga = createYoga<{
       req: IncomingMessage;
       res: ServerResponse;
@@ -16,12 +13,43 @@ describe('node-http', () => {
         typeDefs: /* GraphQL */ `
           type Query {
             isNode: Boolean!
-            throw(status: Int): Int!
           }
         `,
         resolvers: {
           Query: {
             isNode: (_, __, { req, res }) => !!(req && res),
+          },
+        },
+      }),
+    });
+    const server = createServer(yoga);
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      const response = await fetch(`http://localhost:${port}/graphql?query=query{isNode}`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.errors).toBeUndefined();
+      expect(body.data.isNode).toBe(true);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  it('should set status text by status code', async () => {
+    const yoga = createYoga<{
+      req: IncomingMessage;
+      res: ServerResponse;
+    }>({
+      schema: createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            throw(status: Int): Int!
+          }
+        `,
+        resolvers: {
+          Query: {
             throw(_, { status }) {
               throw createGraphQLError('Test', {
                 extensions: {
@@ -36,26 +64,10 @@ describe('node-http', () => {
       }),
       logging: false,
     });
-    server = createServer(yoga);
+    const server = createServer(yoga);
     await new Promise<void>(resolve => server.listen(0, resolve));
-    port = (server.address() as AddressInfo).port;
-  });
+    const port = (server.address() as AddressInfo).port;
 
-  afterAll(async () => {
-    if (server) {
-      await new Promise<void>(resolve => server.close(() => resolve()));
-    }
-  });
-
-  it('should expose Node req and res objects in the context', async () => {
-    const response = await fetch(`http://localhost:${port}/graphql?query=query{isNode}`);
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.errors).toBeUndefined();
-    expect(body.data.isNode).toBe(true);
-  });
-
-  it('should set status text by status code', async () => {
     for (const statusCodeStr in STATUS_CODES) {
       const status = Number(statusCodeStr);
       if (status < 200) continue;
@@ -77,4 +89,146 @@ describe('node-http', () => {
       expect(response.statusText).toBe(STATUS_CODES[status]);
     }
   });
+
+  it('request cancellation causes signal passed to executor to be aborted', async () => {
+    const d = createDeferred();
+    const didAbortD = createDeferred();
+
+    const plugin: Plugin = {
+      onExecute(ctx) {
+        ctx.setExecuteFn(async function execute(params) {
+          d.resolve();
+
+          return new Promise((_, rej) => {
+            // @ts-expect-error Signal is not documented yet...
+            params.signal.addEventListener('abort', () => {
+              didAbortD.resolve();
+              rej(new DOMException('The operation was aborted', 'AbortError'));
+            });
+          });
+        });
+      },
+    };
+    const yoga = createYoga({
+      schema: createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            hi: String!
+          }
+        `,
+      }),
+      plugins: [plugin],
+    });
+    const server = createServer(yoga);
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const controller = new AbortController();
+      const response$ = fetch(`http://localhost:${port}/graphql`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              hi
+            }
+          `,
+        }),
+        signal: controller.signal,
+      });
+      await d.promise;
+      controller.abort();
+      await expect(response$).rejects.toThrow('The operation was aborted');
+      await didAbortD.promise;
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  it('request cancellation causes no more resolvers being invoked', async () => {
+    const didInvokeSlowResolverD = createDeferred();
+
+    const didCancelD = createDeferred();
+
+    let didInvokedNestedField = false;
+    const yoga = createYoga({
+      schema: createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            slow: Nested!
+          }
+
+          type Nested {
+            field: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            async slow() {
+              didInvokeSlowResolverD.resolve();
+              await didCancelD.promise;
+              return {};
+            },
+          },
+          Nested: {
+            field() {
+              didInvokedNestedField = true;
+              return 'test';
+            },
+          },
+        },
+      }),
+    });
+    const server = createServer(yoga);
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const controller = new AbortController();
+      const response$ = fetch(`http://localhost:${port}/graphql`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              slow {
+                field
+              }
+            }
+          `,
+        }),
+        signal: controller.signal,
+      });
+
+      await didInvokeSlowResolverD.promise;
+      controller.abort();
+      await expect(response$).rejects.toThrow('The operation was aborted');
+      // wait a few milliseconds to ensure server-side cancellation logic runs
+      await new Promise<void>(resolve => setTimeout(resolve, 10));
+      didCancelD.resolve();
+      // wait a few milliseconds to allow the nested field resolver to run (if cancellation logic is incorrect)
+      await new Promise<void>(resolve => setTimeout(resolve, 10));
+      expect(didInvokedNestedField).toBe(false);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
 });
+
+type Deferred<T = void> = {
+  resolve: (value: T) => void;
+  reject: (value: unknown) => void;
+  promise: Promise<T>;
+};
+
+function createDeferred<T = void>(): Deferred<T> {
+  const d = {} as Deferred<T>;
+  d.promise = new Promise<T>((resolve, reject) => {
+    d.resolve = resolve;
+    d.reject = reject;
+  });
+  return d;
+}

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,6 +1,6 @@
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createLogger, createSchema, createYoga, FetchAPI } from '../src/index';
-import { useExecutionCancellation } from '../src/plugins/use-execution-cancellation';
+import { useExecutionCancelation } from '../src/plugins/use-execution-cancelation';
 
 const variants: Array<[name: string, fetchAPI: undefined | FetchAPI]> = [
   ['Ponyfilled WhatWG Fetch', undefined],
@@ -75,7 +75,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       schema,
       fetchAPI,
       logging: logger,
-      plugins: [useExecutionCancellation()],
+      plugins: [useExecutionCancelation()],
     });
     const abortController = new AbortController();
     const promise = Promise.resolve(
@@ -145,7 +145,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       schema,
       fetchAPI,
       logging: logger,
-      plugins: [useExecutionCancellation()],
+      plugins: [useExecutionCancelation()],
     });
     const abortController = new AbortController();
     const response = await yoga.fetch('http://yoga/graphql', {
@@ -230,7 +230,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     logger.debug = debugLogs;
     const yoga = createYoga({
       schema,
-      plugins: [useDeferStream(), useExecutionCancellation()],
+      plugins: [useDeferStream(), useExecutionCancelation()],
       fetchAPI,
       logging: logger,
     });

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,0 +1,82 @@
+import { createSchema, createYoga } from '../src/index';
+
+describe('request cancellation', () => {
+  it('request cancellation stops invocation of subsequent resolvers', async () => {
+    const rootResolverGotInvokedD = createDeferred();
+    const requestGotCancelledD = createDeferred();
+
+    let aResolverGotInvoked = false;
+    let rootResolverGotInvoked = false;
+
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          root: A!
+        }
+
+        type A {
+          a: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          async root() {
+            rootResolverGotInvoked = true;
+            rootResolverGotInvokedD.resolve();
+            await requestGotCancelledD.promise;
+
+            return { a: 'a' };
+          },
+        },
+        A: {
+          a() {
+            aResolverGotInvoked = true;
+            return 'a';
+          },
+        },
+      },
+    });
+
+    const yoga = createYoga({ schema });
+
+    const abortController = new AbortController();
+    const promise = Promise.resolve(
+      yoga.fetch('http://yoga/graphql', {
+        method: 'POST',
+        body: JSON.stringify({ query: '{ root { a } }' }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: abortController.signal,
+      }),
+    );
+
+    await rootResolverGotInvokedD.promise;
+    abortController.abort();
+
+    requestGotCancelledD.resolve();
+
+    // The request was aborted, so the promise should raise instead
+    const result = await promise.then(res => res.text());
+    // why does this return a (invalid) GraphQL response?
+    expect(result).toMatchInlineSnapshot(`"{"data":{"root":{"a":null}}}"`);
+
+    expect(rootResolverGotInvoked).toBe(true);
+    expect(aResolverGotInvoked).toBe(false);
+  });
+});
+
+type Deferred<T = void> = {
+  resolve: (value: T) => void;
+  reject: (value: unknown) => void;
+  promise: Promise<T>;
+};
+
+function createDeferred<T = void>(): Deferred<T> {
+  const d = {} as Deferred<T>;
+  d.promise = new Promise<T>((resolve, reject) => {
+    d.resolve = resolve;
+    d.reject = reject;
+  });
+  return d;
+}

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,6 +1,6 @@
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createLogger, createSchema, createYoga, FetchAPI } from '../src/index';
-import { useExecutionCancelation } from '../src/plugins/use-execution-cancelation';
+import { useExecutionCancellation } from '../src/plugins/use-execution-cancellation';
 
 const variants: Array<[name: string, fetchAPI: undefined | FetchAPI]> = [
   ['Ponyfilled WhatWG Fetch', undefined],
@@ -75,7 +75,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       schema,
       fetchAPI,
       logging: logger,
-      plugins: [useExecutionCancelation()],
+      plugins: [useExecutionCancellation()],
     });
     const abortController = new AbortController();
     const promise = Promise.resolve(
@@ -145,7 +145,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       schema,
       fetchAPI,
       logging: logger,
-      plugins: [useExecutionCancelation()],
+      plugins: [useExecutionCancellation()],
     });
     const abortController = new AbortController();
     const response = await yoga.fetch('http://yoga/graphql', {
@@ -230,7 +230,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     logger.debug = debugLogs;
     const yoga = createYoga({
       schema,
-      plugins: [useDeferStream(), useExecutionCancelation()],
+      plugins: [useDeferStream(), useExecutionCancellation()],
       fetchAPI,
       logging: logger,
     });

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -56,10 +56,7 @@ describe('request cancellation', () => {
 
     requestGotCancelledD.resolve();
 
-    // The request was aborted, so the promise should raise instead
-    const result = await promise.then(res => res.text());
-    // why does this return a (invalid) GraphQL response?
-    expect(result).toMatchInlineSnapshot(`"{"data":{"root":{"a":null}}}"`);
+    await expect(promise).rejects.toThrow('Aborted');
 
     expect(rootResolverGotInvoked).toBe(true);
     expect(aResolverGotInvoked).toBe(false);

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -217,7 +217,12 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     const logger = createLogger('silent');
     const debugLogs = jest.fn();
     logger.debug = debugLogs;
-    const yoga = createYoga({ schema, plugins: [useDeferStream()], fetchAPI, logging: logger });
+    const yoga = createYoga({
+      schema,
+      plugins: [useDeferStream()],
+      fetchAPI,
+      logging: logger,
+    });
 
     const abortController = new AbortController();
     const response = await yoga.fetch('http://yoga/graphql', {

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -4,16 +4,13 @@ describe('request cancellation', () => {
   it('request cancellation stops invocation of subsequent resolvers', async () => {
     const rootResolverGotInvokedD = createDeferred();
     const requestGotCancelledD = createDeferred();
-
     let aResolverGotInvoked = false;
     let rootResolverGotInvoked = false;
-
     const schema = createSchema({
       typeDefs: /* GraphQL */ `
         type Query {
           root: A!
         }
-
         type A {
           a: String!
         }
@@ -24,7 +21,6 @@ describe('request cancellation', () => {
             rootResolverGotInvoked = true;
             rootResolverGotInvokedD.resolve();
             await requestGotCancelledD.promise;
-
             return { a: 'a' };
           },
         },
@@ -36,9 +32,7 @@ describe('request cancellation', () => {
         },
       },
     });
-
     const yoga = createYoga({ schema });
-
     const abortController = new AbortController();
     const promise = Promise.resolve(
       yoga.fetch('http://yoga/graphql', {
@@ -50,16 +44,13 @@ describe('request cancellation', () => {
         signal: abortController.signal,
       }),
     );
-
     await rootResolverGotInvokedD.promise;
     abortController.abort();
-
     requestGotCancelledD.resolve();
-
-    await expect(promise).rejects.toThrow('Aborted');
-
+    await expect(promise).rejects.toThrow('This operation was aborted');
     expect(rootResolverGotInvoked).toBe(true);
     expect(aResolverGotInvoked).toBe(false);
+    await requestGotCancelledD.promise;
   });
 });
 

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,5 +1,6 @@
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createLogger, createSchema, createYoga, FetchAPI } from '../src/index';
+import { useExecutionCancellation } from '../src/plugins/use-execution-cancellation';
 
 const variants: Array<[name: string, fetchAPI: undefined | FetchAPI]> = [
   ['Ponyfilled WhatWG Fetch', undefined],
@@ -70,7 +71,12 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     const logger = createLogger('silent');
     const debugLogs = jest.fn();
     logger.debug = debugLogs;
-    const yoga = createYoga({ schema, fetchAPI, logging: logger });
+    const yoga = createYoga({
+      schema,
+      fetchAPI,
+      logging: logger,
+      plugins: [useExecutionCancellation()],
+    });
     const abortController = new AbortController();
     const promise = Promise.resolve(
       yoga.fetch('http://yoga/graphql', {
@@ -135,7 +141,12 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     const logger = createLogger('silent');
     const debugLogs = jest.fn();
     logger.debug = debugLogs;
-    const yoga = createYoga({ schema, fetchAPI, logging: logger });
+    const yoga = createYoga({
+      schema,
+      fetchAPI,
+      logging: logger,
+      plugins: [useExecutionCancellation()],
+    });
     const abortController = new AbortController();
     const response = await yoga.fetch('http://yoga/graphql', {
       method: 'POST',
@@ -219,7 +230,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
     logger.debug = debugLogs;
     const yoga = createYoga({
       schema,
-      plugins: [useDeferStream()],
+      plugins: [useDeferStream(), useExecutionCancellation()],
       fetchAPI,
       logging: logger,
     });

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,11 +1,47 @@
-import { createSchema, createYoga } from '../src/index';
+import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
+import { createLogger, createSchema, createYoga, FetchAPI } from '../src/index';
 
-describe('request cancellation', () => {
-  it('request cancellation stops invocation of subsequent resolvers', async () => {
+const variants: Array<[name: string, fetchAPI: undefined | FetchAPI]> = [
+  ['Ponyfilled WhatWG Fetch', undefined],
+];
+
+const [major] = globalThis?.process?.versions?.node.split('.') ?? [];
+
+if (major === '21' && process.env.LEAKS_TEST !== 'true') {
+  variants.push([
+    'Node.js 21',
+    {
+      fetch: globalThis.fetch,
+      Blob: globalThis.Blob,
+      btoa: globalThis.btoa,
+      FormData: globalThis.FormData,
+      Headers: globalThis.Headers,
+      Request: globalThis.Request,
+      crypto: globalThis.crypto,
+      File: globalThis.File,
+      ReadableStream: globalThis.ReadableStream,
+      // @ts-expect-error json function signature
+      Response: globalThis.Response,
+      TextDecoder: globalThis.TextDecoder,
+      TextEncoder: globalThis.TextEncoder,
+      URL: globalThis.URL,
+      TransformStream: globalThis.TransformStream,
+      // URLPattern: globalThis.URLPattern,
+      URLSearchParams: globalThis.URLSearchParams,
+      WritableStream: globalThis.WritableStream,
+    },
+  ]);
+}
+
+function waitAFewMillisecondsToMakeSureGraphQLExecutionIsNotResumingInBackground() {
+  return new Promise(res => setTimeout(res, 5));
+}
+
+describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
+  it('request cancellation stops invocation of subsequent resolvers (GraphQL over HTTP)', async () => {
     const rootResolverGotInvokedD = createDeferred();
     const requestGotCancelledD = createDeferred();
     let aResolverGotInvoked = false;
-    let rootResolverGotInvoked = false;
     const schema = createSchema({
       typeDefs: /* GraphQL */ `
         type Query {
@@ -18,7 +54,6 @@ describe('request cancellation', () => {
       resolvers: {
         Query: {
           async root() {
-            rootResolverGotInvoked = true;
             rootResolverGotInvokedD.resolve();
             await requestGotCancelledD.promise;
             return { a: 'a' };
@@ -32,7 +67,10 @@ describe('request cancellation', () => {
         },
       },
     });
-    const yoga = createYoga({ schema });
+    const logger = createLogger('silent');
+    const debugLogs = jest.fn();
+    logger.debug = debugLogs;
+    const yoga = createYoga({ schema, fetchAPI, logging: logger });
     const abortController = new AbortController();
     const promise = Promise.resolve(
       yoga.fetch('http://yoga/graphql', {
@@ -48,9 +86,188 @@ describe('request cancellation', () => {
     abortController.abort();
     requestGotCancelledD.resolve();
     await expect(promise).rejects.toThrow('This operation was aborted');
-    expect(rootResolverGotInvoked).toBe(true);
+    await waitAFewMillisecondsToMakeSureGraphQLExecutionIsNotResumingInBackground();
     expect(aResolverGotInvoked).toBe(false);
-    await requestGotCancelledD.promise;
+    expect(debugLogs.mock.calls).toEqual([
+      ['Parsing request to extract GraphQL parameters'],
+      ['Processing GraphQL Parameters'],
+      ['Request aborted'],
+    ]);
+  });
+
+  it('request cancellation stops invocation of subsequent resolvers (GraphQL over SSE with Subscription)', async () => {
+    const rootResolverGotInvokedD = createDeferred();
+    const requestGotCancelledD = createDeferred();
+    let aResolverGotInvoked = false;
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          root: A!
+        }
+        type Subscription {
+          root: A!
+        }
+        type A {
+          a: String!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          root: {
+            async *subscribe() {
+              yield 1;
+            },
+            async resolve() {
+              rootResolverGotInvokedD.resolve();
+              await requestGotCancelledD.promise;
+              return { a: 'a' };
+            },
+          },
+        },
+        A: {
+          a() {
+            aResolverGotInvoked = true;
+            return 'a';
+          },
+        },
+      },
+    });
+    const logger = createLogger('silent');
+    const debugLogs = jest.fn();
+    logger.debug = debugLogs;
+    const yoga = createYoga({ schema, fetchAPI, logging: logger });
+    const abortController = new AbortController();
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: 'subscription { root { a } }' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      signal: abortController.signal,
+    });
+    expect(response.status).toBe(200);
+    const iterator = response.body![Symbol.asyncIterator]();
+    // first we will always get a ping/keep alive for flushed headers
+    const next = await iterator.next();
+    expect(Buffer.from(next.value).toString('utf-8')).toMatchInlineSnapshot(`
+":
+
+"
+`);
+
+    await rootResolverGotInvokedD.promise;
+    const next$ = iterator.next().then(({ done, value }) => {
+      // in case it resolves, parse the buffer to string for easier debugging.
+      return { done, value: Buffer.from(value).toString('utf-8') };
+    });
+
+    abortController.abort();
+    requestGotCancelledD.resolve();
+
+    await expect(next$).rejects.toThrow('This operation was aborted');
+    await waitAFewMillisecondsToMakeSureGraphQLExecutionIsNotResumingInBackground();
+    expect(aResolverGotInvoked).toBe(false);
+
+    expect(debugLogs.mock.calls).toEqual([
+      ['Parsing request to extract GraphQL parameters'],
+      ['Processing GraphQL Parameters'],
+      ['Processing GraphQL Parameters done.'],
+      ['Request aborted'],
+    ]);
+  });
+
+  it('request cancellation stops invocation of subsequent resolvers (GraphQL over Multipart with defer/stream)', async () => {
+    const aResolverGotInvokedD = createDeferred();
+    const requestGotCancelledD = createDeferred();
+    let bResolverGotInvoked = false;
+    const schema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          root: A!
+        }
+        type A {
+          a: B!
+        }
+        type B {
+          b: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          async root() {
+            return { a: 'a' };
+          },
+        },
+        A: {
+          async a() {
+            aResolverGotInvokedD.resolve();
+            await requestGotCancelledD.promise;
+            return { b: 'b' };
+          },
+        },
+        B: {
+          b: obj => {
+            bResolverGotInvoked = true;
+            return obj.b;
+          },
+        },
+      },
+    });
+    const logger = createLogger('silent');
+    const debugLogs = jest.fn();
+    logger.debug = debugLogs;
+    const yoga = createYoga({ schema, plugins: [useDeferStream()], fetchAPI, logging: logger });
+
+    const abortController = new AbortController();
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          query {
+            root {
+              ... @defer {
+                a {
+                  b
+                }
+              }
+            }
+          }
+        `,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        accept: 'multipart/mixed',
+      },
+      signal: abortController.signal,
+    });
+    expect(response.status).toEqual(200);
+    const iterator = response.body![Symbol.asyncIterator]();
+    let payload = '';
+
+    // Shitty wait condition, but it works lol
+    while (payload.split('\r\n').length < 6 || !payload.endsWith('---')) {
+      const next = await iterator.next();
+      payload += Buffer.from(next.value).toString('utf-8');
+    }
+
+    const next$ = iterator.next().then(({ done, value }) => {
+      // in case it resolves, parse the buffer to string for easier debugging.
+      return { done, value: Buffer.from(value).toString('utf-8') };
+    });
+
+    await aResolverGotInvokedD.promise;
+    abortController.abort();
+    requestGotCancelledD.resolve();
+    await expect(next$).rejects.toThrow('This operation was aborted');
+    await waitAFewMillisecondsToMakeSureGraphQLExecutionIsNotResumingInBackground();
+    expect(bResolverGotInvoked).toBe(false);
+    expect(debugLogs.mock.calls).toEqual([
+      ['Parsing request to extract GraphQL parameters'],
+      ['Processing GraphQL Parameters'],
+      ['Processing GraphQL Parameters done.'],
+      ['Request aborted'],
+    ]);
   });
 });
 

--- a/packages/graphql-yoga/__tests__/utilities.ts
+++ b/packages/graphql-yoga/__tests__/utilities.ts
@@ -15,7 +15,7 @@ export function eventStream<TType = unknown>(source: ReadableStream<Uint8Array>)
         break;
       }
 
-      const values = result.value.toString().split('\n').filter(Boolean);
+      const values = Buffer.from(result.value).toString('utf-8').split('\n').filter(Boolean);
       for (const value of values) {
         if (!value.startsWith('data: ')) {
           continue;

--- a/packages/graphql-yoga/__tests__/utilities.ts
+++ b/packages/graphql-yoga/__tests__/utilities.ts
@@ -4,7 +4,10 @@ import { Repeater } from '@repeaterjs/repeater';
 /** Parse SSE event stream and yield data pieces. */
 export function eventStream<TType = unknown>(source: ReadableStream<Uint8Array>) {
   return new Repeater<TType>(async (push, end) => {
-    const cancel: Promise<{ done: true }> = end.then(() => ({ done: true }));
+    const cancel: Promise<{ done: true; value: undefined }> = end.then(() => ({
+      done: true,
+      value: undefined,
+    }));
     const iterable = source[Symbol.asyncIterator]();
 
     // eslint-disable-next-line no-constant-condition

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -56,7 +56,7 @@
     "@graphql-yoga/logger": "^2.0.0",
     "@graphql-yoga/subscription": "^5.0.0",
     "@whatwg-node/fetch": "^0.9.7",
-    "@whatwg-node/server": "^0.9.1",
+    "@whatwg-node/server": "^0.9.27",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.5.2"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -50,13 +50,13 @@
   },
   "dependencies": {
     "@envelop/core": "^5.0.0",
-    "@graphql-tools/executor": "^1.2.2",
+    "@graphql-tools/executor": "^1.2.3",
     "@graphql-tools/schema": "^10.0.0",
     "@graphql-tools/utils": "^10.1.0",
     "@graphql-yoga/logger": "^2.0.0",
     "@graphql-yoga/subscription": "^5.0.0",
-    "@whatwg-node/fetch": "^0.9.7",
-    "@whatwg-node/server": "^0.9.27",
+    "@whatwg-node/fetch": "^0.9.17",
+    "@whatwg-node/server": "^0.9.30",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.5.2"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -56,7 +56,7 @@
     "@graphql-yoga/logger": "^2.0.0",
     "@graphql-yoga/subscription": "^5.0.0",
     "@whatwg-node/fetch": "^0.9.17",
-    "@whatwg-node/server": "^0.9.31",
+    "@whatwg-node/server": "^0.9.32",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.5.2"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -56,7 +56,7 @@
     "@graphql-yoga/logger": "^2.0.0",
     "@graphql-yoga/subscription": "^5.0.0",
     "@whatwg-node/fetch": "^0.9.17",
-    "@whatwg-node/server": "^0.9.30",
+    "@whatwg-node/server": "^0.9.31",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.5.2"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@envelop/core": "^5.0.0",
-    "@graphql-tools/executor": "^1.2.3",
+    "@graphql-tools/executor": "^1.2.5",
     "@graphql-tools/schema": "^10.0.0",
     "@graphql-tools/utils": "^10.1.0",
     "@graphql-yoga/logger": "^2.0.0",

--- a/packages/graphql-yoga/src/error.ts
+++ b/packages/graphql-yoga/src/error.ts
@@ -50,6 +50,11 @@ export function handleError(
         errors.add(handledError);
       }
     }
+  } else if (
+    error?.constructor?.name === 'DOMException' &&
+    (error as Record<string, unknown>).name === 'AbortError'
+  ) {
+    logger.debug('Request aborted');
   } else if (maskedErrorsOpts) {
     const maskedError = maskedErrorsOpts.maskError(
       error,

--- a/packages/graphql-yoga/src/error.ts
+++ b/packages/graphql-yoga/src/error.ts
@@ -37,6 +37,14 @@ export function isOriginalGraphQLError(
   return false;
 }
 
+export function isAbortError(error: unknown): error is DOMException {
+  return (
+    typeof error === 'object' &&
+    error?.constructor?.name === 'DOMException' &&
+    (error as Record<string, unknown>).name === 'AbortError'
+  );
+}
+
 export function handleError(
   error: unknown,
   maskedErrorsOpts: YogaMaskedErrorOpts | null,
@@ -50,10 +58,7 @@ export function handleError(
         errors.add(handledError);
       }
     }
-  } else if (
-    error?.constructor?.name === 'DOMException' &&
-    (error as Record<string, unknown>).name === 'AbortError'
-  ) {
+  } else if (isAbortError(error)) {
     logger.debug('Request aborted');
   } else if (maskedErrorsOpts) {
     const maskedError = maskedErrorsOpts.maskError(

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -38,4 +38,4 @@ export {
   usePayloadFormatter,
 } from '@envelop/core';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
-export { useExecutionCancelation } from './plugins/use-execution-cancelation.js';
+export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -38,4 +38,4 @@ export {
   usePayloadFormatter,
 } from '@envelop/core';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
-export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';
+export { useExecutionCancelation } from './plugins/use-execution-cancelation.js';

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -38,3 +38,4 @@ export {
   usePayloadFormatter,
 } from '@envelop/core';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
+export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';

--- a/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
@@ -37,28 +37,33 @@ export function processMultipartResult(result: ResultProcessorInput, fetchAPI: F
       controller.enqueue(textEncoder.encode(`---`));
     },
     async pull(controller) {
-      const { done, value } = await iterator.next();
-      if (value != null) {
-        controller.enqueue(textEncoder.encode('\r\n'));
+      try {
+        const { done, value } = await iterator.next();
+        if (value != null) {
+          controller.enqueue(textEncoder.encode('\r\n'));
 
-        controller.enqueue(textEncoder.encode('Content-Type: application/json; charset=utf-8'));
-        controller.enqueue(textEncoder.encode('\r\n'));
+          controller.enqueue(textEncoder.encode('Content-Type: application/json; charset=utf-8'));
+          controller.enqueue(textEncoder.encode('\r\n'));
 
-        const chunk = jsonStringifyResultWithoutInternals(value);
-        const encodedChunk = textEncoder.encode(chunk);
+          const chunk = jsonStringifyResultWithoutInternals(value);
+          const encodedChunk = textEncoder.encode(chunk);
 
-        controller.enqueue(textEncoder.encode('Content-Length: ' + encodedChunk.byteLength));
-        controller.enqueue(textEncoder.encode('\r\n'));
+          controller.enqueue(textEncoder.encode('Content-Length: ' + encodedChunk.byteLength));
+          controller.enqueue(textEncoder.encode('\r\n'));
 
-        controller.enqueue(textEncoder.encode('\r\n'));
-        controller.enqueue(encodedChunk);
-        controller.enqueue(textEncoder.encode('\r\n'));
+          controller.enqueue(textEncoder.encode('\r\n'));
+          controller.enqueue(encodedChunk);
+          controller.enqueue(textEncoder.encode('\r\n'));
 
-        controller.enqueue(textEncoder.encode('---'));
-      }
-      if (done) {
-        controller.enqueue(textEncoder.encode('--\r\n'));
-        controller.close();
+          controller.enqueue(textEncoder.encode('---'));
+        }
+
+        if (done) {
+          controller.enqueue(textEncoder.encode('--\r\n'));
+          controller.close();
+        }
+      } catch (err) {
+        controller.error(err);
       }
     },
     async cancel(e) {

--- a/packages/graphql-yoga/src/plugins/use-execution-cancelation.ts
+++ b/packages/graphql-yoga/src/plugins/use-execution-cancelation.ts
@@ -3,7 +3,7 @@ import type { Plugin } from './types';
 /**
  * Enables experimental support for request cancelation.
  */
-export function useExecutionCancellation(): Plugin {
+export function useExecutionCancelation(): Plugin {
   return {
     onExecute({ args }) {
       // @ts-expect-error we don't have this typing in envelop

--- a/packages/graphql-yoga/src/plugins/use-execution-cancellation.ts
+++ b/packages/graphql-yoga/src/plugins/use-execution-cancellation.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from './types';
+
+/**
+ * Enables experimental support for request cancelation.
+ */
+export function useExecutionCancellation(): Plugin {
+  return {
+    onExecute({ args }) {
+      // @ts-expect-error we don't have this typing in envelop
+      args.signal = args.contextValue?.request?.signal ?? undefined;
+    },
+    onSubscribe({ args }) {
+      // @ts-expect-error we don't have this typing in envelop
+      args.signal = args.contextValue?.request?.signal ?? undefined;
+    },
+  };
+}

--- a/packages/graphql-yoga/src/plugins/use-execution-cancellation.ts
+++ b/packages/graphql-yoga/src/plugins/use-execution-cancellation.ts
@@ -3,7 +3,7 @@ import type { Plugin } from './types';
 /**
  * Enables experimental support for request cancelation.
  */
-export function useExecutionCancelation(): Plugin {
+export function useExecutionCancellation(): Plugin {
   return {
     onExecute({ args }) {
       // @ts-expect-error we don't have this typing in envelop

--- a/packages/graphql-yoga/src/process-request.ts
+++ b/packages/graphql-yoga/src/process-request.ts
@@ -1,5 +1,6 @@
-import { ExecutionArgs, getOperationAST } from 'graphql';
+import { getOperationAST } from 'graphql';
 import { GetEnvelopedFn } from '@envelop/core';
+import { ExecutionArgs } from '@graphql-tools/executor';
 import { OnResultProcess, ResultProcessor, ResultProcessorInput } from './plugins/types.js';
 import { FetchAPI, GraphQLParams } from './types.js';
 
@@ -71,13 +72,13 @@ export async function processRequest({
 
   // Build the context for the execution
   const contextValue = await enveloped.contextFactory();
-
   const executionArgs: ExecutionArgs = {
     schema: enveloped.schema,
     document,
     contextValue,
     variableValues: params.variables,
     operationName: params.operationName,
+    signal: contextValue?.request?.signal ?? undefined,
   };
 
   // Get the actual operation

--- a/packages/graphql-yoga/src/process-request.ts
+++ b/packages/graphql-yoga/src/process-request.ts
@@ -78,7 +78,6 @@ export async function processRequest({
     contextValue,
     variableValues: params.variables,
     operationName: params.operationName,
-    signal: contextValue?.request?.signal ?? undefined,
   };
 
   // Get the actual operation

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -373,7 +373,20 @@ export class YogaServer<
           // We make sure that the user doesn't send a mutation with GET
           // @ts-expect-error Add plugins has context but this hook doesn't care
           addPlugin(usePreventMutationViaGET());
+
           if (maskedErrors) {
+            // Make sure we always throw AbortError instead of masking it!
+            addPlugin({
+              onSubscribe() {
+                return {
+                  onSubscribeError({ error }) {
+                    if ((error as any)?.name === 'AbortError') {
+                      throw error;
+                    }
+                  },
+                };
+              },
+            });
             addPlugin(useMaskedErrors(maskedErrors));
           }
           addPlugin(
@@ -468,7 +481,6 @@ export class YogaServer<
         const enveloped = this.getEnveloped(initialContext);
 
         this.logger.debug(`Processing GraphQL Parameters`);
-
         result = await processGraphQLParams({
           params,
           enveloped,
@@ -485,6 +497,11 @@ export class YogaServer<
           iterator,
           v => v,
           (err: Error) => {
+            if (err.name === 'AbortError') {
+              this.logger.debug(`Request aborted`);
+              throw err;
+            }
+
             const errors = handleError(err, this.maskedErrorsOpts, this.logger);
             return {
               errors,

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -21,7 +21,7 @@ import {
   useCORS,
   useErrorHandling,
 } from '@whatwg-node/server';
-import { handleError } from './error.js';
+import { handleError, isAbortError } from './error.js';
 import { isGETRequest, parseGETRequest } from './plugins/request-parser/get.js';
 import {
   isPOSTFormUrlEncodedRequest,
@@ -380,7 +380,7 @@ export class YogaServer<
               onSubscribe() {
                 return {
                   onSubscribeError({ error }) {
-                    if ((error as any)?.name === 'AbortError') {
+                    if (isAbortError(error)) {
                       throw error;
                     }
                   },

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
     "@types/express": "^4.17.17",
     "@types/glob": "^8.0.1",
     "@types/ws": "^8.5.4",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "express": "^4.18.2",
     "fastify": "^4.13.0",
     "glob": "^10.0.0",

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -162,7 +162,7 @@ export abstract class AbstractYogaDriver<
     this.yoga = yoga as YogaDriverServerInstance<Platform>;
 
     app.all(yoga.graphqlEndpoint, async (req, reply) => {
-      const response = await yoga.handleNodeRequest(req, {
+      const response = await yoga.handleNodeRequestAndResponse(req, reply, {
         req,
         reply,
       });

--- a/packages/plugins/apollo-inline-trace/package.json
+++ b/packages/plugins/apollo-inline-trace/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@graphql-tools/utils": "^10.0.0",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "graphql": "^15.2.0 || ^16.0.0",
     "graphql-yoga": "^5.2.0"
   },
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@envelop/on-resolve": "^4.0.0",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "graphql": "^16.6.0",
     "graphql-yoga": "5.2.0"
   },

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -1,6 +1,6 @@
 import { createServer, get, IncomingMessage } from 'node:http';
 import { AddressInfo } from 'node:net';
-import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createPushPullAsyncIterable } from '../__tests__/push-pull-async-iterable.js';
 
@@ -141,7 +141,7 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
         },
       },
     }),
-    plugins: [useDeferStream(), useExecutionCancellation()],
+    plugins: [useDeferStream(), useExecutionCancelation()],
     logging: logger,
   });
 

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -1,6 +1,6 @@
 import { createServer, get, IncomingMessage } from 'node:http';
 import { AddressInfo } from 'node:net';
-import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createPushPullAsyncIterable } from '../__tests__/push-pull-async-iterable.js';
 
@@ -141,7 +141,7 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
         },
       },
     }),
-    plugins: [useDeferStream(), useExecutionCancelation()],
+    plugins: [useDeferStream(), useExecutionCancellation()],
     logging: logger,
   });
 

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -1,8 +1,7 @@
 import { createServer, get, IncomingMessage } from 'node:http';
 import { AddressInfo } from 'node:net';
-import { createSchema, createYoga } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga } from 'graphql-yoga';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
-import { fetch } from '@whatwg-node/fetch';
 import { createPushPullAsyncIterable } from '../__tests__/push-pull-async-iterable.js';
 
 it('correctly deals with the source upon aborted requests', async () => {
@@ -87,33 +86,48 @@ it('correctly deals with the source upon aborted requests', async () => {
   }
 });
 
+type Deferred<T = void> = {
+  resolve: (value: T) => void;
+  reject: (value: unknown) => void;
+  promise: Promise<T>;
+};
+
+function createDeferred<T = void>(): Deferred<T> {
+  const d = {} as Deferred<T>;
+  d.promise = new Promise<T>((resolve, reject) => {
+    d.resolve = resolve;
+    d.reject = reject;
+  });
+  return d;
+}
+
 it('memory/cleanup leak by source that never publishes a value', async () => {
   let sourceGotCleanedUp = false;
-  let i = 1;
-  let interval: NodeJS.Timer;
   const controller = new AbortController();
+  const d = createDeferred();
 
-  const noop = new Promise<{ done: true; value: undefined }>(() => undefined);
+  const noop = d.promise.then(() => ({ done: true, value: undefined }));
+
   const source = {
     [Symbol.asyncIterator]() {
       return this;
     },
     next() {
-      interval = setInterval(() => {
-        i++;
-        if (i === 3) {
-          controller.abort();
-        }
+      setTimeout(() => {
+        controller.abort();
       }, 10);
       return noop;
     },
     return() {
-      clearInterval(interval);
       sourceGotCleanedUp = true;
       return Promise.resolve({ done: true, value: undefined });
     },
   };
 
+  const logger = createLogger('silent');
+  const debugLogger = jest.fn();
+
+  logger.debug = debugLogger;
   const yoga = createYoga({
     schema: createSchema({
       typeDefs: /* GraphQL */ `
@@ -128,9 +142,11 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
       },
     }),
     plugins: [useDeferStream()],
+    logging: logger,
   });
 
   const server = createServer(yoga);
+
   try {
     await new Promise<void>(resolve => {
       server.listen(() => {
@@ -144,46 +160,46 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
     }
 
     const response = await new Promise<IncomingMessage>(resolve => {
-      const request = get(
+      get(
         `http://localhost:${port}/graphql?query={hi @stream}`,
         {
           headers: {
             accept: 'multipart/mixed',
           },
+          signal: controller.signal,
         },
-        res => resolve(res),
-      );
-      controller.signal.addEventListener(
-        'abort',
-        () => {
-          request.destroy();
-        },
-        { once: true },
+        response => resolve(response),
       );
     });
 
-    try {
-      for await (const chunk of response) {
-        const chunkStr = Buffer.from(chunk).toString('utf-8');
-        expect(chunkStr).toMatchInlineSnapshot(`
-          "---
-          Content-Type: application/json; charset=utf-8
-          Content-Length: 33
+    const iterator = response![Symbol.asyncIterator]();
 
-          {"data":{"hi":[]},"hasNext":true}
-          ---"
-        `);
-      }
-    } catch (err: unknown) {
-      expect((err as Error).message).toContain('aborted');
-    }
+    const next = await iterator.next();
+
+    const chunkStr = Buffer.from(next.value).toString('utf-8');
+    expect(chunkStr).toMatchInlineSnapshot(`
+    "---
+    Content-Type: application/json; charset=utf-8
+    Content-Length: 33
+
+    {"data":{"hi":[]},"hasNext":true}
+    ---"
+    `);
+
+    await expect(iterator.next()).rejects.toMatchInlineSnapshot(`[Error: aborted]`);
 
     // Wait a bit - just to make sure the time is cleaned up for sure...
     await new Promise(res => setTimeout(res, 50));
-
-    expect(i).toEqual(3);
     expect(sourceGotCleanedUp).toBe(true);
+
+    expect(debugLogger.mock.calls).toEqual([
+      ['Parsing request to extract GraphQL parameters'],
+      ['Processing GraphQL Parameters'],
+      ['Processing GraphQL Parameters done.'],
+      ['Request aborted'],
+    ]);
   } finally {
+    d.resolve();
     await new Promise<void>(res => {
       server.close(() => {
         res();

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -1,6 +1,6 @@
 import { createServer, get, IncomingMessage } from 'node:http';
 import { AddressInfo } from 'node:net';
-import { createLogger, createSchema, createYoga } from 'graphql-yoga';
+import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createPushPullAsyncIterable } from '../__tests__/push-pull-async-iterable.js';
 
@@ -141,7 +141,7 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
         },
       },
     }),
-    plugins: [useDeferStream()],
+    plugins: [useDeferStream(), useExecutionCancellation()],
     logging: logger,
   });
 

--- a/packages/plugins/defer-stream/package.json
+++ b/packages/plugins/defer-stream/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@graphql-tools/executor-http": "^1.0.4",
-    "@whatwg-node/fetch": "^0.9.7",
+    "@whatwg-node/fetch": "^0.9.17",
     "graphql": "^16.6.0",
     "tslib": "^2.5.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.0
-        version: 1.0.0(@whatwg-node/server@0.9.31)
+        version: 1.0.0(@whatwg-node/server@0.9.32)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1602,8 +1602,8 @@ importers:
         specifier: ^0.9.17
         version: 0.9.17
       '@whatwg-node/server':
-        specifier: ^0.9.31
-        version: 0.9.31
+        specifier: ^0.9.32
+        version: 0.9.32
       dset:
         specifier: ^3.1.1
         version: 3.1.2
@@ -14740,14 +14740,14 @@ packages:
       fast-querystring: 1.1.1
       tslib: 2.6.2
 
-  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.31):
+  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.32):
     resolution: {integrity: sha512-o0MqK6H4Yhxht+J+cgZIpEhdb4SID1grFWfOiMdni3csNHBKZ+MKAFhxS+6wAJsarHN7BEZ0QMu4PG09Uwhr2g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@whatwg-node/server': ^0.9.0
     dependencies:
       '@whatwg-node/cookie-store': 0.2.0
-      '@whatwg-node/server': 0.9.31
+      '@whatwg-node/server': 0.9.32
       tslib: 2.5.3
     dev: false
 
@@ -14759,8 +14759,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@whatwg-node/server@0.9.31:
-    resolution: {integrity: sha512-crd8CPnKX6UELsnoU8G4DjAjMYVgNykHsZiRZMaglwqICxY4s2J2QggU0Ism00wbtwJ43umEOGYnwE389BHGOg==}
+  /@whatwg-node/server@0.9.32:
+    resolution: {integrity: sha512-PRTRE8ZhObwYx9yRoUdxYkrhCoDk2vyDA5BtaG+NAqEmU1wwbwlXUpaeRRrPuGaM7ScbIkueU25A0GJIRQzccw==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@whatwg-node/fetch': 0.9.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,7 +1545,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.1
-        version: 8.0.1(@types/node@18.16.16)(graphql@16.6.0)
+        version: 8.0.1(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@6.0.0)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -1584,8 +1584,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       '@graphql-tools/executor':
-        specifier: ^1.2.3
-        version: 1.2.3(graphql@16.6.0)
+        specifier: ^1.2.5
+        version: 1.2.5(graphql@16.6.0)
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.0(graphql@16.6.0)
@@ -7811,7 +7811,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/batch-execute': 9.0.0(graphql@16.6.0)
-      '@graphql-tools/executor': 1.2.3(graphql@16.6.0)
+      '@graphql-tools/executor': 1.2.5(graphql@16.6.0)
       '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       dataloader: 2.2.2
@@ -7943,8 +7943,8 @@ packages:
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/executor@1.2.3(graphql@16.6.0):
-    resolution: {integrity: sha512-aAS+TGjSq8BJuDq1RV/A/8E53Iu3KvaWpD8DPio0Qe/0YF26tdpK6EcmNSGrrjiZOwVIZ80wclZrFstHzCPm8A==}
+  /@graphql-tools/executor@1.2.5(graphql@16.6.0):
+    resolution: {integrity: sha512-s7sW4K3BUNsk9sjq+vNicwb9KwcR3G55uS/CI8KZQ4x0ZdeYMIwpeU9MVeORCCpHuQyTaV+/VnO0hFrS/ygzsg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -8239,6 +8239,33 @@ packages:
       '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
+      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
+      '@types/ws': 8.5.4
+      '@whatwg-node/fetch': 0.9.17
+      graphql: 16.6.0
+      isomorphic-ws: 5.0.0(ws@8.13.0)
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: true
+
+  /@graphql-tools/url-loader@8.0.1(graphql@16.6.0):
+    resolution: {integrity: sha512-B2k8KQEkEQmfV1zhurT5GLoXo8jbXP+YQHUayhCSxKYlRV7j/1Fhp1b21PDM8LXIDGlDRXaZ0FbWKOs7eYXDuQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/sync-fetch': 0.0.1
+      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
+      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
       '@types/ws': 8.5.4
@@ -8253,6 +8280,7 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.0
-        version: 1.0.0(@whatwg-node/server@0.9.1)
+        version: 1.0.0(@whatwg-node/server@0.9.27)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1602,8 +1602,8 @@ importers:
         specifier: ^0.9.7
         version: 0.9.12
       '@whatwg-node/server':
-        specifier: ^0.9.1
-        version: 0.9.1
+        specifier: ^0.9.27
+        version: 0.9.27
       dset:
         specifier: ^3.1.1
         version: 3.1.2
@@ -7756,7 +7756,7 @@ packages:
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       graphql: 16.6.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -7890,7 +7890,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.4
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       extract-files: 11.0.0
       graphql: 16.6.0
       meros: 1.2.1(@types/node@18.16.16)
@@ -7984,7 +7984,7 @@ packages:
       '@graphql-tools/executor-http': 1.0.4(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/graphql-tag-pluck': 8.0.0(@babel/core@7.22.1)(graphql@16.6.0)
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       graphql: 16.6.0
       tslib: 2.6.2
       value-or-promise: 1.0.12
@@ -8127,7 +8127,7 @@ packages:
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       chalk: 4.1.2
       debug: 4.3.4(supports-color@9.2.3)
       dotenv: 16.3.1
@@ -8215,7 +8215,7 @@ packages:
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
       '@types/ws': 8.5.4
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       graphql: 16.6.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
       tslib: 2.6.2
@@ -9372,6 +9372,9 @@ packages:
     engines: {node: '>=v12.0.0'}
     dependencies:
       lodash: 4.17.21
+
+  /@kamilkisiela/fast-url-parser@1.1.4:
+    resolution: {integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==}
 
   /@lezer/common@1.1.1:
     resolution: {integrity: sha512-aAPB9YbvZHqAW+bIwiuuTDGB4DG0sYNRObGLxud8cW7osw1ZQxfDuTZ8KQiqfZ0QJGcR34CvpTMDXEyo/+Htgg==}
@@ -14706,6 +14709,13 @@ packages:
       '@whatwg-node/node-fetch': 0.4.18
       urlpattern-polyfill: 9.0.0
 
+  /@whatwg-node/fetch@0.9.17:
+    resolution: {integrity: sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/node-fetch': 0.5.8
+      urlpattern-polyfill: 10.0.0
+
   /@whatwg-node/node-fetch@0.3.6:
     resolution: {integrity: sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==}
     dependencies:
@@ -14737,14 +14747,24 @@ packages:
       fast-url-parser: 1.1.3
       tslib: 2.6.2
 
-  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.1):
+  /@whatwg-node/node-fetch@0.5.8:
+    resolution: {integrity: sha512-rB+2P3oi9fD4TcsijkflJAQqOh4yZrPgOV4fGaDgCdOqqwTicJvL2nnVbr3comW8bxEuypOcyE1AtBtkpip0Gw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@kamilkisiela/fast-url-parser': 1.1.4
+      '@whatwg-node/events': 0.1.0
+      busboy: 1.6.0
+      fast-querystring: 1.1.1
+      tslib: 2.6.2
+
+  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.27):
     resolution: {integrity: sha512-o0MqK6H4Yhxht+J+cgZIpEhdb4SID1grFWfOiMdni3csNHBKZ+MKAFhxS+6wAJsarHN7BEZ0QMu4PG09Uwhr2g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@whatwg-node/server': ^0.9.0
     dependencies:
       '@whatwg-node/cookie-store': 0.2.0
-      '@whatwg-node/server': 0.9.1
+      '@whatwg-node/server': 0.9.27
       tslib: 2.5.3
     dev: false
 
@@ -14752,16 +14772,16 @@ packages:
     resolution: {integrity: sha512-5nzOE61W5VA43rE4MeUVHLDPpZGDfGiQ5LnEwJNbVehUI6Ua8QD566C8dhBmXxFuT8pXTlxWZHe3sjjGZCc4ng==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       tslib: 2.6.2
     dev: false
 
-  /@whatwg-node/server@0.9.1:
-    resolution: {integrity: sha512-Zq0FWafIlJzYyyAL7UwzsEhqSMzvKci/XqIFKpC4V031PxKKPBmZSP1mXCew5eZFW8Z5Sj6bZNi2CIsHd062ug==}
+  /@whatwg-node/server@0.9.27:
+    resolution: {integrity: sha512-6H+rbzWtr+PD4MLiEroDzunp+L0UcsPleXg0BjttuEgA9N5a8like3kvQaJsTKQd37IaUsdX5b/eUVbx4ZT/7A==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      '@whatwg-node/fetch': 0.9.12
-      tslib: 2.5.3
+      '@whatwg-node/fetch': 0.9.17
+      tslib: 2.6.2
     dev: false
 
   /@wry/context@0.7.0:
@@ -20735,7 +20755,7 @@ packages:
     dependencies:
       '@ardatan/fast-json-stringify': 0.0.6(ajv-formats@2.1.1)(ajv@8.12.0)
       '@whatwg-node/cookie-store': 0.1.0
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       '@whatwg-node/server': 0.8.1
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
@@ -34517,6 +34537,9 @@ packages:
       punycode: 1.3.2
       querystring: 0.2.0
     dev: false
+
+  /urlpattern-polyfill@10.0.0:
+    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
   /urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.0
-        version: 1.0.0(@whatwg-node/server@0.9.30)
+        version: 1.0.0(@whatwg-node/server@0.9.31)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1545,7 +1545,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.1
-        version: 8.0.1(graphql@16.6.0)
+        version: 8.0.1(@types/node@18.16.16)(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@6.0.0)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -1602,8 +1602,8 @@ importers:
         specifier: ^0.9.17
         version: 0.9.17
       '@whatwg-node/server':
-        specifier: ^0.9.30
-        version: 0.9.30
+        specifier: ^0.9.31
+        version: 0.9.31
       dset:
         specifier: ^3.1.1
         version: 3.1.2
@@ -8239,33 +8239,6 @@ packages:
       '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
-      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
-      '@types/ws': 8.5.4
-      '@whatwg-node/fetch': 0.9.17
-      graphql: 16.6.0
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.6.2
-      value-or-promise: 1.0.12
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: true
-
-  /@graphql-tools/url-loader@8.0.1(graphql@16.6.0):
-    resolution: {integrity: sha512-B2k8KQEkEQmfV1zhurT5GLoXo8jbXP+YQHUayhCSxKYlRV7j/1Fhp1b21PDM8LXIDGlDRXaZ0FbWKOs7eYXDuQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
-      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
       '@types/ws': 8.5.4
@@ -8280,7 +8253,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}
@@ -14768,14 +14740,14 @@ packages:
       fast-querystring: 1.1.1
       tslib: 2.6.2
 
-  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.30):
+  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.31):
     resolution: {integrity: sha512-o0MqK6H4Yhxht+J+cgZIpEhdb4SID1grFWfOiMdni3csNHBKZ+MKAFhxS+6wAJsarHN7BEZ0QMu4PG09Uwhr2g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@whatwg-node/server': ^0.9.0
     dependencies:
       '@whatwg-node/cookie-store': 0.2.0
-      '@whatwg-node/server': 0.9.30
+      '@whatwg-node/server': 0.9.31
       tslib: 2.5.3
     dev: false
 
@@ -14787,8 +14759,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@whatwg-node/server@0.9.30:
-    resolution: {integrity: sha512-SeL1vL0/uF2xBkpy/dW4sA3aS4IBQMPk097QQ15vW21EhO0ow3RqQu2FCRLCnU1Xgiu8SCpvt3iQUBx74o4ZjQ==}
+  /@whatwg-node/server@0.9.31:
+    resolution: {integrity: sha512-crd8CPnKX6UELsnoU8G4DjAjMYVgNykHsZiRZMaglwqICxY4s2J2QggU0Ism00wbtwJ43umEOGYnwE389BHGOg==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@whatwg-node/fetch': 0.9.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: 2.4.7
         version: 2.4.7(graphql@16.6.0)
       '@whatwg-node/fetch':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.9.17
+        version: 0.9.17
 
   examples/apollo-federation-compatibility:
     dependencies:
@@ -335,8 +335,8 @@ importers:
         version: link:../../packages/graphql-yoga/dist
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.9.17
+        version: 0.9.17
 
   examples/cloudflare-advanced:
     dependencies:
@@ -376,8 +376,8 @@ importers:
         specifier: 4.20230518.0
         version: 4.20230518.0
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -389,7 +389,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.0
-        version: 1.0.0(@whatwg-node/server@0.9.27)
+        version: 1.0.0(@whatwg-node/server@0.9.30)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -437,8 +437,8 @@ importers:
   examples/error-handling:
     dependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -554,8 +554,8 @@ importers:
         version: 10.9.1(@types/node@18.16.16)(typescript@5.1.6)
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.9.17
+        version: 0.9.17
 
   examples/file-upload-nextjs-pothos:
     dependencies:
@@ -582,8 +582,8 @@ importers:
         specifier: 18.2.8
         version: 18.2.8
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       eslint:
         specifier: 8.42.0
         version: 8.42.0
@@ -607,8 +607,8 @@ importers:
         version: 1.3.0(graphql@16.6.0)
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@types/node@18.16.16)(typescript@5.1.6)
@@ -688,8 +688,8 @@ importers:
         specifier: 18.16.16
         version: 18.16.16
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -825,8 +825,8 @@ importers:
         version: link:../../packages/graphql-yoga/dist
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@types/node@18.16.16)(typescript@5.1.6)
@@ -1275,8 +1275,8 @@ importers:
         specifier: 18.16.16
         version: 18.16.16
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -1300,8 +1300,8 @@ importers:
         version: link:../../packages/graphql-yoga/dist
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1450,8 +1450,8 @@ importers:
         specifier: 8.5.4
         version: 8.5.4
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       ws:
         specifier: 8.13.0
         version: 8.13.0
@@ -1545,7 +1545,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.1
-        version: 8.0.1(@types/node@18.16.16)(graphql@16.6.0)
+        version: 8.0.1(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@6.0.0)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -1584,8 +1584,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       '@graphql-tools/executor':
-        specifier: ^1.2.2
-        version: 1.2.2(graphql@16.6.0)
+        specifier: ^1.2.3
+        version: 1.2.3(graphql@16.6.0)
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.0(graphql@16.6.0)
@@ -1599,11 +1599,11 @@ importers:
         specifier: ^5.0.0
         version: link:../subscription/dist
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       '@whatwg-node/server':
-        specifier: ^0.9.27
-        version: 0.9.27
+        specifier: ^0.9.30
+        version: 0.9.30
       dset:
         specifier: ^3.1.1
         version: 3.1.2
@@ -1701,8 +1701,8 @@ importers:
         specifier: ^8.5.4
         version: 8.5.4
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -1796,8 +1796,8 @@ importers:
         version: 2.5.2
     devDependencies:
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1846,8 +1846,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(@types/node@18.16.16)(graphql@16.6.0)
       '@whatwg-node/fetch':
-        specifier: ^0.9.7
-        version: 0.9.12
+        specifier: ^0.9.17
+        version: 0.9.17
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -6627,7 +6627,7 @@ packages:
     dependencies:
       '@envelop/core': 5.0.0
       '@graphql-tools/utils': 10.1.0(graphql@16.6.0)
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       fast-json-stable-stringify: 2.1.0
       graphql: 16.6.0
       lru-cache: 10.0.0
@@ -7811,7 +7811,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/batch-execute': 9.0.0(graphql@16.6.0)
-      '@graphql-tools/executor': 1.2.2(graphql@16.6.0)
+      '@graphql-tools/executor': 1.2.3(graphql@16.6.0)
       '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       dataloader: 2.2.2
@@ -7873,7 +7873,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 10.0.6(graphql@16.6.0)
       '@repeaterjs/repeater': 3.0.4
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       extract-files: 11.0.0
       graphql: 16.6.0
       meros: 1.2.1(@types/node@18.16.16)
@@ -7943,8 +7943,8 @@ packages:
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/executor@1.2.2(graphql@16.6.0):
-    resolution: {integrity: sha512-wZkyjndwlzi01HTU3PDveoucKA8qVO0hdKmJhjIGK/vRN/A4w5rDdeqRGcyXVss0clCAy3R6jpixCVu5pWs2Qg==}
+  /@graphql-tools/executor@1.2.3(graphql@16.6.0):
+    resolution: {integrity: sha512-aAS+TGjSq8BJuDq1RV/A/8E53Iu3KvaWpD8DPio0Qe/0YF26tdpK6EcmNSGrrjiZOwVIZ80wclZrFstHzCPm8A==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -8239,10 +8239,10 @@ packages:
       '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
       '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
       '@types/ws': 8.5.4
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       graphql: 16.6.0
       isomorphic-ws: 5.0.0(ws@8.13.0)
       tslib: 2.6.2
@@ -8253,6 +8253,34 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: true
+
+  /@graphql-tools/url-loader@8.0.1(graphql@16.6.0):
+    resolution: {integrity: sha512-B2k8KQEkEQmfV1zhurT5GLoXo8jbXP+YQHUayhCSxKYlRV7j/1Fhp1b21PDM8LXIDGlDRXaZ0FbWKOs7eYXDuQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/sync-fetch': 0.0.1
+      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
+      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
+      '@types/ws': 8.5.4
+      '@whatwg-node/fetch': 0.9.17
+      graphql: 16.6.0
+      isomorphic-ws: 5.0.0(ws@8.13.0)
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}
@@ -14702,13 +14730,6 @@ packages:
       urlpattern-polyfill: 8.0.2
     dev: true
 
-  /@whatwg-node/fetch@0.9.12:
-    resolution: {integrity: sha512-zNUkPJNfM1v9Jhy3Vmi2a7lQxaNIDTSiAb1NKO5eMsSdo05XoddBEj/CHj1xu4IOMU68VerDvuBVwzPjxBl12g==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@whatwg-node/node-fetch': 0.4.18
-      urlpattern-polyfill: 9.0.0
-
   /@whatwg-node/fetch@0.9.17:
     resolution: {integrity: sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==}
     engines: {node: '>=16.0.0'}
@@ -14737,16 +14758,6 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@whatwg-node/node-fetch@0.4.18:
-    resolution: {integrity: sha512-zdey6buMKCqDVDq+tMqcjopO75Fb6iLqWo+g6cWwN5kiwctEHtVcbws2lJUFhCbo+TLZeH6bMDRUXEo5bkPtcQ==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@whatwg-node/events': 0.1.0
-      busboy: 1.6.0
-      fast-querystring: 1.1.1
-      fast-url-parser: 1.1.3
-      tslib: 2.6.2
-
   /@whatwg-node/node-fetch@0.5.8:
     resolution: {integrity: sha512-rB+2P3oi9fD4TcsijkflJAQqOh4yZrPgOV4fGaDgCdOqqwTicJvL2nnVbr3comW8bxEuypOcyE1AtBtkpip0Gw==}
     engines: {node: '>=16.0.0'}
@@ -14757,14 +14768,14 @@ packages:
       fast-querystring: 1.1.1
       tslib: 2.6.2
 
-  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.27):
+  /@whatwg-node/server-plugin-cookies@1.0.0(@whatwg-node/server@0.9.30):
     resolution: {integrity: sha512-o0MqK6H4Yhxht+J+cgZIpEhdb4SID1grFWfOiMdni3csNHBKZ+MKAFhxS+6wAJsarHN7BEZ0QMu4PG09Uwhr2g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@whatwg-node/server': ^0.9.0
     dependencies:
       '@whatwg-node/cookie-store': 0.2.0
-      '@whatwg-node/server': 0.9.27
+      '@whatwg-node/server': 0.9.30
       tslib: 2.5.3
     dev: false
 
@@ -14776,8 +14787,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@whatwg-node/server@0.9.27:
-    resolution: {integrity: sha512-6H+rbzWtr+PD4MLiEroDzunp+L0UcsPleXg0BjttuEgA9N5a8like3kvQaJsTKQd37IaUsdX5b/eUVbx4ZT/7A==}
+  /@whatwg-node/server@0.9.30:
+    resolution: {integrity: sha512-SeL1vL0/uF2xBkpy/dW4sA3aS4IBQMPk097QQ15vW21EhO0ow3RqQu2FCRLCnU1Xgiu8SCpvt3iQUBx74o4ZjQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@whatwg-node/fetch': 0.9.17
@@ -20558,6 +20569,7 @@ packages:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
     dependencies:
       punycode: 1.4.1
+    dev: true
 
   /fast-write-atomic@0.2.1:
     resolution: {integrity: sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw==}
@@ -32027,7 +32039,7 @@ packages:
       graphql: ^15.0.0 || ^16.0.0
     dependencies:
       '@graphql-tools/utils': 10.1.0(graphql@16.6.0)
-      '@whatwg-node/fetch': 0.9.12
+      '@whatwg-node/fetch': 0.9.17
       ansi-colors: 4.1.3
       fets: 0.2.0
       graphql: 16.6.0
@@ -34544,9 +34556,6 @@ packages:
   /urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
     dev: true
-
-  /urlpattern-polyfill@9.0.0:
-    resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
 
   /use-callback-ref@1.3.0(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
 
   examples/fastify:
     dependencies:
+      '@whatwg-node/fetch':
+        specifier: ^0.9.17
+        version: 0.9.17
       fastify:
         specifier: 4.17.0
         version: 4.17.0
@@ -2422,7 +2425,7 @@ packages:
       loglevel: 1.8.0
       make-fetch-happen: 11.0.3
       node-abort-controller: 3.0.1
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - bluebird
       - encoding
@@ -21045,7 +21048,7 @@ packages:
       cors: 2.8.5
       express: 4.18.2
       firebase-admin: 11.5.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -21090,7 +21093,7 @@ packages:
       mime: 2.6.0
       minimatch: 3.1.2
       morgan: 1.10.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.12
       open: 6.4.0
       ora: 5.4.1
       p-limit: 3.1.0
@@ -28098,17 +28101,6 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: true
-
-  /node-fetch@2.6.9:
-    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
 
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,9 +765,15 @@ importers:
         specifier: 8.13.0
         version: 8.13.0
     devDependencies:
+      cross-env:
+        specifier: 7.0.3
+        version: 7.0.3
       ts-node:
         specifier: 10.9.1
         version: 10.9.1(@types/node@18.16.16)(typescript@5.1.6)
+      ts-node-dev:
+        specifier: 2.0.0
+        version: 2.0.0(@types/node@18.16.16)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1259,6 +1265,34 @@ importers:
         specifier: 5.1.6
         version: 5.1.6
 
+  examples/request-cancelation:
+    dependencies:
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      graphql-yoga:
+        specifier: 5.2.0
+        version: link:../../packages/graphql-yoga/dist
+    devDependencies:
+      '@types/node':
+        specifier: 18.16.16
+        version: 18.16.16
+      '@whatwg-node/fetch':
+        specifier: ^0.9.17
+        version: 0.9.17
+      cross-env:
+        specifier: 7.0.3
+        version: 7.0.3
+      ts-node:
+        specifier: 10.9.1
+        version: 10.9.1(@types/node@18.16.16)(typescript@5.1.6)
+      ts-node-dev:
+        specifier: 2.0.0
+        version: 2.0.0(@types/node@18.16.16)(typescript@5.1.6)
+      typescript:
+        specifier: 5.1.6
+        version: 5.1.6
+
   examples/response-cache:
     dependencies:
       '@graphql-yoga/plugin-response-cache':
@@ -1545,7 +1579,7 @@ importers:
         version: 0.8.4(graphql@16.6.0)
       '@graphql-tools/url-loader':
         specifier: 8.0.1
-        version: 8.0.1(graphql@16.6.0)
+        version: 8.0.1(@types/node@18.16.16)(graphql@16.6.0)
       graphiql:
         specifier: 2.0.7
         version: 2.0.7(@codemirror/language@6.0.0)(@types/react@18.2.8)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -8239,33 +8273,6 @@ packages:
       '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
       '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/utils': 10.1.1(graphql@16.6.0)
-      '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
-      '@types/ws': 8.5.4
-      '@whatwg-node/fetch': 0.9.17
-      graphql: 16.6.0
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      tslib: 2.6.2
-      value-or-promise: 1.0.12
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-    dev: true
-
-  /@graphql-tools/url-loader@8.0.1(graphql@16.6.0):
-    resolution: {integrity: sha512-B2k8KQEkEQmfV1zhurT5GLoXo8jbXP+YQHUayhCSxKYlRV7j/1Fhp1b21PDM8LXIDGlDRXaZ0FbWKOs7eYXDuQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 10.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-graphql-ws': 1.0.0(graphql@16.6.0)
-      '@graphql-tools/executor-http': 1.0.5(@types/node@18.16.16)(graphql@16.6.0)
-      '@graphql-tools/executor-legacy-ws': 1.0.0(graphql@16.6.0)
       '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
       '@graphql-tools/wrap': 10.0.0(graphql@16.6.0)
       '@types/ws': 8.5.4
@@ -8280,7 +8287,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: false
 
   /@graphql-tools/utils@10.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-ndBPc6zgR+eGU/jHLpuojrs61kYN3Z89JyMLwK3GCRkPv4EQn9EOr1UWqF1JO0iM+/jAVHY0mvfUxyrFFN9DUQ==}
@@ -17839,6 +17845,7 @@ packages:
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
     dependencies:
       cross-spawn: 7.0.3
     dev: true
@@ -31337,6 +31344,7 @@ packages:
 
   /rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    hasBin: true
     dependencies:
       glob: 7.2.3
 

--- a/website/src/pages/docs/features/_meta.ts
+++ b/website/src/pages/docs/features/_meta.ts
@@ -3,6 +3,7 @@ export default {
   graphiql: 'GraphiQL',
   context: 'GraphQL Context',
   'error-masking': 'Error Masking',
+  'execution-cancelation': 'Execution Cancelation',
   introspection: 'Introspection',
   subscriptions: 'Subscriptions',
   'file-uploads': 'File Uploads',

--- a/website/src/pages/docs/features/_meta.ts
+++ b/website/src/pages/docs/features/_meta.ts
@@ -3,7 +3,7 @@ export default {
   graphiql: 'GraphiQL',
   context: 'GraphQL Context',
   'error-masking': 'Error Masking',
-  'execution-cancelation': 'Execution Cancelation',
+  'execution-cancellation': 'Execution Cancellation',
   introspection: 'Introspection',
   subscriptions: 'Subscriptions',
   'file-uploads': 'File Uploads',

--- a/website/src/pages/docs/features/context.mdx
+++ b/website/src/pages/docs/features/context.mdx
@@ -239,7 +239,7 @@ const yoga = createYoga<{
 
 // somewhere within the request handler
 
-const response = await yoga.handleNodeRequest(req, {
+const response = await yoga.handleNodeRequestAndResponse(req, reply, {
   req,
   reply
 })

--- a/website/src/pages/docs/features/execution-cancelation.mdx
+++ b/website/src/pages/docs/features/execution-cancelation.mdx
@@ -1,0 +1,290 @@
+---
+description: Yoga has experimental support for canceling the GraphQL execution.
+---
+
+# Execution Cancelation
+
+In the real world a lot of HTTP requests are dropped or canceled. This can happen due to flakey
+internet connection, navigation to a new view or page within a web or native app or the user simply
+closing the app. In this case, the server can simply stop processing the request and save resources.
+
+That is why Yoga comes with experimental support for canceling the GraphQL execution upon request
+cancelation.
+
+## Getting started
+
+To enable execution cancelation, you need to add the `useExecutionCancelation` plugin to your Yoga
+instance.
+
+```ts filename="Execution Cancelation configuration" {1,6}
+import { createYoga, useExecutionCancelation } from 'graphql-yoga'
+import { schema } from './schema'
+
+// Provide your schema
+const yoga = createYoga({
+  plugins: [useExecutionCancelation()],
+  schema
+})
+
+// Start the server and explore http://localhost:4000/graphql
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
+
+That is all you need to do to enable execution cancelation in your Yoga server. Theoretically, you
+can enable this and immediatly benefit from it without making any other adjustments within your
+GraphQL schema implementation.
+
+If you want to understand how it works and how you can adjust your resolvers to properly cancel
+pending promises (else.gc. database reads or HTTP requests), you can continue with the next section.
+
+## How it works
+
+The following example demonstrates how the execution cancelation works.
+
+```graphql filename="Simple GraphQL schema"
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+  name: String!
+  bestFriend: User
+}
+```
+
+The `Query.user` resolver has a artifical delay of 10 seconds to simulate a long running e.g. a slow
+read from a database.
+
+```ts filename="Full Yoga Example"
+import { createServer } from 'node:http'
+import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga'
+
+const logger = createLogger('debug')
+
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      user: User
+    }
+
+    type User {
+      id: ID!
+      name: String!
+      bestFriend: User
+    }
+  `,
+  resolvers: {
+    Query: {
+      async user(_, __, { request }) {
+        logger.info('resolving user')
+
+        await new Promise(resolve => {
+          setTimeout(resolve, 5000)
+        })
+
+        logger.info('resolved user')
+
+        return {
+          id: '1',
+          name: 'Chewie'
+        }
+      }
+    },
+    User: {
+      bestFriend() {
+        logger.info('resolving user best friend')
+
+        return {
+          id: '2',
+          name: 'Han Solo'
+        }
+      }
+    }
+  }
+})
+
+const yoga = createYoga({
+  plugins: [useExecutionCancelation()],
+  schema,
+  logging: logger
+})
+
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
+
+With this server setup we are going to execute the following GraphQL query.
+
+```graphql filename="GraphQL Query for fetching user with best friend"
+query UserWithBestFriend {
+  user {
+    id
+    name
+    bestFriend {
+      id
+      name
+    }
+  }
+}
+```
+
+For your convencience, you can copy the following `curl` command to execute the query.
+
+```bash filename="Curl Request for executing the operation"
+curl -g \
+  -X POST \
+  -H "content-type: application/json" \
+  -d '{"query":"{ user { id name bestFriend { id name } } }"}' \
+  "http://localhost:4000/graphql"
+```
+
+Execute this will give us the following server log output:
+
+```bash filename="Server logs"
+DEBUG Parsing request to extract GraphQL parameters
+DEBUG Processing GraphQL Parameters
+INFO resolving user
+INFO resolved user
+INFO resolving user best friend
+DEBUG Processing GraphQL Parameters done.
+```
+
+Now, let's cancel the request by closing the terminal or pressing `Ctrl + C` after the server shows
+the `INFO resolving user` log.
+
+This will now log the following.
+
+```bash filename="Server logs for canceled request"
+DEBUG Parsing request to extract GraphQL parameters
+DEBUG Processing GraphQL Parameters
+INFO resolving user
+DEBUG Request aborted
+INFO resolved user
+```
+
+The interesting part is that now `DEBUG Request aborted` is shown. At this point any further GraphQL
+execution will be stopped. However, the `INFO resolved user` log is still showing up.
+
+We can further adjust our server to cancel the artifical delay promise when the request is aborted
+to avoid any further processing.
+
+```ts filename="Altered server example with timer cleanup" {22-28}
+import { createServer } from 'node:http'
+import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga'
+
+const logger = createLogger('debug')
+
+const schema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      user: User
+    }
+
+    type User {
+      id: ID!
+      name: String!
+      bestFriend: User
+    }
+  `,
+  resolvers: {
+    Query: {
+      async user(_, __, { request }) {
+        logger.info('resolving user')
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(resolve, 5000)
+          request.signal.addEventListener('abort', () => {
+            clearTimeout(timeout)
+            reject(request.signal.reason)
+          })
+        })
+        logger.info('resolved user')
+
+        return {
+          id: '1',
+          name: 'Chewie'
+        }
+      }
+    },
+    User: {
+      bestFriend() {
+        logger.info('resolving user best friend')
+
+        return {
+          id: '2',
+          name: 'Han Solo'
+        }
+      }
+    }
+  }
+})
+
+// Provide your schema
+const yoga = createYoga({
+  plugins: [useExecutionCancelation()],
+  schema,
+  logging: logger
+})
+
+// Start the server and explore http://localhost:4000/graphql
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
+
+After these adjustments, timer will be cleaned up properly, and `INFO resolved user`, will no longer
+show up in the logs.
+
+```bash filename="Server Logs after timer cleanup"
+DEBUG Parsing request to extract GraphQL parameters
+DEBUG Processing GraphQL Parameters
+INFO resolving user
+DEBUG Request aborted
+```
+
+## Propagate cancelation in resolvers
+
+As shown in the previous Selection, you can utilize the Yoga context object `request.signal` to
+cancel pending asynchronous operations in your resolvers.
+
+### `fetch` example
+
+In this example we just pass `context.request.signal` to the fetch call. This will cancel the fetch
+request when the GraphQL request is canceled.
+
+```ts filename="Resolver fetch cancelation example" {15}
+import { createSchema, createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        greeting: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        greeting: async (_, args, context) => {
+          // This service does not exist
+          const greeting = await fetch('http://localhost:9876/greeting', {
+            signal: context.request.signal
+          }).then(res => res.text())
+
+          return greeting
+        }
+      }
+    }
+  })
+})
+
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```

--- a/website/src/pages/docs/features/execution-cancellation.mdx
+++ b/website/src/pages/docs/features/execution-cancellation.mdx
@@ -301,3 +301,4 @@ The execution cancelation API is built on top of the `AbortController` and `Abor
 The execution cancelation is a feature of our GraphQL executor that is a fork of `graphql-js`.
 
 - [`@graphql-tools/executor`](https://github.com/ardatan/graphql-tools/tree/master/packages/executor)
+- [Yoga request cancelation example](https://github.com/dotansimha/graphql-yoga/tree/main/examples/request-cancelation)

--- a/website/src/pages/docs/features/execution-cancellation.mdx
+++ b/website/src/pages/docs/features/execution-cancellation.mdx
@@ -34,7 +34,7 @@ server.listen(4000, () => {
 ```
 
 That is all you need to do to enable execution cancellation in your Yoga server. Theoretically, you
-can enable this and immediatly benefit from it without making any other adjustments within your
+can enable this and immediately benefit from it without making any other adjustments within your
 GraphQL schema implementation.
 
 If you want to understand how it works and how you can adjust your resolvers to properly cancel
@@ -56,8 +56,8 @@ type User {
 }
 ```
 
-The `Query.user` resolver has a artifical delay of 10 seconds to simulate a long running e.g. a slow
-read from a database.
+The `Query.user` resolver has a artificial delay of 10 seconds to simulate a long-running operation
+e.g. a slow read from a database.
 
 ```ts filename="Full Yoga Example"
 import { createServer } from 'node:http'
@@ -134,7 +134,7 @@ query UserWithBestFriend {
 }
 ```
 
-For your convencience, you can copy the following `curl` command to execute the query.
+For your convenience, you can copy the following `curl` command to execute the query.
 
 ```bash filename="Curl Request for executing the operation"
 curl -g \
@@ -168,10 +168,12 @@ DEBUG Request aborted
 INFO resolved user
 ```
 
-The interesting part is that now `DEBUG Request aborted` is shown. At this point any further GraphQL
-execution will be stopped. However, the `INFO resolved user` log is still showing up.
+The interesting part is that now `DEBUG Request aborted` is shown. At this point, any further
+GraphQL execution will be stopped and no other GraphQL resolvers will be invoked.
 
-We can further adjust our server to cancel the artifical delay promise when the request is aborted
+However, the `INFO resolved user` log is still showing up.
+
+We can further adjust our server to cancel the artificial delay promise when the request is aborted
 to avoid any further processing.
 
 ```ts filename="Altered server example with timer cleanup" {22-28}
@@ -238,8 +240,8 @@ server.listen(4000, () => {
 })
 ```
 
-After these adjustments, timer will be cleaned up properly, and `INFO resolved user`, will no longer
-show up in the logs.
+After these adjustments, the timer will be cleaned up properly, and `INFO resolved user`, will no
+longer show up in the logs.
 
 ```bash filename="Server Logs after timer cleanup"
 DEBUG Parsing request to extract GraphQL parameters
@@ -288,3 +290,14 @@ server.listen(4000, () => {
   console.info('Server is running on http://localhost:4000/graphql')
 })
 ```
+
+## Further Resources
+
+The execution cancelation API is built on top of the `AbortController` and `AbortSignal` APIs.
+
+- [MDN AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) and
+- [MDN AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) APIs
+
+The execution cancelation is a feature of our GraphQL executor that is a fork of `graphql-js`.
+
+- [`@graphql-tools/executor`](https://github.com/ardatan/graphql-tools/tree/master/packages/executor)

--- a/website/src/pages/docs/features/execution-cancellation.mdx
+++ b/website/src/pages/docs/features/execution-cancellation.mdx
@@ -2,27 +2,27 @@
 description: Yoga has experimental support for canceling the GraphQL execution.
 ---
 
-# Execution Cancelation
+# Execution Cancellation
 
-In the real world a lot of HTTP requests are dropped or canceled. This can happen due to flakey
+In the real world, a lot of HTTP requests are dropped or canceled. This can happen due to a flakey
 internet connection, navigation to a new view or page within a web or native app or the user simply
-closing the app. In this case, the server can simply stop processing the request and save resources.
+closing the app. In this case, the server can stop processing the request and save resources.
 
 That is why Yoga comes with experimental support for canceling the GraphQL execution upon request
-cancelation.
+cancellation.
 
 ## Getting started
 
-To enable execution cancelation, you need to add the `useExecutionCancelation` plugin to your Yoga
+To enable execution cancellation, you need to add the `useExecutionCancellation` plugin to your Yoga
 instance.
 
-```ts filename="Execution Cancelation configuration" {1,6}
-import { createYoga, useExecutionCancelation } from 'graphql-yoga'
+```ts filename="Execution Cancellation configuration" {1,6}
+import { createYoga, useExecutionCancellation } from 'graphql-yoga'
 import { schema } from './schema'
 
 // Provide your schema
 const yoga = createYoga({
-  plugins: [useExecutionCancelation()],
+  plugins: [useExecutionCancellation()],
   schema
 })
 
@@ -33,16 +33,16 @@ server.listen(4000, () => {
 })
 ```
 
-That is all you need to do to enable execution cancelation in your Yoga server. Theoretically, you
+That is all you need to do to enable execution cancellation in your Yoga server. Theoretically, you
 can enable this and immediatly benefit from it without making any other adjustments within your
 GraphQL schema implementation.
 
 If you want to understand how it works and how you can adjust your resolvers to properly cancel
-pending promises (else.gc. database reads or HTTP requests), you can continue with the next section.
+pending promises (e.g. database reads or HTTP requests), you can continue with the next section.
 
 ## How it works
 
-The following example demonstrates how the execution cancelation works.
+The following example demonstrates how the execution cancellation works.
 
 ```graphql filename="Simple GraphQL schema"
 type Query {
@@ -61,7 +61,7 @@ read from a database.
 
 ```ts filename="Full Yoga Example"
 import { createServer } from 'node:http'
-import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga'
+import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga'
 
 const logger = createLogger('debug')
 
@@ -108,7 +108,7 @@ const schema = createSchema({
 })
 
 const yoga = createYoga({
-  plugins: [useExecutionCancelation()],
+  plugins: [useExecutionCancellation()],
   schema,
   logging: logger
 })
@@ -176,7 +176,7 @@ to avoid any further processing.
 
 ```ts filename="Altered server example with timer cleanup" {22-28}
 import { createServer } from 'node:http'
-import { createLogger, createSchema, createYoga, useExecutionCancelation } from 'graphql-yoga'
+import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga'
 
 const logger = createLogger('debug')
 
@@ -226,7 +226,7 @@ const schema = createSchema({
 
 // Provide your schema
 const yoga = createYoga({
-  plugins: [useExecutionCancelation()],
+  plugins: [useExecutionCancellation()],
   schema,
   logging: logger
 })
@@ -248,7 +248,7 @@ INFO resolving user
 DEBUG Request aborted
 ```
 
-## Propagate cancelation in resolvers
+## Propagate cancellation in resolvers
 
 As shown in the previous Selection, you can utilize the Yoga context object `request.signal` to
 cancel pending asynchronous operations in your resolvers.
@@ -258,7 +258,7 @@ cancel pending asynchronous operations in your resolvers.
 In this example we just pass `context.request.signal` to the fetch call. This will cancel the fetch
 request when the GraphQL request is canceled.
 
-```ts filename="Resolver fetch cancelation example" {15}
+```ts filename="Resolver fetch cancellation example" {15}
 import { createSchema, createYoga } from 'graphql-yoga'
 
 const yoga = createYoga({

--- a/website/src/pages/docs/integrations/integration-with-fastify.mdx
+++ b/website/src/pages/docs/integrations/integration-with-fastify.mdx
@@ -52,7 +52,7 @@ app.route({
   method: ['GET', 'POST', 'OPTIONS'],
   handler: async (req, reply) => {
     // Second parameter adds Fastify's `req` and `reply` to the GraphQL Context
-    const response = await yoga.handleNodeRequest(req, {
+    const response = await yoga.handleNodeRequestAndResponse(req, reply, {
       req,
       reply
     })

--- a/website/src/pages/docs/integrations/integration-with-hapi.mdx
+++ b/website/src/pages/docs/integrations/integration-with-hapi.mdx
@@ -45,7 +45,14 @@ server.route({
     }
   },
   handler: async (req, h) => {
-    const { status, headers, body } = await yoga.handleNodeRequest(req.raw.req, { req, h })
+    const { status, headers, body } = await yoga.handleNodeRequestAndResponse(
+      req.raw.req,
+      req.raw.res,
+      {
+        req,
+        h
+      }
+    )
 
     const res = h.response(
       Readable.from(body, {

--- a/website/src/pages/docs/integrations/integration-with-koa.mdx
+++ b/website/src/pages/docs/integrations/integration-with-koa.mdx
@@ -30,7 +30,7 @@ const yoga = createYoga<Koa.ParameterizedContext>()
 // Bind GraphQL Yoga to `/graphql` endpoint
 app.use(async ctx => {
   // Second parameter adds Koa's context into GraphQL Context
-  const response = await yoga.handleNodeRequest(ctx.req, ctx)
+  const response = await yoga.handleNodeRequestAndResponse(ctx.req, ctx.res, ctx)
 
   // Set status code
   ctx.status = response.status


### PR DESCRIPTION
Since `@graphql-tools/executor` supports aborting the execution, I wanted to add support in Yoga.