### PR TITLE
Revert "chore(deps): update dependency eslint to v9"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ examples/apollo-federation-compatibility/src/resolvers-types.ts
 **/node_modules
 **/dist
 **/.next
+**/.bob

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,8 @@
+packages/graphql-yoga/src/landing-page-html.ts
+packages/graphql-yoga/src/graphiql-html.ts
+.tool-versions
 **/generated/**
+examples/apollo-federation-compatibility/src/resolvers-types.ts
+**/node_modules
+**/dist
+**/.next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Prettier
         run: pnpm prettier:check
 
+      - name: eslint
+        run: pnpm lint
+
   apollo-federation-compatibility:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -93,7 +93,7 @@ const DUMMY_VARIABLES = {};
 export async function assertQuery(
   endpoint: string,
   query: string = DUMMY_QUERY,
-  variables: Record<string, any> = DUMMY_VARIABLES,
+  variables: Record<string, string> = DUMMY_VARIABLES,
 ) {
   console.log(`ℹ️ Trying to run a GraphQL operation against ${endpoint}:`);
   console.log(`\t operation: ${query}`);

--- a/examples/apollo-federation-compatibility/src/index.ts
+++ b/examples/apollo-federation-compatibility/src/index.ts
@@ -59,6 +59,7 @@ const inventory: Inventory = {
 const resolvers: Resolvers = {
   Query: {
     product(_: unknown, args: { id: string }) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return products.find(p => p.id === args.id)! as unknown as Product;
     },
     deprecatedProduct: (_, args) => {
@@ -84,6 +85,7 @@ const resolvers: Resolvers = {
   },
   ProductResearch: {
     __resolveReference: reference => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return productResearch.find(p => reference.study.caseNumber === p.study.caseNumber)!;
     },
   },
@@ -138,7 +140,7 @@ const resolvers: Resolvers = {
     name() {
       return 'Jane Smith';
     },
-    // @ts-expect-error
+    // @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
     __resolveReference(userRef) {
       const ref = userRef as User;
       if (ref.email) {
@@ -151,7 +153,7 @@ const resolvers: Resolvers = {
           user.totalProductsCreated = ref.totalProductsCreated;
         }
         if (ref.yearsOfEmployment) {
-          // @ts-expect-error
+          // @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
           user.yearsOfEmployment = ref.yearsOfEmployment;
         }
         return user;

--- a/examples/cloudflare-advanced/src/index.ts
+++ b/examples/cloudflare-advanced/src/index.ts
@@ -45,11 +45,11 @@ const yoga = createYoga({
             limit,
             cursor,
           }),
-        readFileAsText: (root, args) => EXAMPLE_KV.get(args.name, 'text'),
-        readFileAsJson: (root, args) => EXAMPLE_KV.get(args.name, 'json'),
+        readFileAsText: (_, args) => EXAMPLE_KV.get(args.name, 'text'),
+        readFileAsJson: (_, args) => EXAMPLE_KV.get(args.name, 'json'),
       },
       TodoKeyInfo: {
-        value: ({ name }: any) => EXAMPLE_KV.get(name, 'text'),
+        value: ({ name }: { name: string }) => EXAMPLE_KV.get(name, 'text'),
       },
       Mutation: {
         addTodo: async (_, { content }) => {

--- a/examples/cloudflare-modules/src/index.ts
+++ b/examples/cloudflare-modules/src/index.ts
@@ -15,7 +15,7 @@ const schema = createSchema({
 });
 
 export default {
-  fetch(request: Request, env: Record<string, any>, ...rest: any[]) {
+  fetch(request: Request, env: Record<string, string>, ...rest: unknown[]) {
     const yoga = createYoga({
       graphqlEndpoint: env.GRAPHQL_ROUTE || '/graphql',
       landingPage: false,

--- a/examples/file-upload-nextjs-pothos/package.json
+++ b/examples/file-upload-nextjs-pothos/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/react": "^18.0.17",
     "@whatwg-node/fetch": "^0.9.17",
-    "eslint": "9.0.0",
+    "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "typescript": "5.1.6"
   }

--- a/examples/graphql-ws/__integration-tests__/graphql-ws.spec.ts
+++ b/examples/graphql-ws/__integration-tests__/graphql-ws.spec.ts
@@ -102,7 +102,9 @@ describe('graphql-ws example integration', () => {
 
     const wsServer = useServer(
       {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         execute: (args: any) => args.execute(args),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         subscribe: (args: any) => args.subscribe(args),
         onSubscribe: async (_ctx, msg) => {
           const { schema, execute, subscribe, contextFactory, parse, validate } =

--- a/examples/graphql-ws/src/app.ts
+++ b/examples/graphql-ws/src/app.ts
@@ -53,7 +53,9 @@ export function buildApp() {
 
   useServer(
     {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       execute: (args: any) => args.execute(args),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       subscribe: (args: any) => args.subscribe(args),
       onSubscribe: async (ctx, msg) => {
         const { schema, execute, subscribe, contextFactory, parse, validate } = yoga.getEnveloped({

--- a/examples/hackernews/__integration-tests__/hackernews.spec.ts
+++ b/examples/hackernews/__integration-tests__/hackernews.spec.ts
@@ -6,7 +6,7 @@ import type { GraphQLContext } from '../src/context';
 import { schema } from '../src/schema';
 
 describe('hackernews example integration', () => {
-  let yoga: YogaServerInstance<Record<string, any>, GraphQLContext>;
+  let yoga: YogaServerInstance<Record<string, unknown>, GraphQLContext>;
   beforeAll(async () => {
     const { createContext } = await import('../src/context');
     yoga = createYoga({ schema, context: createContext });

--- a/examples/live-query/src/main.ts
+++ b/examples/live-query/src/main.ts
@@ -9,6 +9,7 @@ const liveQueryStore = new InMemoryLiveQueryStore();
 
 setInterval(() => {
   const firstElement = greetings.pop();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   greetings.unshift(firstElement!);
   liveQueryStore.invalidate('Query.greetings');
 }, 1000).unref();

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -13,7 +13,7 @@
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
     "autoprefixer": "10.4.19",
-    "eslint": "9.0.0",
+    "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "graphql": "^16.1.0",
     "graphql-yoga": "5.3.0",

--- a/examples/nextjs-auth/package.json
+++ b/examples/nextjs-auth/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/react": "18.2.8",
-    "eslint": "9.0.0",
+    "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "typescript": "5.1.6"
   }

--- a/examples/nextjs-legacy-pages/package.json
+++ b/examples/nextjs-legacy-pages/package.json
@@ -23,7 +23,7 @@
     "@types/node": "20.2.3",
     "@types/react": "18.2.8",
     "esbuild": "0.17.19",
-    "eslint": "9.0.0",
+    "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "typescript": "5.1.6"
   }

--- a/examples/nextjs-ws/package.json
+++ b/examples/nextjs-ws/package.json
@@ -21,7 +21,7 @@
     "@types/node": "18.16.16",
     "@types/react": "18.2.8",
     "@types/ws": "8.5.4",
-    "eslint": "9.0.0",
+    "eslint": "8.42.0",
     "eslint-config-next": "13.4.12",
     "typescript": "5.1.6"
   }

--- a/examples/nextjs-ws/server.js
+++ b/examples/nextjs-ws/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-env node */
 const { createServer } = require('node:http');
 const { WebSocketServer } = require('ws');

--- a/examples/response-cache/src/main.ts
+++ b/examples/response-cache/src/main.ts
@@ -41,7 +41,7 @@ export const create = (config?: Omit<UseResponseCacheParameter, 'session'>, port
   return new Promise<[number, () => Promise<void>]>(resolve => {
     server.listen(port, () => {
       resolve([
-        (server.address() as any).port as number,
+        (server.address() as { port: number }).port,
         () =>
           new Promise<void>(resolve => {
             server.close(() => {

--- a/examples/service-worker/__integration-tests__/integration.spec.ts
+++ b/examples/service-worker/__integration-tests__/integration.spec.ts
@@ -19,10 +19,10 @@ globalThis.self = {
       listeners.delete(listener);
     }
   },
-} as any;
+} as unknown as typeof globalThis.self;
 
 function trigger(eventName: string, data) {
-  // eslint-disable-next-line unicorn/no-array-for-each -- is Set
+  // eslint-disable-next-line unicorn/no-array-for-each, @typescript-eslint/no-explicit-any -- is Set
   listenerMap.get(eventName)?.forEach((listener: any) => {
     const listenerFn = listener.handleEvent ?? listener;
     listenerFn(data);
@@ -158,7 +158,7 @@ describe('Service worker', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toBe('text/event-stream');
     let counter = 0;
-    for await (const chunk of response.body as any) {
+    for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
       const data = Buffer.from(chunk).toString('utf-8');
       if (data === ':\n\n') {
         continue;

--- a/examples/sofa/src/yoga.ts
+++ b/examples/sofa/src/yoga.ts
@@ -148,20 +148,20 @@ const schema = createSchema({
       me() {
         return UsersCollection.get(1);
       },
-      user(_: any, { id }: any) {
+      user(_: unknown, { id }: { id: string }) {
         return UsersCollection.get(id);
       },
       users() {
         return UsersCollection.all();
       },
-      usersLimit(_: any, { limit }: any) {
+      usersLimit(_: unknown, { limit }: { limit: number }) {
         return UsersCollection.all().slice(0, limit);
       },
-      usersSort(_: any, { sort }: any) {
+      usersSort(_: unknown, { sort }: { sort: number }) {
         const users = UsersCollection.all();
         return sort ? users.sort((a, b) => b.id - a.id) : users;
       },
-      book(_: any, { id }: any) {
+      book(_: unknown, { id }: { id: string }) {
         return BooksCollection.get(id);
       },
       books() {
@@ -175,7 +175,7 @@ const schema = createSchema({
       },
     },
     Mutation: {
-      addBook(_: any, { title }: any) {
+      addBook(_: unknown, { title }: { title: string }) {
         const book = BooksCollection.add(title);
 
         pubsub.publish(BOOK_ADDED, { onBook: book });
@@ -189,7 +189,7 @@ const schema = createSchema({
       },
     },
     Food: {
-      __resolveType(obj: any) {
+      __resolveType(obj: { ingredients?: string[]; toppings?: string[] }) {
         if (obj.ingredients) {
           return 'Salad';
         }

--- a/examples/subscriptions/src/index.ts
+++ b/examples/subscriptions/src/index.ts
@@ -67,7 +67,7 @@ const resolvers: Resolvers<Context> = {
             console.log('stop');
           });
         }),
-      resolve: (payload: any) => payload,
+      resolve: (payload: number) => payload,
     },
     globalCounter: {
       // Merge initial value with source stream of new values
@@ -83,7 +83,7 @@ const resolvers: Resolvers<Context> = {
           // map all events to the latest globalCounter
           map(() => globalCounter),
         ),
-      resolve: (payload: any) => payload,
+      resolve: (payload: number) => payload,
     },
   },
   Mutation: {
@@ -95,7 +95,7 @@ const resolvers: Resolvers<Context> = {
   },
 };
 
-const yoga = createYoga<Context, any>({
+const yoga = createYoga<Context>({
   schema: createSchema({
     resolvers,
     typeDefs,

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -21,7 +21,7 @@
 		"@types/jest": "^29.0.0",
 		"@typescript-eslint/eslint-plugin": "6.7.5",
 		"@typescript-eslint/parser": "6.7.5",
-		"eslint": "9.0.0",
+		"eslint": "8.42.0",
 		"eslint-config-prettier": "9.0.0",
 		"eslint-plugin-svelte3": "4.0.0",
 		"jest": "^29.0.0",

--- a/examples/uwebsockets/__integration-tests__/uwebsockets.test.ts
+++ b/examples/uwebsockets/__integration-tests__/uwebsockets.test.ts
@@ -8,7 +8,7 @@ import { fetch } from '@whatwg-node/fetch';
 describe('uWebSockets', () => {
   const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
   if (nodeMajor < 16 || nodeMajor > 20) {
-    it('should be skipped', () => {});
+    it('should be skipped', () => undefined);
     return;
   }
   let listenSocket: us_listen_socket;
@@ -16,6 +16,7 @@ describe('uWebSockets', () => {
   let client: Client;
   beforeAll(async () => {
     port = await getPortFree();
+    // eslint-disable-next-line no-async-promise-executor
     await new Promise<void>(async (resolve, reject) => {
       const { app } = await import('../src/app');
       app.listen(port, newListenSocket => {
@@ -35,7 +36,7 @@ describe('uWebSockets', () => {
        * Reference: https://gist.github.com/jed/982883
        */
       generateID: () =>
-        // @ts-expect-error
+        // @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
         ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
           (c ^ (Crypto.randomBytes(1)[0] & (15 >> (c / 4)))).toString(16),
         ),

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "babel-plugin-transform-typescript-metadata": "0.3.2",
     "bob-the-bundler": "7.0.1",
     "cross-env": "7.0.3",
-    "eslint": "^9.0.0",
+    "eslint": "^8.44.0",
     "graphql": "^16.5.0",
     "husky": "^8.0.0",
     "jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build-website": "pnpm build && cd website && pnpm build",
     "changeset": "changeset",
     "check": "pnpm -r run check",
-    "lint": "eslint --ignore-path .gitignore --ext ts,js,tsx,jsx .",
+    "lint": "eslint --ignore-path .eslintignore --ext ts,js,tsx,jsx .",
     "postchangeset": "pnpm install --no-frozen-lockfile",
     "postinstall": "husky install",
     "prebuild": "rimraf packages/*/dist",

--- a/packages/graphql-yoga/__tests__/custom-serializer.spec.ts
+++ b/packages/graphql-yoga/__tests__/custom-serializer.spec.ts
@@ -52,6 +52,7 @@ it('supports custom JSON serializer', async () => {
 });
 
 it('works with the custom serializer of GraphQL JIT', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stringifyFn: any;
   const yoga = createYoga({
     schema: createSchema({

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -457,7 +457,7 @@ describe('requests', () => {
   });
 
   it('contains the correct request object in the unique execution context', async () => {
-    const onExecuteFn = jest.fn((() => {}) as OnExecuteHook<YogaInitialContext>);
+    const onExecuteFn = jest.fn((() => undefined) as OnExecuteHook<YogaInitialContext>);
     const yoga = createYoga({
       schema: createSchema({
         typeDefs: /* GraphQL */ `
@@ -467,7 +467,7 @@ describe('requests', () => {
         `,
         resolvers: {
           Query: {
-            greetings: (_, __, ctx) => {
+            greetings: () => {
               return `Hello world!`;
             },
           },

--- a/packages/graphql-yoga/src/process-request.ts
+++ b/packages/graphql-yoga/src/process-request.ts
@@ -61,6 +61,7 @@ export async function processRequest({
   enveloped: ReturnType<GetEnvelopedFn<unknown>>;
 }) {
   // Parse GraphQLParams
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const document = enveloped.parse(params.query!);
 
   // Validate parsed Document Node

--- a/packages/graphql-yoga/type-api-check.ts
+++ b/packages/graphql-yoga/type-api-check.ts
@@ -53,6 +53,7 @@ const request: Request = null as any;
       resolvers: {
         Query: {
           foo: (_: unknown, __: unknown, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             context.iAmHere;
           },
         },
@@ -70,6 +71,7 @@ const request: Request = null as any;
         Query: {
           foo: (_: unknown, __: unknown, context) => {
             // @ts-expect-error Property 'iAmHere' does not exist on type 'YogaInitialContext'.ts(2339)
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             context.iAmHere;
           },
         },
@@ -87,6 +89,7 @@ const request: Request = null as any;
   const resolvers: IResolvers<unknown, YogaInitialContext & Context> = {
     Query: {
       foo: (_: unknown, __: unknown, context) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         context.brrt;
       },
     },

--- a/packages/plugins/response-cache/__tests__/response-cache.spec.ts
+++ b/packages/plugins/response-cache/__tests__/response-cache.spec.ts
@@ -1154,6 +1154,7 @@ describe('shouldCacheResult', () => {
 });
 
 it('response has "servedFromResponseCache" symbol', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const results: Array<any> = [];
   const yoga = createYoga({
     plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 2.26.2
       '@theguild/eslint-config':
         specifier: 0.11.0
-        version: 0.11.0(eslint@9.0.0)(typescript@5.1.6)
+        version: 0.11.0(eslint@8.44.0)(typescript@5.1.6)
       '@theguild/prettier-config':
         specifier: 2.0.1
         version: 2.0.1(prettier@3.0.0)
@@ -63,10 +63,10 @@ importers:
         version: 2.0.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
-        version: 6.0.0(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)(typescript@5.1.6)
+        version: 6.0.0(@typescript-eslint/parser@6.0.0)(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^6.0.0
-        version: 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+        version: 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       babel-jest:
         specifier: ^29.0.0
         version: 29.2.0(@babel/core@7.22.1)
@@ -83,8 +83,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       eslint:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^8.44.0
+        version: 8.44.0
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -588,11 +588,11 @@ importers:
         specifier: ^0.9.17
         version: 0.9.17
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-next:
         specifier: 13.4.12
-        version: 13.4.12(eslint@9.0.0)(typescript@5.1.6)
+        version: 13.4.12(eslint@8.42.0)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1036,11 +1036,11 @@ importers:
         specifier: 10.4.19
         version: 10.4.19(postcss@8.4.38)
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-next:
         specifier: 13.4.12
-        version: 13.4.12(eslint@9.0.0)(typescript@5.1.6)
+        version: 13.4.12(eslint@8.42.0)(typescript@5.1.6)
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -1098,11 +1098,11 @@ importers:
         specifier: 18.2.8
         version: 18.2.8
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-next:
         specifier: 13.4.12
-        version: 13.4.12(eslint@9.0.0)(typescript@5.1.6)
+        version: 13.4.12(eslint@8.42.0)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1138,11 +1138,11 @@ importers:
         specifier: 0.17.19
         version: 0.17.19
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-next:
         specifier: 13.4.12
-        version: 13.4.12(eslint@9.0.0)(typescript@5.1.6)
+        version: 13.4.12(eslint@8.42.0)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1181,11 +1181,11 @@ importers:
         specifier: 8.5.4
         version: 8.5.4
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-next:
         specifier: 13.4.12
-        version: 13.4.12(eslint@9.0.0)(typescript@5.1.6)
+        version: 13.4.12(eslint@8.42.0)(typescript@5.1.6)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -1415,19 +1415,19 @@ importers:
         version: 29.2.0
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.5
-        version: 6.7.5(@typescript-eslint/parser@6.7.5)(eslint@9.0.0)(typescript@5.1.6)
+        version: 6.7.5(@typescript-eslint/parser@6.7.5)(eslint@8.42.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: 6.7.5
-        version: 6.7.5(eslint@9.0.0)(typescript@5.1.6)
+        version: 6.7.5(eslint@8.42.0)(typescript@5.1.6)
       eslint:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: 8.42.0
+        version: 8.42.0
       eslint-config-prettier:
         specifier: 9.0.0
-        version: 9.0.0(eslint@9.0.0)
+        version: 9.0.0(eslint@8.42.0)
       eslint-plugin-svelte3:
         specifier: 4.0.0
-        version: 4.0.0(eslint@9.0.0)(svelte@4.0.1)
+        version: 4.0.0(eslint@8.42.0)(svelte@4.0.1)
       jest:
         specifier: ^29.0.0
         version: 29.2.0
@@ -7113,32 +7113,50 @@ packages:
       - supports-color
     dev: false
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@9.0.0):
+  /@eslint-community/eslint-utils@4.2.0(eslint@8.42.0):
+    resolution: {integrity: sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.42.0
+      eslint-visitor-keys: 3.4.1
+
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.42.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.42.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.44.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.44.0
       eslint-visitor-keys: 3.4.1
 
-  /@eslint-community/regexpp@4.10.0:
-    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+  /@eslint-community/regexpp@4.4.0:
+    resolution: {integrity: sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
 
-  /@eslint/eslintrc@3.0.2:
-    resolution: {integrity: sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  /@eslint/eslintrc@2.0.3:
+    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@9.2.3)
-      espree: 10.0.1
-      globals: 14.0.0
+      espree: 9.6.0
+      globals: 13.19.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -7147,9 +7165,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@eslint/js@9.0.0:
-    resolution: {integrity: sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  /@eslint/eslintrc@2.1.0:
+    resolution: {integrity: sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@9.2.3)
+      espree: 9.6.0
+      globals: 13.19.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@eslint/js@8.42.0:
+    resolution: {integrity: sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@eslint/js@8.44.0:
+    resolution: {integrity: sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@faker-js/faker@8.0.2:
     resolution: {integrity: sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==}
@@ -8569,11 +8607,11 @@ packages:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array@0.12.3:
-    resolution: {integrity: sha512-jsNnTBlMWuTpDkeE3on7+dWJi0D6fdDfeANj/w7MpS8ztROCoLvIO2nG0CcFj+E4k8j4QrSTh4Oryi3i2G669g==}
+  /@humanwhocodes/config-array@0.11.10:
+    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
+      '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.4(supports-color@9.2.3)
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -8588,8 +8626,8 @@ packages:
     engines: {node: '>=10.10.0'}
     dev: true
 
-  /@humanwhocodes/object-schema@2.0.3:
-    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+  /@humanwhocodes/object-schema@1.2.1:
+    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
 
   /@ianvs/prettier-plugin-sort-imports@4.0.2(prettier@3.0.0):
     resolution: {integrity: sha512-VnsTzyb9aSWpc3v6HvZKD6eolZRvofIYjhda+6IbW1GYwr2byWqK0KhLPbYNkit9MAgShad5bhZ1hgBn867A1A==}
@@ -12851,28 +12889,28 @@ packages:
       - webpack
     dev: false
 
-  /@theguild/eslint-config@0.11.0(eslint@9.0.0)(typescript@5.1.6):
+  /@theguild/eslint-config@0.11.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-dxKcEb0uKZvkKBp9KwcKe/npuHZw789vrQPUJGJksz9ghjvAQOc9Kx4PMJTTrVWOzg/1lzFB9s070V9yviYkHg==}
     peerDependencies:
       eslint: ^8.24.0
     dependencies:
       '@rushstack/eslint-patch': 1.3.2
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@9.0.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
-      eslint: 9.0.0
-      eslint-config-prettier: 8.8.0(eslint@9.0.0)
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@9.0.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)
-      eslint-plugin-jsonc: 2.9.0(eslint@9.0.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@9.0.0)
-      eslint-plugin-mdx: 2.1.0(eslint@9.0.0)
-      eslint-plugin-n: 16.0.1(eslint@9.0.0)
-      eslint-plugin-promise: 6.1.1(eslint@9.0.0)
-      eslint-plugin-react: 7.32.2(eslint@9.0.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@9.0.0)
-      eslint-plugin-sonarjs: 0.19.0(eslint@9.0.0)
-      eslint-plugin-unicorn: 47.0.0(eslint@9.0.0)
-      eslint-plugin-yml: 1.8.0(eslint@9.0.0)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
+      eslint: 8.44.0
+      eslint-config-prettier: 8.8.0(eslint@8.44.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@8.44.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.44.0)
+      eslint-plugin-jsonc: 2.9.0(eslint@8.44.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.44.0)
+      eslint-plugin-mdx: 2.1.0(eslint@8.44.0)
+      eslint-plugin-n: 16.0.1(eslint@8.44.0)
+      eslint-plugin-promise: 6.1.1(eslint@8.44.0)
+      eslint-plugin-react: 7.32.2(eslint@8.44.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.44.0)
+      eslint-plugin-sonarjs: 0.19.0(eslint@8.44.0)
+      eslint-plugin-unicorn: 47.0.0(eslint@8.44.0)
+      eslint-plugin-yml: 1.8.0(eslint@8.44.0)
     transitivePeerDependencies:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
@@ -13561,7 +13599,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13572,13 +13610,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -13589,7 +13627,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.0.0)(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-xuv6ghKGoiq856Bww/yVYnXGsKa588kY3M0XK7uUW/3fJNNULKRfZfSBkMTSpqGG/8ZCXCadfh8G/z/B4aqS/A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13601,13 +13639,13 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 6.0.0
-      '@typescript-eslint/type-utils': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.0.0
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       grapheme-splitter: 1.0.4
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -13620,7 +13658,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.7.5)(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@6.7.5(@typescript-eslint/parser@6.7.5)(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13632,13 +13670,13 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 6.7.5(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.7.5(eslint@8.42.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 6.7.5
-      '@typescript-eslint/type-utils': 6.7.5(eslint@9.0.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.7.5(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 6.7.5(eslint@8.42.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.7.5(eslint@8.42.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.42.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
@@ -13649,7 +13687,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@5.62.0(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13663,12 +13701,32 @@ packages:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.2.3)(typescript@5.1.6)
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.42.0
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.0.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@5.62.0(eslint@8.44.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.2.3)(typescript@5.1.6)
+      debug: 4.3.4(supports-color@9.2.3)
+      eslint: 8.44.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.0.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-TNaufYSPrr1U8n+3xN+Yp9g31vQDJqhXzzPSHfQDLcaO4tU+mCfODPxCwf4H530zo7aUBE3QIdxCXamEnG04Tg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13683,12 +13741,12 @@ packages:
       '@typescript-eslint/typescript-estree': 6.0.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.0.0
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.7.5(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@6.7.5(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13703,7 +13761,7 @@ packages:
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.42.0
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -13731,7 +13789,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.7.5
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -13742,16 +13800,16 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.2.3)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       tsutils: 3.21.0(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@6.0.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@6.0.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ah6LJvLgkoZ/pyJ9GAdFkzeuMZ8goV6BH7eC9FPmojrnX9yNCIsfjB+zYcnex28YO3RFvBkV6rMV6WpIqkPvoQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13762,16 +13820,16 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 6.0.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@6.7.5(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@6.7.5(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-Gs0qos5wqxnQrvpYv+pf3XfcRXW6jiAn9zE/K+DlmYf6FcpxeNYN0AIETaPR7rHO4K2UY+D0CIbDP9Ut0U4m1g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13782,9 +13840,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.7.5(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.7.5(eslint@8.42.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.42.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -13865,19 +13923,19 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.62.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.2.3)(typescript@5.1.6)
-      eslint: 9.0.0
+      eslint: 8.44.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -13885,19 +13943,19 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.0.0(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@6.0.0(eslint@8.44.0)(typescript@5.1.6):
     resolution: {integrity: sha512-SOr6l4NB6HE4H/ktz0JVVWNXqCJTOo/mHnvIte1ZhBQ0Cvd04x5uKZa3zT6tiodL06zf5xxdK8COiDvPnQ27JQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.0.0
       '@typescript-eslint/types': 6.0.0
       '@typescript-eslint/typescript-estree': 6.0.0(typescript@5.1.6)
-      eslint: 9.0.0
+      eslint: 8.44.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -13905,19 +13963,19 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.7.5(eslint@9.0.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@6.7.5(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.42.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.7.5
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
-      eslint: 9.0.0
+      eslint: 8.42.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -13973,7 +14031,7 @@ packages:
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.10(supports-color@9.2.3)
       '@rollup/pluginutils': 4.2.1
-      acorn: 8.11.3
+      acorn: 8.9.0
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
@@ -14486,14 +14544,6 @@ packages:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  /acorn-import-assertions@1.9.0(acorn@8.11.3):
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.11.3
-    dev: true
-
   /acorn-import-assertions@1.9.0(acorn@8.8.2):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
@@ -14502,12 +14552,20 @@ packages:
       acorn: 8.8.2
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.3):
+  /acorn-import-assertions@1.9.0(acorn@8.9.0):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.9.0
+    dev: true
+
+  /acorn-jsx@5.3.2(acorn@8.9.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
 
   /acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -14519,11 +14577,6 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
@@ -14533,7 +14586,6 @@ packages:
     resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /agent-base@6.0.2(supports-color@9.2.3):
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -16141,7 +16193,7 @@ packages:
       '@types/http-cache-semantics': 4.0.1
       get-stream: 6.0.1
       http-cache-semantics: 4.1.1
-      keyv: 4.5.4
+      keyv: 4.5.0
       mimic-response: 4.0.0
       normalize-url: 7.2.0
       responselike: 3.0.0
@@ -16154,7 +16206,7 @@ packages:
       '@types/http-cache-semantics': 4.0.1
       get-stream: 6.0.1
       http-cache-semantics: 4.1.1
-      keyv: 4.5.4
+      keyv: 4.5.3
       mimic-response: 4.0.0
       normalize-url: 8.0.0
       responselike: 3.0.0
@@ -16720,7 +16772,7 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@types/estree': 1.0.0
-      acorn: 8.11.3
+      acorn: 8.9.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
     dev: true
@@ -18299,6 +18351,12 @@ packages:
     dependencies:
       esutils: 2.0.3
 
+  /doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      esutils: 2.0.3
+
   /dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
@@ -18810,7 +18868,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@13.4.12(eslint@9.0.0)(typescript@5.1.6):
+  /eslint-config-next@13.4.12(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -18821,35 +18879,35 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.4.12
       '@rushstack/eslint-patch': 1.3.2
-      '@typescript-eslint/parser': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
-      eslint: 9.0.0
+      '@typescript-eslint/parser': 5.62.0(eslint@8.42.0)(typescript@5.1.6)
+      eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@9.0.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@9.0.0)
-      eslint-plugin-react: 7.32.2(eslint@9.0.0)
-      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@9.0.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.42.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.42.0)
+      eslint-plugin-react: 7.32.2(eslint@8.42.0)
+      eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.42.0)
       typescript: 5.1.6
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-config-prettier@8.8.0(eslint@9.0.0):
+  /eslint-config-prettier@8.8.0(eslint@8.44.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.44.0
     dev: true
 
-  /eslint-config-prettier@9.0.0(eslint@9.0.0):
+  /eslint-config-prettier@9.0.0(eslint@8.42.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.42.0
     dev: true
 
   /eslint-import-resolver-node@0.3.7:
@@ -18861,7 +18919,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@9.0.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.42.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -18870,9 +18928,9 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@9.2.3)
       enhanced-resolve: 5.15.0
-      eslint: 9.0.0
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@9.0.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)
+      eslint: 8.42.0
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.42.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.42.0)
       get-tsconfig: 4.5.0
       globby: 13.1.3
       is-core-module: 2.12.1
@@ -18884,7 +18942,7 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@9.0.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@8.44.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -18893,9 +18951,9 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@9.2.3)
       enhanced-resolve: 5.15.0
-      eslint: 9.0.0
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@9.0.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@9.0.0)
+      eslint: 8.44.0
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.44.0)
       get-tsconfig: 4.5.0
       globby: 13.1.3
       is-core-module: 2.12.1
@@ -18908,15 +18966,15 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-mdx@2.1.0(eslint@9.0.0):
+  /eslint-mdx@2.1.0(eslint@8.44.0):
     resolution: {integrity: sha512-dVLHDcpCFJRXZhxEQx8nKc68KT1qm+9JOeMD+j1/WW2h+oco1j7Qq+CLrX2kP64LI3fF9TUtj7a0AvncHUME6w==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8.0.0'
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint: 9.0.0
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
+      eslint: 8.44.0
       espree: 9.6.0
       estree-util-visit: 1.2.1
       remark-mdx: 2.3.0
@@ -18933,7 +18991,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@9.0.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.42.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -18954,15 +19012,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.42.0)(typescript@5.1.6)
       debug: 3.2.7
-      eslint: 9.0.0
+      eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@9.0.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.42.0)
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@9.0.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -18983,15 +19041,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
       debug: 3.2.7
-      eslint: 9.0.0
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@9.0.0)
+      eslint: 8.44.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-plugin-import@2.27.5)(eslint@8.44.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@9.0.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@8.42.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -19012,25 +19071,54 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       debug: 3.2.7
-      eslint: 9.0.0
+      eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-plugin-es-x@7.1.0(eslint@9.0.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@8.44.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
+      debug: 3.2.7
+      eslint: 8.44.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-es-x@7.1.0(eslint@8.44.0):
     resolution: {integrity: sha512-AhiaF31syh4CCQ+C5ccJA0VG6+kJK8+5mXKKE7Qs1xcPRg02CDPOj3mWlQxuWS/AYtg7kxrDNgW9YW3vc0Q+Mw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
-      '@eslint-community/regexpp': 4.10.0
-      eslint: 9.0.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      '@eslint-community/regexpp': 4.5.1
+      eslint: 8.44.0
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.0.0)(eslint@9.0.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.42.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -19040,15 +19128,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.0.0(eslint@9.0.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.0.0
+      eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@9.0.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@8.42.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -19062,19 +19150,52 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-plugin-jsonc@2.9.0(eslint@9.0.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.0.0)(eslint@8.44.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.44.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.0.0)(eslint-import-resolver-node@0.3.7)(eslint@8.44.0)
+      has: 1.0.3
+      is-core-module: 2.12.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.2
+      semver: 6.3.1
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-jsonc@2.9.0(eslint@8.44.0):
     resolution: {integrity: sha512-RK+LeONVukbLwT2+t7/OY54NJRccTXh/QbnXzPuTLpFMVZhPuq1C9E07+qWenGx7rrQl0kAalAWl7EmB+RjpGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
-      eslint: 9.0.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      eslint: 8.44.0
       jsonc-eslint-parser: 2.1.0
       natural-compare: 1.4.0
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.7.1(eslint@9.0.0):
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.42.0):
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -19089,7 +19210,7 @@ packages:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.0.0
+      eslint: 8.42.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
@@ -19098,27 +19219,52 @@ packages:
       object.fromentries: 2.0.6
       semver: 6.3.1
 
-  /eslint-plugin-markdown@3.0.0(eslint@9.0.0):
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.44.0):
+    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      '@babel/runtime': 7.20.13
+      aria-query: 5.3.0
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      ast-types-flow: 0.0.7
+      axe-core: 4.6.3
+      axobject-query: 3.2.1
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.44.0
+      has: 1.0.3
+      jsx-ast-utils: 3.3.3
+      language-tags: 1.0.5
+      minimatch: 3.1.2
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      semver: 6.3.1
+    dev: true
+
+  /eslint-plugin-markdown@3.0.0(eslint@8.44.0):
     resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.44.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-mdx@2.1.0(eslint@9.0.0):
+  /eslint-plugin-mdx@2.1.0(eslint@8.44.0):
     resolution: {integrity: sha512-Q8P1JXv+OrD+xhWT95ZyV30MMdnqJ1voKtXfxWrJJ2XihJRI15gPmXbIWY9t8CjA8C//isfzNOmnVY9e3GTL0g==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8.0.0'
     dependencies:
-      eslint: 9.0.0
-      eslint-mdx: 2.1.0(eslint@9.0.0)
-      eslint-plugin-markdown: 3.0.0(eslint@9.0.0)
+      eslint: 8.44.0
+      eslint-mdx: 2.1.0(eslint@8.44.0)
+      eslint-plugin-markdown: 3.0.0(eslint@8.44.0)
       remark-mdx: 2.3.0
       remark-parse: 10.0.1
       remark-stringify: 10.0.2
@@ -19129,16 +19275,16 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-n@16.0.1(eslint@9.0.0):
+  /eslint-plugin-n@16.0.1(eslint@8.44.0):
     resolution: {integrity: sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
       builtins: 5.0.1
-      eslint: 9.0.0
-      eslint-plugin-es-x: 7.1.0(eslint@9.0.0)
+      eslint: 8.44.0
+      eslint-plugin-es-x: 7.1.0(eslint@8.44.0)
       ignore: 5.2.4
       is-core-module: 2.12.1
       minimatch: 3.1.2
@@ -19146,33 +19292,33 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /eslint-plugin-promise@6.1.1(eslint@9.0.0):
+  /eslint-plugin-promise@6.1.1(eslint@8.44.0):
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.44.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@9.0.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.44.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.44.0
     dev: true
 
-  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@9.0.0):
+  /eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.42.0):
     resolution: {integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.42.0
 
-  /eslint-plugin-react@7.32.2(eslint@9.0.0):
+  /eslint-plugin-react@7.32.2(eslint@8.42.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -19182,7 +19328,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 9.0.0
+      eslint: 8.42.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -19195,36 +19341,60 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.8
 
-  /eslint-plugin-sonarjs@0.19.0(eslint@9.0.0):
+  /eslint-plugin-react@7.32.2(eslint@8.44.0):
+    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      array.prototype.tosorted: 1.1.1
+      doctrine: 2.1.0
+      eslint: 8.44.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.3
+      minimatch: 3.1.2
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      object.hasown: 1.1.2
+      object.values: 1.1.6
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.4
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.8
+    dev: true
+
+  /eslint-plugin-sonarjs@0.19.0(eslint@8.44.0):
     resolution: {integrity: sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==}
     engines: {node: '>=14'}
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.44.0
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@9.0.0)(svelte@4.0.1):
+  /eslint-plugin-svelte3@4.0.0(eslint@8.42.0)(svelte@4.0.1):
     resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
     peerDependencies:
       eslint: '>=8.0.0'
       svelte: ^3.2.0
     dependencies:
-      eslint: 9.0.0
+      eslint: 8.42.0
       svelte: 4.0.1
     dev: true
 
-  /eslint-plugin-unicorn@47.0.0(eslint@9.0.0):
+  /eslint-plugin-unicorn@47.0.0(eslint@8.44.0):
     resolution: {integrity: sha512-ivB3bKk7fDIeWOUmmMm9o3Ax9zbMz1Bsza/R2qm46ufw4T6VBFBaJIR1uN3pCKSmSXm8/9Nri8V+iUut1NhQGA==}
     engines: {node: '>=16'}
     peerDependencies:
       eslint: '>=8.38.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
       ci-info: 3.8.0
       clean-regexp: 1.0.0
-      eslint: 9.0.0
+      eslint: 8.44.0
       esquery: 1.5.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.1
@@ -19239,14 +19409,14 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-yml@1.8.0(eslint@9.0.0):
+  /eslint-plugin-yml@1.8.0(eslint@8.44.0):
     resolution: {integrity: sha512-fgBiJvXD0P2IN7SARDJ2J7mx8t0bLdG6Zcig4ufOqW5hOvSiFxeUyc2g5I1uIm8AExbo26NNYCcTGZT0MXTsyg==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4(supports-color@9.2.3)
-      eslint: 9.0.0
+      eslint: 8.44.0
       lodash: 4.17.21
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.2.2
@@ -19270,9 +19440,9 @@ packages:
       estraverse: 4.3.0
     dev: true
 
-  /eslint-scope@8.0.1:
-    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  /eslint-scope@7.2.0:
+    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
@@ -19281,41 +19451,88 @@ packages:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /eslint-visitor-keys@4.0.0:
-    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  /eslint@9.0.0:
-    resolution: {integrity: sha512-IMryZ5SudxzQvuod6rUdIUz29qFItWx281VhtFVc2Psy/ZhlCeD/5DT6lBIJ4H3G+iamGJoTln1v+QSuPw0p7Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  /eslint@8.42.0:
+    resolution: {integrity: sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.0.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 3.0.2
-      '@eslint/js': 9.0.0
-      '@humanwhocodes/config-array': 0.12.3
+      '@eslint-community/eslint-utils': 4.2.0(eslint@8.42.0)
+      '@eslint-community/regexpp': 4.4.0
+      '@eslint/eslintrc': 2.0.3
+      '@eslint/js': 8.42.0
+      '@humanwhocodes/config-array': 0.11.10
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.4(supports-color@9.2.3)
+      doctrine: 3.0.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.0.1
-      eslint-visitor-keys: 4.0.0
-      espree: 10.0.1
-      esquery: 1.5.0
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
+      esquery: 1.4.2
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
+      file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
+      globals: 13.19.0
       graphemer: 1.4.0
       ignore: 5.2.4
+      import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /eslint@8.44.0:
+    resolution: {integrity: sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.1.0
+      '@eslint/js': 8.44.0
+      '@humanwhocodes/config-array': 0.11.10
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4(supports-color@9.2.3)
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.6.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.19.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -19323,6 +19540,7 @@ packages:
       natural-compare: 1.4.0
       optionator: 0.9.3
       strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
@@ -19332,26 +19550,32 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /espree@10.0.1:
-    resolution: {integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  /espree@9.5.2:
+    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint-visitor-keys: 4.0.0
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
+      eslint-visitor-keys: 3.4.1
 
   /espree@9.6.0:
     resolution: {integrity: sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
       eslint-visitor-keys: 3.4.1
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  /esquery@1.4.2:
+    resolution: {integrity: sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
 
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -20147,11 +20371,11 @@ packages:
       is-unicode-supported: 1.3.0
     dev: true
 
-  /file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+  /file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 4.0.1
+      flat-cache: 3.0.4
 
   /file-loader@4.3.0(webpack@4.46.0):
     resolution: {integrity: sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==}
@@ -20441,15 +20665,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+  /flat-cache@3.0.4:
+    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flatted: 3.3.1
-      keyv: 4.5.4
+      flatted: 3.2.7
+      rimraf: 3.0.2
 
-  /flatted@3.3.1:
-    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+  /flatted@3.2.7:
+    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
   /flexsearch@0.7.43:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
@@ -21136,9 +21360,11 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+  /globals@13.19.0:
+    resolution: {integrity: sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
 
   /globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
@@ -24062,6 +24288,7 @@ packages:
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
 
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -24145,7 +24372,7 @@ packages:
     resolution: {integrity: sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
       eslint-visitor-keys: 3.4.1
       espree: 9.6.0
       semver: 7.5.4
@@ -24312,10 +24539,17 @@ packages:
       tsscmp: 1.0.6
     dev: false
 
-  /keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+  /keyv@4.5.0:
+    resolution: {integrity: sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
+
+  /keyv@4.5.3:
+    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
 
   /khroma@2.0.0:
     resolution: {integrity: sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g==}
@@ -25939,8 +26173,8 @@ packages:
   /micromark-extension-mdxjs@1.0.0:
     resolution: {integrity: sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==}
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
       micromark-extension-mdx-expression: 1.0.3
       micromark-extension-mdx-jsx: 1.0.3
       micromark-extension-mdx-md: 1.0.0
@@ -25952,8 +26186,8 @@ packages:
   /micromark-extension-mdxjs@3.0.0:
     resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
+      acorn: 8.9.0
+      acorn-jsx: 5.3.2(acorn@8.9.0)
       micromark-extension-mdx-expression: 3.0.0
       micromark-extension-mdx-jsx: 3.0.0
       micromark-extension-mdx-md: 2.0.0
@@ -26404,7 +26638,7 @@ packages:
     resolution: {integrity: sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==}
     engines: {node: '>=16.13'}
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
       acorn-walk: 8.2.0
       better-sqlite3: 8.4.0
       capnp-ts: 0.7.0
@@ -27941,6 +28175,17 @@ packages:
       levn: 0.3.0
       prelude-ls: 1.1.2
       type-check: 0.3.2
+      word-wrap: 1.2.3
+
+  /optionator@0.9.1:
+    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
       word-wrap: 1.2.3
 
   /optionator@0.9.3:
@@ -32499,7 +32744,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
@@ -32511,7 +32756,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.11.3
+      acorn: 8.9.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -32522,7 +32767,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.11.3
+      acorn: 8.9.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -33183,7 +33428,6 @@ packages:
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
-    dev: true
 
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -34060,7 +34304,7 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
       acorn-walk: 8.2.0
     dev: true
 
@@ -34187,7 +34431,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     hasBin: true
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.9.0
       acorn-walk: 8.2.0
       chalk: 4.1.2
       commander: 7.2.0
@@ -34313,8 +34557,8 @@ packages:
       '@webassemblyjs/ast': 1.11.5
       '@webassemblyjs/wasm-edit': 1.11.5
       '@webassemblyjs/wasm-parser': 1.11.5
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      acorn: 8.9.0
+      acorn-import-assertions: 1.9.0(acorn@8.9.0)
       browserslist: 4.23.0
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0

--- a/scripts/override-graphql-version.js
+++ b/scripts/override-graphql-version.js
@@ -1,5 +1,7 @@
 /* eslint-env node */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require('node:fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('node:path');
 
 // supply the wished graphql version as first argument of script

--- a/website/src/lib/v2-get-static-props.ts
+++ b/website/src/lib/v2-get-static-props.ts
@@ -1,5 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from 'next'
-// @ts-expect-error
+// @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
 import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote'
 import { defaultRemarkPlugins } from '@theguild/components/next.config'
 import json from '../../remote-files/v2.json' assert { type: 'json' }

--- a/website/src/lib/v3-get-static-props.ts
+++ b/website/src/lib/v3-get-static-props.ts
@@ -1,5 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from 'next'
-// @ts-expect-error
+// @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
 import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote'
 import { defaultRemarkPlugins } from '@theguild/components/next.config'
 import json from '../../remote-files/v3.json' assert { type: 'json' }

--- a/website/src/lib/v4-get-static-props.ts
+++ b/website/src/lib/v4-get-static-props.ts
@@ -1,5 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from 'next'
-// @ts-expect-error
+// @ts-expect-error I have no idea for the reason of this error. I am just the guy that has to fix the broken eslint setup.
 import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote'
 import { defaultRemarkPlugins } from '@theguild/components/next.config'
 import json from '../../remote-files/v4.json' assert { type: 'json' }

--- a/website/src/pages/docs/features/graphiql.mdx
+++ b/website/src/pages/docs/features/graphiql.mdx
@@ -9,8 +9,9 @@ import { Callout } from '@theguild/components'
 [GraphiQL](https://github.com/graphql/graphiql) is an in-browser IDE for writing, validating, and
 testing GraphQL queries.
 
-By default, GraphiQL is enabled only when in development and served under the `/graphql` route for `GET` requests with a
-`accept: text/html` header. You can configure or completely disable GraphiQL with the `graphiql` option.
+By default, GraphiQL is enabled only when in development and served under the `/graphql` route for
+`GET` requests with a `accept: text/html` header. You can configure or completely disable GraphiQL
+with the `graphiql` option.
 
 ## Default Document String
 

--- a/website/src/pages/docs/index.mdx
+++ b/website/src/pages/docs/index.mdx
@@ -134,19 +134,19 @@ npm i gqtx
 ```
 
 ```js filename="schema.js"
-import { buildGraphQLSchema, Gql } from "gqtx";
+import { buildGraphQLSchema, Gql } from 'gqtx'
 
 const Query = Gql.Query({
   fields: () => [
     Gql.Field({
-      name: "hello",
+      name: 'hello',
       type: Gql.String,
-      resolve: () => "world",
-    }),
-  ],
-});
+      resolve: () => 'world'
+    })
+  ]
+})
 
-export const schema = buildGraphQLSchema({ query: Query });
+export const schema = buildGraphQLSchema({ query: Query })
 ```
 
   </Tabs.Tab>


### PR DESCRIPTION
Reverts dotansimha/graphql-yoga#3230

Noticed that the eslint setup is broken since 3 weeks.
Reverting eslint 9 upgrade, as it got merged without actually running and testing it.
Also fixes all eslint issues and makes sure eslint runs as part of CI...