### PR TITLE
Retain server context prototype for batched requests

### DIFF
--- a/.changeset/silly-pigs-rhyme.md
+++ b/.changeset/silly-pigs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Retain server context prototype for batched requests

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -474,9 +474,7 @@ export class YogaServer<
               };
 
         const initialContext = args[0]
-          ? batched
-            ? Object.assign({}, args[0], additionalContext)
-            : Object.assign(args[0], additionalContext)
+          ? Object.assign(batched ? Object.create(args[0]) : args[0], additionalContext)
           : additionalContext;
 
         const enveloped = this.getEnveloped(initialContext);


### PR DESCRIPTION
I am using graphql-yoga with Koa, and I want to pass a server context object with a prototype to `handleNodeRequest`. This works for regular requests, but for batched requests, the prototype is lost, and only the enumerable properties get copied to the request-specific context objects. This change makes it so that batched requests use `Object.create` for the extended context instead of an empty object.