### PR TITLE
[plugin/jwt] allow passing all verify options

### DIFF
--- a/.changeset/stale-geckos-draw.md
+++ b/.changeset/stale-geckos-draw.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-jwt': minor
+---
+
+Update type to allow passing every jsonwebtoken.verify options

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -1,12 +1,12 @@
 import { createGraphQLError, Plugin } from 'graphql-yoga';
-import jsonwebtoken, { Algorithm, JwtPayload } from 'jsonwebtoken';
+import jsonwebtoken, { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import { JwksClient } from 'jwks-rsa';
 
 const { decode } = jsonwebtoken;
 
 export type JwtPluginOptions = JwtPluginOptionsWithJWKS | JwtPluginOptionsWithSigningKey;
 
-export interface JwtPluginOptionsBase {
+export interface JwtPluginOptionsBase extends VerifyOptions {
   /**
    * List of the algorithms used to verify the token
    *
@@ -16,11 +16,12 @@ export interface JwtPluginOptionsBase {
   /**
    * The audience is the identifier of the API and is forwarded to your Auth API in order to specify for which API we are trying to authenticate our user for. E.g. if our API is hosted on `http://localhost:3000/graphql`, we would pass that value.
    */
-  audience?: string;
+  audience?: VerifyOptions['audience'];
   /**
    * For example: `https://myapp.auth0.com/`
    */
-  issuer: string;
+  issuer: VerifyOptions['issuer'];
+
   /**
    * Once a user got successfully authenticated the authentication information is added on the context object under this field. In our resolvers we can then access the authentication information via `context._jwt.sub`.
    */
@@ -121,11 +122,7 @@ function unauthorizedError(message: string, options?: Parameters<typeof createGr
   });
 }
 
-function verify(
-  token: string,
-  signingKey: string,
-  options: Parameters<typeof jsonwebtoken.verify>[2],
-) {
+function verify(token: string, signingKey: string, options: VerifyOptions | undefined) {
   return new Promise((resolve, reject) => {
     jsonwebtoken.verify(
       token,

--- a/website/src/pages/docs/features/automatic-persisted-queries.mdx
+++ b/website/src/pages/docs/features/automatic-persisted-queries.mdx
@@ -124,32 +124,32 @@ For external stores the `set` and `get` properties on the store can also return 
   Instead of raising an error, returning undefined or null will allow the server to continue to
   respond to requests if the store goes down.
 
-  ```ts filename="Automatic Persisted Operations with a redis store" {16}
-  import Keyv from "keyv";
+```ts filename="Automatic Persisted Operations with a redis store" {16}
+import Keyv from 'keyv'
 
-  const store = new Keyv("redis://user:pass@localhost:6379");
+const store = new Keyv('redis://user:pass@localhost:6379')
 
-  useAPQ({
-    store: {
-      async get(key) {
-        try {
-          return await store.get(key);
-        } catch(e) {
-          console.error(`Error while fetching the operation: ${key}`, e);
-        }
-      },
-      async set(key, value) {
-        try {
-          return await store.set(key, value);
-        } catch(e) {
-          console.error(`Error while saving the operation: ${key}`, e);
-        }
+useAPQ({
+  store: {
+    async get(key) {
+      try {
+        return await store.get(key)
+      } catch (e) {
+        console.error(`Error while fetching the operation: ${key}`, e)
+      }
+    },
+    async set(key, value) {
+      try {
+        return await store.set(key, value)
+      } catch (e) {
+        console.error(`Error while saving the operation: ${key}`, e)
       }
     }
-  })
-  ```
-</Callout>
+  }
+})
+```
 
+</Callout>
 
 ## Configure Error responses
 


### PR DESCRIPTION
Current type of the plugin options offer only a limited set of options to verify the JWT. This PR updates the type to allow passing all options offered by `jsonwebtoken`