### PR TITLE
Remove unnecessary Events ponyfill

### DIFF
--- a/.changeset/@graphql-yoga_redis-event-target-3306-dependencies.md
+++ b/.changeset/@graphql-yoga_redis-event-target-3306-dependencies.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/redis-event-target': patch
+---
+dependencies updates:
+  - Removed dependency [`@whatwg-node/events@^0.1.0`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/events/v/0.1.0) (from `dependencies`)

--- a/.changeset/@graphql-yoga_subscription-3306-dependencies.md
+++ b/.changeset/@graphql-yoga_subscription-3306-dependencies.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/subscription': patch
+---
+dependencies updates:
+  - Removed dependency [`@whatwg-node/events@^0.1.0`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/events/v/0.1.0) (from `dependencies`)

--- a/.changeset/gentle-timers-breathe.md
+++ b/.changeset/gentle-timers-breathe.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/redis-event-target': patch
+'@graphql-yoga/subscription': patch
+---
+
+Remove @whatwg-node/events ponyfill

--- a/import-map.json
+++ b/import-map.json
@@ -12,7 +12,6 @@
     "@envelop/core": "npm:@envelop/core@3",
     "@envelop/parser-cache": "npm:@envelop/parser-cache",
     "@whatwg-node/fetch": "npm:@whatwg-node/fetch",
-    "@whatwg-node/events": "npm:@whatwg-node/events@0.0.3",
     "@whatwg-node/server": "npm:@whatwg-node/server",
     "@repeaterjs/repeater": "npm:@repeaterjs/repeater",
     "lru-cache": "npm:lru-cache@^9.0.0"

--- a/packages/event-target/redis-event-target/__tests__/redis-event-target.spec.ts
+++ b/packages/event-target/redis-event-target/__tests__/redis-event-target.spec.ts
@@ -1,5 +1,4 @@
 import Redis from 'ioredis-mock';
-import { CustomEvent } from '@whatwg-node/events';
 import { createRedisEventTarget } from '../src';
 
 describe('createRedisEventTarget', () => {

--- a/packages/event-target/redis-event-target/__tests__/serializer.spec.ts
+++ b/packages/event-target/redis-event-target/__tests__/serializer.spec.ts
@@ -1,5 +1,4 @@
 import Redis from 'ioredis-mock';
-import { CustomEvent } from '@whatwg-node/events';
 import { createRedisEventTarget } from '../src';
 
 describe('createRedisEventTarget: serializer arg', () => {

--- a/packages/event-target/redis-event-target/package.json
+++ b/packages/event-target/redis-event-target/package.json
@@ -46,8 +46,7 @@
     "ioredis": "^5.0.6"
   },
   "dependencies": {
-    "@graphql-yoga/typed-event-target": "workspace:^",
-    "@whatwg-node/events": "^0.1.0"
+    "@graphql-yoga/typed-event-target": "workspace:^"
   },
   "devDependencies": {
     "@types/ioredis-mock": "8.2.2",

--- a/packages/event-target/redis-event-target/src/index.ts
+++ b/packages/event-target/redis-event-target/src/index.ts
@@ -1,6 +1,5 @@
 import type { Cluster, Redis } from 'ioredis';
 import type { TypedEventTarget } from '@graphql-yoga/typed-event-target';
-import { CustomEvent } from '@whatwg-node/events';
 
 export type CreateRedisEventTargetArgs = {
   publishClient: Redis | Cluster;

--- a/packages/subscription/package.json
+++ b/packages/subscription/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "@graphql-yoga/typed-event-target": "workspace:^",
     "@repeaterjs/repeater": "^3.0.4",
-    "@whatwg-node/events": "^0.1.0",
     "tslib": "^2.5.2"
   },
   "devDependencies": {

--- a/packages/subscription/src/create-pub-sub.ts
+++ b/packages/subscription/src/create-pub-sub.ts
@@ -1,6 +1,5 @@
 import type { TypedEventTarget } from '@graphql-yoga/typed-event-target';
 import { Repeater } from '@repeaterjs/repeater';
-import { CustomEvent } from '@whatwg-node/events';
 
 type PubSubPublishArgsByKey = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
After Node 18, the entire Events API is available so the ponyfill is no longer needed.