### PR TITLE
Indicating graphiQL default status when in production

### DIFF
--- a/website/src/pages/docs/features/graphiql.mdx
+++ b/website/src/pages/docs/features/graphiql.mdx
@@ -9,9 +9,8 @@ import { Callout } from '@theguild/components'
 [GraphiQL](https://github.com/graphql/graphiql) is an in-browser IDE for writing, validating, and
 testing GraphQL queries.
 
-By default, GraphiQL is enabled and served under the `/graphql` route for `GET` requests with a
-`accept: text/html` header. You can configure or completely disable GraphiQL with the `graphiql`
-option.
+By default, GraphiQL is enabled only when in development and served under the `/graphql` route for `GET` requests with a
+`accept: text/html` header. You can configure or completely disable GraphiQL with the `graphiql` option.
 
 ## Default Document String
 

--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -216,7 +216,7 @@ mutation UpdateUser {
 }
 ```
 
-For the given GraphQL operation and execution result all cached query results that contain the type
+For the given GraphQL operation and execution result, all cached query results that contain the type
 `User` with the id `1` will be invalidated.
 
 This behavior can be disabled by setting the `invalidateViaMutation` option to `false`.
@@ -232,7 +232,7 @@ useResponseCache({
 
 You can invalidate a type or specific instances of a type using the cache invalidation API.
 
-In order to use the API, you need to manually instantiate the cache an pass it to the
+In order to use the API, you need to manually instantiate the cache and pass it to the
 `useResponseCache` plugin.
 
 ```ts filename="Manual cache construction" {3,6}
@@ -251,21 +251,21 @@ Then in your business logic you can call the `invalidate` method on the cache in
 Invalidate all GraphQL query results that reference a specific type:
 
 ```ts filename="Invalidating a type"
-cache.invalidate([{ type: 'User' }])
+cache.invalidate([{ typename: 'User' }])
 ```
 
 Invalidate all GraphQL query results that reference a specific entity of a type:
 
 ```ts filename="Invalidate a specific entity of a type"
-cache.invalidate([{ type: 'User', id: '1' }])
+cache.invalidate([{ typename: 'User', id: '1' }])
 ```
 
 Invalidate all GraphQL query results multiple entities in a single call.
 
 ```ts filename="Invalidate multiple entities"
 cache.invalidate([
-  { type: 'Post', id: '1' },
-  { type: 'User', id: '2' }
+  { typename: 'Post', id: '1' },
+  { typename: 'User', id: '2' }
 ])
 ```
 


### PR DESCRIPTION
This PR includes a setence correction/update that includes that when in development graphiql is accessible on the `/graphql` endpoint and not when in production, unless the graphiql option is  updated.

This PR referenes #3158 