### PR TITLE
docs: µWebSockets.js listen params

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-uwebsockets.mdx
+++ b/website/src/pages/docs/integrations/integration-with-uwebsockets.mdx
@@ -47,7 +47,7 @@ const yoga = createYoga<ServerContext>({
 
 App()
   .any('/*', yoga)
-  .listen(() => {
+  .listen("localhost", 4000, () => {
     console.log(`Server is running on http://localhost:4000`)
   })
 ```


### PR DESCRIPTION
This PR fixes these TypeScript errors in the µWebSockets.js example in the docs: https://the-guild.dev/graphql/yoga-server/docs/integrations/integration-with-uwebsockets

![338243916-eb3aa6e6-c012-4c6f-9498-0954fb4ee6b4](https://github.com/dotansimha/graphql-yoga/assets/60944077/956b3224-0e66-45db-ad3c-e7b729ba0426)
