### PR TITLE
feat(response-cache): accept `serverContext` as the 2nd param in `enabled` and `session`

### DIFF
--- a/.changeset/quiet-moles-nail.md
+++ b/.changeset/quiet-moles-nail.md
@@ -1,5 +1,5 @@
 ---
-'graphql-yoga': patch
+'graphql-yoga': minor
 ---
 
 Now `onParams` hook's payload has `serverContext`

--- a/.changeset/quiet-moles-nail.md
+++ b/.changeset/quiet-moles-nail.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': patch
+---
+
+Now `onParams` hook's payload has `serverContext`

--- a/.changeset/twenty-birds-sin.md
+++ b/.changeset/twenty-birds-sin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-response-cache': patch
+---
+
+Now `enabled` and `session` factory functions take a second parameter `ServerContext` that includes the server specific context object. But this object is not the one provided by the user. [Learn more about the difference between the server context and the user context](https://the-guild.dev/graphql/yoga-server/docs/features/context#advanced-context-life-cycle)

--- a/examples/bun-yoga-ws/package.json
+++ b/examples/bun-yoga-ws/package.json
@@ -10,7 +10,7 @@
     "bun-types": "^1.0.0",
     "graphql": "^16.6.0",
     "graphql-ws": "^5.14.1",
-    "graphql-yoga": "^4.0.5"
+    "graphql-yoga": "5.3.1"
   },
   "devDependencies": {
     "@whatwg-node/fetch": "^0.9.0"

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -106,11 +106,11 @@ export interface OnRequestParseDoneEventPayload {
   setRequestParserResult: (params: GraphQLParams | GraphQLParams[]) => void;
 }
 
-export type OnParamsHook<TServerContext> = (
+export type OnParamsHook<TServerContext = unknown> = (
   payload: OnParamsEventPayload<TServerContext>,
 ) => PromiseOrValue<void>;
 
-export interface OnParamsEventPayload<TServerContext> {
+export interface OnParamsEventPayload<TServerContext = unknown> {
   params: GraphQLParams;
   request: Request;
   serverContext?: TServerContext;

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -49,7 +49,7 @@ export type Plugin<
      * Use this hook with your own risk. It is still experimental and may change in the future.
      * @internal
      */
-    onParams?: OnParamsHook;
+    onParams?: OnParamsHook<TServerContext>;
     /**
      * Use this hook with your own risk. It is still experimental and may change in the future.
      * @internal
@@ -106,11 +106,14 @@ export interface OnRequestParseDoneEventPayload {
   setRequestParserResult: (params: GraphQLParams | GraphQLParams[]) => void;
 }
 
-export type OnParamsHook = (payload: OnParamsEventPayload) => PromiseOrValue<void>;
+export type OnParamsHook<TServerContext> = (
+  payload: OnParamsEventPayload<TServerContext>,
+) => PromiseOrValue<void>;
 
-export interface OnParamsEventPayload {
+export interface OnParamsEventPayload<TServerContext> {
   params: GraphQLParams;
   request: Request;
+  serverContext?: TServerContext;
   setParams: (params: GraphQLParams) => void;
   setResult: (result: ExecutionResult | AsyncIterable<ExecutionResult>) => void;
   fetchAPI: FetchAPI;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: ^5.14.1
         version: 5.14.1(graphql@16.8.1)
       graphql-yoga:
-        specifier: ^4.0.5
-        version: 4.0.5(graphql@16.8.1)
+        specifier: 5.3.1
+        version: link:../../packages/graphql-yoga/dist
     devDependencies:
       '@whatwg-node/fetch':
         specifier: ^0.9.0
@@ -7751,31 +7751,6 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.1
-
-  /@graphql-yoga/logger@1.0.0:
-    resolution: {integrity: sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@graphql-yoga/subscription@4.0.0:
-    resolution: {integrity: sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@graphql-yoga/typed-event-target': 2.0.0
-      '@repeaterjs/repeater': 3.0.4
-      '@whatwg-node/events': 0.1.0
-      tslib: 2.6.2
-    dev: false
-
-  /@graphql-yoga/typed-event-target@2.0.0:
-    resolution: {integrity: sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@repeaterjs/repeater': 3.0.4
-      tslib: 2.6.2
-    dev: false
 
   /@grpc/grpc-js@1.8.11:
     resolution: {integrity: sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==}
@@ -21529,26 +21504,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-
-  /graphql-yoga@4.0.5(graphql@16.8.1):
-    resolution: {integrity: sha512-vIbJU9QX5RP4PoxbMCHcfOlt/3EsC/0uLdAOlKaiUvlwJDTFCaIHo2X10vL4i/27Gw8g90ECIwm2YbmeLDwcqg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
-    dependencies:
-      '@envelop/core': 4.0.0
-      '@graphql-tools/executor': 1.2.5(graphql@16.8.1)
-      '@graphql-tools/schema': 10.0.3(graphql@16.8.1)
-      '@graphql-tools/utils': 10.1.1(graphql@16.8.1)
-      '@graphql-yoga/logger': 1.0.0
-      '@graphql-yoga/subscription': 4.0.0
-      '@whatwg-node/fetch': 0.9.17
-      '@whatwg-node/server': 0.9.33
-      dset: 3.1.2
-      graphql: 16.8.1
-      lru-cache: 10.0.0
-      tslib: 2.6.2
-    dev: false
 
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32171,7 +32171,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.18
       esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.3.0


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-yoga/issues/3282

- Add  `serverContext` to `onParams` hook's payload
- `enabled` and `session` factory functions take a second parameter `ServerContext` that includes the server specific context object. But this object is not the one provided by the user. [Learn more about the difference between the server context and the user context](https://the-guild.dev/graphql/yoga-server/docs/features/context#advanced-context-life-cycle)