### PR TITLE
feat: support shouldPersistHeaders option in GraphiQL plugin

### DIFF
--- a/.changeset/rotten-knives-remember.md
+++ b/.changeset/rotten-knives-remember.md
@@ -1,0 +1,6 @@
+---
+'graphql-yoga': minor
+'@graphql-yoga/graphiql': minor
+---
+
+support shouldPersistHeaders option in GraphiQL plugin

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -8,7 +8,7 @@ contains the React component `GraphQLYoga`.
 You can run a local instance on `http://localhost:4001` with the following command".
 
 ```ts
-pnpm --filter @graphiql/yoga start
+pnpm --filter @graphql-yoga/graphiql start
 ```
 
 The development server will automatically proxy `http://localhost:4000/graphql`, so make sure you

--- a/packages/graphiql/src/YogaGraphiQL.tsx
+++ b/packages/graphiql/src/YogaGraphiQL.tsx
@@ -148,6 +148,7 @@ export function YogaGraphiQL(props: YogaGraphiQLProps): React.ReactElement {
         headers={props.headers}
         schemaDescription={true}
         fetcher={fetcher}
+        shouldPersistHeaders={props.shouldPersistHeaders}
       >
         <GraphiQLInterface
           isHeadersEditorEnabled

--- a/packages/graphql-yoga/src/plugins/use-graphiql.ts
+++ b/packages/graphql-yoga/src/plugins/use-graphiql.ts
@@ -22,6 +22,11 @@ export type GraphiQLOptions = {
    */
   headers?: string;
   /**
+   * This prop toggles if the contents of the headers editor are persisted in
+   * storage.
+   */
+  shouldPersistHeaders?: boolean;
+  /**
    * More info there: https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
    */
   credentials?: RequestCredentials;


### PR DESCRIPTION
This PR added support for the `shouldPersistHeaders` option to the graphiql plugin.