### PR TITLE
fix(types): Remove global ReadableStream override

### DIFF
--- a/examples/fastify/tsconfig.json
+++ b/examples/fastify/tsconfig.json
@@ -7,5 +7,6 @@
     "lib": ["esnext", "DOM", "DOM.Iterable"],
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true
-  }
+  },
+  "include": ["src/*"]
 }

--- a/packages/graphql-yoga/__integration-tests__/incremental-delivery.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/incremental-delivery.spec.ts
@@ -8,6 +8,7 @@ import {
   GraphQLSchema,
   GraphQLString,
 } from 'graphql';
+import { castToYogaReadableStream } from 'graphql-yoga';
 import { Push } from '@repeaterjs/repeater';
 import { createFetch, fetch, File, FormData } from '@whatwg-node/fetch';
 import { createSchema, createYoga, Plugin, Repeater } from '../src';
@@ -74,7 +75,7 @@ describe('incremental delivery', () => {
       });
 
       // Start and Close a HTTP Request
-      for await (const chunk of res.body!) {
+      for await (const chunk of castToYogaReadableStream(res.body!)) {
         if (chunk === undefined) {
           break;
         }

--- a/packages/graphql-yoga/__integration-tests__/subscription.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/subscription.spec.ts
@@ -2,7 +2,7 @@ import { createServer } from 'node:http';
 import { AddressInfo } from 'node:net';
 import { ExecutionResult } from 'graphql';
 import { fetch } from '@whatwg-node/fetch';
-import { createSchema, createYoga } from '../src';
+import { castToYogaReadableStream, createSchema, createYoga } from '../src';
 
 describe('subscription', () => {
   test('Subscription is closed properly', async () => {
@@ -61,7 +61,7 @@ describe('subscription', () => {
         expect(response.status).toBe(200);
         expect(response.headers.get('content-type')).toBe('text/event-stream');
 
-        for await (const chunk of response.body!) {
+        for await (const chunk of castToYogaReadableStream(response.body!)) {
           const str = Buffer.from(chunk).toString('utf-8');
           if (str) {
             break;

--- a/packages/graphql-yoga/__tests__/accept-header.spec.ts
+++ b/packages/graphql-yoga/__tests__/accept-header.spec.ts
@@ -1,5 +1,11 @@
 import { ExecutionResult } from 'graphql';
-import { createSchema, createYoga, Plugin, Repeater } from '../src/index.js';
+import {
+  castToYogaReadableStream,
+  createSchema,
+  createYoga,
+  Plugin,
+  Repeater,
+} from '../src/index.js';
 
 describe('accept header', () => {
   it('instruct server to return an event-stream with GET parameters', async () => {
@@ -73,7 +79,7 @@ describe('accept header', () => {
       `Content-Length: 24`,
       JSON.stringify({ data: { ping: 'pong' } }),
     ];
-    for await (const chunk of response.body!) {
+    for await (const chunk of castToYogaReadableStream(response.body!)) {
       const valueStr = Buffer.from(chunk).toString('utf-8');
       if (expectedStrs.includes(valueStr)) {
         expectedStrs.splice(expectedStrs.indexOf(valueStr), 1);
@@ -112,7 +118,7 @@ describe('accept header', () => {
       `Content-Length: 24`,
       JSON.stringify({ data: { ping: 'pong' } }),
     ]);
-    for await (const chunk of response.body!) {
+    for await (const chunk of castToYogaReadableStream(response.body!)) {
       const valueStr = Buffer.from(chunk).toString('utf-8');
       for (const expectedStr of expectedStrs) {
         if (valueStr.includes(expectedStr)) {

--- a/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
+++ b/packages/graphql-yoga/__tests__/request-cancellation.spec.ts
@@ -1,5 +1,11 @@
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
-import { createLogger, createSchema, createYoga, FetchAPI } from '../src/index';
+import {
+  castToYogaReadableStream,
+  createLogger,
+  createSchema,
+  createYoga,
+  FetchAPI,
+} from '../src/index';
 import { useExecutionCancellation } from '../src/plugins/use-execution-cancellation';
 
 const variants: Array<[name: string, fetchAPI: undefined | FetchAPI]> = [
@@ -158,7 +164,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       signal: abortController.signal,
     });
     expect(response.status).toBe(200);
-    const iterator = response.body![Symbol.asyncIterator]();
+    const iterator = castToYogaReadableStream(response.body!)[Symbol.asyncIterator]();
     // first we will always get a ping/keep alive for flushed headers
     const next = await iterator.next();
     expect(Buffer.from(next.value).toString('utf-8')).toMatchInlineSnapshot(`
@@ -258,7 +264,7 @@ describe.each(variants)('request cancellation (%s)', (_, fetchAPI) => {
       signal: abortController.signal,
     });
     expect(response.status).toEqual(200);
-    const iterator = response.body![Symbol.asyncIterator]();
+    const iterator = castToYogaReadableStream(response.body!)[Symbol.asyncIterator]();
     let payload = '';
 
     // Shitty wait condition, but it works lol

--- a/packages/graphql-yoga/__tests__/subscriptions.spec.ts
+++ b/packages/graphql-yoga/__tests__/subscriptions.spec.ts
@@ -1,5 +1,11 @@
 import { GraphQLError } from 'graphql';
-import { createSchema, createYoga, maskError, Plugin } from '../src/index.js';
+import {
+  castToYogaReadableStream,
+  createSchema,
+  createYoga,
+  maskError,
+  Plugin,
+} from '../src/index.js';
 import { eventStream } from './utilities.js';
 
 describe('Subscription', () => {
@@ -106,7 +112,7 @@ describe('Subscription', () => {
       }),
     });
 
-    const iterator = response.body![Symbol.asyncIterator]();
+    const iterator = castToYogaReadableStream(response.body!)[Symbol.asyncIterator]();
 
     const results = [];
     let value: Uint8Array;
@@ -195,7 +201,7 @@ data:
       }),
     });
 
-    const iterator = response.body![Symbol.asyncIterator]();
+    const iterator = castToYogaReadableStream(response.body!)[Symbol.asyncIterator]();
 
     const results = [];
     let value: Uint8Array;

--- a/packages/graphql-yoga/__tests__/utilities.ts
+++ b/packages/graphql-yoga/__tests__/utilities.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Repeater } from '@repeaterjs/repeater';
+import { castToYogaReadableStream } from '../src';
 
 /** Parse SSE event stream and yield data pieces. */
 export function eventStream<TType = unknown>(source: ReadableStream<Uint8Array>) {
@@ -8,7 +9,7 @@ export function eventStream<TType = unknown>(source: ReadableStream<Uint8Array>)
       done: true,
       value: undefined,
     }));
-    const iterable = source[Symbol.asyncIterator]();
+    const iterable = castToYogaReadableStream(source)[Symbol.asyncIterator]();
 
     // eslint-disable-next-line no-constant-condition
     while (true) {

--- a/packages/graphql-yoga/src/types.ts
+++ b/packages/graphql-yoga/src/types.ts
@@ -39,10 +39,19 @@ export type CORSOptions =
     }
   | false;
 
-declare global {
-  interface ReadableStream<R = any> {
-    [Symbol.asyncIterator]: () => AsyncIterator<R>;
-  }
+/**
+ * Overrides the standard library definition to include AsyncIterator support.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator
+ */
+export interface YogaReadableStreamOverride<R = any> extends ReadableStream<R> {
+  [Symbol.asyncIterator]: () => AsyncIterator<R>;
+}
+
+export function castToYogaReadableStream<T extends ReadableStream<R>, R = any>(
+  value: T,
+): YogaReadableStreamOverride<R> {
+  return value as unknown as YogaReadableStreamOverride;
 }
 
 export type FetchAPI = ReturnType<typeof createFetch>;

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -1,6 +1,12 @@
 import { createServer, get, IncomingMessage } from 'node:http';
 import { AddressInfo } from 'node:net';
-import { createLogger, createSchema, createYoga, useExecutionCancellation } from 'graphql-yoga';
+import {
+  castToYogaReadableStream,
+  createLogger,
+  createSchema,
+  createYoga,
+  useExecutionCancellation,
+} from 'graphql-yoga';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { createPushPullAsyncIterable } from '../__tests__/push-pull-async-iterable.js';
 
@@ -50,7 +56,7 @@ it('correctly deals with the source upon aborted requests', async () => {
     });
     let counter = 0;
     const toStr = (arr: Uint8Array) => Buffer.from(arr).toString('utf-8');
-    for await (const chunk of response.body!) {
+    for await (const chunk of castToYogaReadableStream(response.body!)) {
       const parts = toStr(chunk)
         .split('\r\n')
         .filter(p => p.startsWith('{'));


### PR DESCRIPTION
This PR attempts to solve the problem raised in https://github.com/n1ru4l/envelop/issues/2104

Currently graphql-yoga overrides the `ReadableStream` interface in the `global` namespace. This causes issues in environments like cloudflare workers where `@cloudflare/worker-types` already overrides the global namespace with its own definitions of `ReadableStream` among other types.