### PR TITLE
[plugin/prometheus] fix labels not filled properly on invalid operations

### DIFF
--- a/.changeset/rotten-chefs-love.md
+++ b/.changeset/rotten-chefs-love.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-prometheus': patch
+---
+
+Fix labels not filled properly on invalid operations

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -15,12 +15,12 @@ import {
 
 export {
   CounterAndLabels,
-  FillLabelsFnParams,
-  HistogramAndLabels,
-  SummaryAndLabels,
   createCounter,
   createHistogram,
   createSummary,
+  FillLabelsFnParams,
+  HistogramAndLabels,
+  SummaryAndLabels,
 };
 
 export interface PrometheusTracingPluginConfig extends EnvelopPrometheusTracingPluginConfig {
@@ -101,15 +101,15 @@ export function usePrometheus(options: PrometheusTracingPluginConfig): Plugin {
       }
       return undefined;
     },
-    onExecute({ args }) {
-      const operationAST = getOperationAST(args.document, args.operationName);
-      const operationType = operationAST?.operation;
-      const operationName = operationAST?.name?.value;
-      paramsByRequest.set(args.contextValue.request, {
-        document: args.document,
-        operationName,
-        operationType,
-      });
+    onParse() {
+      return ({ result: document, context: { params, request } }) => {
+        const operationAST = getOperationAST(document, params.operationName);
+        paramsByRequest.set(request, {
+          document,
+          operationName: operationAST?.name?.value,
+          operationType: operationAST?.operation,
+        });
+      };
     },
     onResponse({ request, response, serverContext }) {
       const start = startByRequest.get(request);

--- a/packages/plugins/prometheus/tests/prometheus.spec.ts
+++ b/packages/plugins/prometheus/tests/prometheus.spec.ts
@@ -148,6 +148,7 @@ describe('Prometheus', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/graphql+json',
+        Accept: 'application/graphql-response+json',
       },
       body: JSON.stringify({
         query: /* GraphQL */ `
@@ -158,10 +159,12 @@ describe('Prometheus', () => {
       }),
     });
     await result.text();
+    expect(result.status).toBe(400);
     const metrics = await registry.metrics();
     expect(metrics).toContain('graphql_yoga_http_duration_bucket');
     expect(metrics).toContain('operationType="query"');
     expect(metrics).toContain('method="POST"');
+    expect(metrics).toContain('statusCode="400"');
     expect(metrics).toContain('operationName="TestProm"');
   });
 });

--- a/website/src/pages/docs/features/automatic-persisted-queries.mdx
+++ b/website/src/pages/docs/features/automatic-persisted-queries.mdx
@@ -124,32 +124,32 @@ For external stores the `set` and `get` properties on the store can also return 
   Instead of raising an error, returning undefined or null will allow the server to continue to
   respond to requests if the store goes down.
 
-  ```ts filename="Automatic Persisted Operations with a redis store" {16}
-  import Keyv from "keyv";
+```ts filename="Automatic Persisted Operations with a redis store" {16}
+import Keyv from 'keyv'
 
-  const store = new Keyv("redis://user:pass@localhost:6379");
+const store = new Keyv('redis://user:pass@localhost:6379')
 
-  useAPQ({
-    store: {
-      async get(key) {
-        try {
-          return await store.get(key);
-        } catch(e) {
-          console.error(`Error while fetching the operation: ${key}`, e);
-        }
-      },
-      async set(key, value) {
-        try {
-          return await store.set(key, value);
-        } catch(e) {
-          console.error(`Error while saving the operation: ${key}`, e);
-        }
+useAPQ({
+  store: {
+    async get(key) {
+      try {
+        return await store.get(key)
+      } catch (e) {
+        console.error(`Error while fetching the operation: ${key}`, e)
+      }
+    },
+    async set(key, value) {
+      try {
+        return await store.set(key, value)
+      } catch (e) {
+        console.error(`Error while saving the operation: ${key}`, e)
       }
     }
-  })
-  ```
-</Callout>
+  }
+})
+```
 
+</Callout>
 
 ## Configure Error responses
 


### PR DESCRIPTION
To fill labels, the plugin is caching operation params using the `onExecute` hook. This leads to params missing when the operation is not executed (such as for invalid operation with unknown fields for example).

This PR uses `onParse` hook instead.

fixes #3274 