### PR TITLE
Fix shared context between batched executions

### DIFF
--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -562,7 +562,7 @@ export class YogaServer<
                 request,
                 batched: true,
               },
-              serverContext,
+              { ...serverContext },
             ),
           ),
         )


### PR DESCRIPTION
We have recently made some improvement around context object referential stability.

But this improvements also introduced a subtle bug when the operation batching is enabled. The fact that the context is referentially stable now turned it into a shared context between all parallel executions of batch operations.

This is a bug since most plugins using the context do not expect multiple operations to be run with the same mutable context object.

The simplest solution is to actually make a new context for each execution **when we have batched operations**.

I don't have any other solution for now, this is something we will have to think about in our discution about the reworking of the context in Envelop/Yoga