### PR TITLE
add `display: children` for basic tutorials

### DIFF
--- a/website/src/pages/tutorial/_meta.ts
+++ b/website/src/pages/tutorial/_meta.ts
@@ -1,5 +1,8 @@
 export default {
-  basic: 'Basic',
+  basic: {
+    title: 'Basic',
+    display: 'children',
+  },
   advanced: {
     title: 'Advanced',
     display: 'hidden',


### PR DESCRIPTION
tiny change to not have nested folder

<img width="510" alt="image" src="https://github.com/dotansimha/graphql-yoga/assets/7361780/f83a519f-ec47-4a7b-9daf-960cced1a97a">
