### PR TITLE
feat: customize landing page via `landingPage`

### DIFF
--- a/.changeset/unlucky-cats-lie.md
+++ b/.changeset/unlucky-cats-lie.md
@@ -1,0 +1,6 @@
+---
+'graphql-yoga': minor
+---
+
+Customize the landing page by passing a custom renderer that returns `Response` to the `landingPage`
+option

--- a/.changeset/unlucky-cats-lie.md
+++ b/.changeset/unlucky-cats-lie.md
@@ -4,3 +4,32 @@
 
 Customize the landing page by passing a custom renderer that returns `Response` to the `landingPage`
 option
+
+```ts
+import { createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  landingPage: ({ url, fetchAPI }) => {
+    return new fetchAPI.Response(
+      /* HTML */ `
+        <!doctype html>
+        <html>
+          <head>
+            <title>404 Not Found</title>
+          </head>
+          <body>
+            <h1>404 Not Found</h1>
+            <p>Sorry, the page (${url.pathname}) you are looking for could not be found.</p>
+          </body>
+        </html>
+      `,
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'text/html'
+        }
+      }
+    )
+  }
+})
+```

--- a/packages/graphql-yoga/__tests__/404.spec.ts
+++ b/packages/graphql-yoga/__tests__/404.spec.ts
@@ -17,10 +17,9 @@ describe('404', () => {
       logging: false,
     });
     const url = `http://localhost:4000/notgraphql`;
-    const response = await yoga.fetch(
-      url.replace('mypath', 'yourpath') + '?query=' + encodeURIComponent('{ __typename }'),
-      { method: 'GET' },
-    );
+    const response = await yoga.fetch(url + '?query=' + encodeURIComponent('{ __typename }'), {
+      method: 'GET',
+    });
 
     expect(response.status).toEqual(404);
     expect(await response.text()).toEqual('');
@@ -76,5 +75,23 @@ describe('404', () => {
     expect(response.status).toEqual(566);
     const body = await response.text();
     expect(body).toEqual('Do you really like em?');
+  });
+  it('supports custom landing page', async () => {
+    const customLandingPageContent = 'My Custom Landing Page';
+    const yoga = createYoga({
+      logging: false,
+      landingPage({ fetchAPI }) {
+        return new fetchAPI.Response(customLandingPageContent, {
+          status: 200,
+        });
+      },
+    });
+    const response = await yoga.fetch(`http://localhost:4000/notgraphql`, {
+      method: 'GET',
+      headers: { Accept: 'text/html' },
+    });
+    expect(response.status).toEqual(200);
+    const body = await response.text();
+    expect(body).toEqual(customLandingPageContent);
   });
 });

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -39,3 +39,4 @@ export {
 } from '@envelop/core';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
 export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';
+export { LandingPageRenderer, LandingPageRendererOpts } from './plugins/use-unhandled-route.js';

--- a/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
+++ b/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
@@ -9,6 +9,8 @@ export interface LandingPageRendererOpts {
   fetchAPI: FetchAPI;
   url: URL;
   graphqlEndpoint: string;
+  // Not sure why the global `URLPattern` causes errors with the ponyfill typings
+  // So instead we use this which points to the same type
   urlPattern: InstanceType<FetchAPI['URLPattern']>;
 }
 

--- a/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
+++ b/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
@@ -9,7 +9,7 @@ export interface LandingPageRendererOpts {
   fetchAPI: FetchAPI;
   url: URL;
   graphqlEndpoint: string;
-  urlPattern: URLPattern;
+  urlPattern: InstanceType<FetchAPI['URLPattern']>;
 }
 
 export type LandingPageRenderer = (opts: LandingPageRendererOpts) => PromiseOrValue<Response>;
@@ -46,7 +46,7 @@ export function useUnhandledRoute(args: {
   const landingPageRenderer: LandingPageRenderer =
     args.landingPageRenderer || defaultRenderLandingPage;
   return {
-    onRequest({ request, fetchAPI, endResponse, url }) {
+    onRequest({ request, fetchAPI, endResponse, url }): PromiseOrValue<void> {
       if (
         !request.url.endsWith(args.graphqlEndpoint) &&
         !request.url.endsWith(`${args.graphqlEndpoint}/`) &&
@@ -69,10 +69,9 @@ export function useUnhandledRoute(args: {
             },
           });
           if (isPromise(landingPage$)) {
-            landingPage$.then(res => endResponse(res));
-          } else {
-            endResponse(landingPage$);
+            return landingPage$.then(endResponse);
           }
+          endResponse(landingPage$);
           return;
         }
 

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -59,7 +59,7 @@ import {
 import { useRequestParser } from './plugins/use-request-parser.js';
 import { useResultProcessors } from './plugins/use-result-processor.js';
 import { useSchema, YogaSchemaDefinition } from './plugins/use-schema.js';
-import { useUnhandledRoute } from './plugins/use-unhandled-route.js';
+import { LandingPageRenderer, useUnhandledRoute } from './plugins/use-unhandled-route.js';
 import { processRequest as processGraphQLParams, processResult } from './process-request.js';
 import {
   FetchAPI,
@@ -120,7 +120,7 @@ export type YogaServerOptions<TServerContext, TUserContext> = {
   /**
    * Whether the landing page should be shown.
    */
-  landingPage?: boolean | undefined;
+  landingPage?: boolean | LandingPageRenderer | undefined;
 
   /**
    * GraphiQL options
@@ -360,11 +360,14 @@ export class YogaServer<
           addPlugin(useLimitBatching(batchingLimit));
           // @ts-expect-error Add plugins has context but this hook doesn't care
           addPlugin(useCheckGraphQLQueryParams());
+          const showLandingPage = !!(options?.landingPage ?? true);
           addPlugin(
             // @ts-expect-error Add plugins has context but this hook doesn't care
             useUnhandledRoute({
               graphqlEndpoint,
-              showLandingPage: options?.landingPage ?? true,
+              showLandingPage,
+              landingPageRenderer:
+                typeof options?.landingPage === 'function' ? options.landingPage : undefined,
             }),
           );
           // We check the method after user-land plugins because the plugin might support more methods (like graphql-sse).

--- a/packages/nestjs/__tests__/graphql-http.spec.ts
+++ b/packages/nestjs/__tests__/graphql-http.spec.ts
@@ -30,7 +30,6 @@ describe('GraphQL over HTTP', () => {
   })) {
     if (
       // we dont control the JSON parsing
-      audit.id === 'D477' ||
       audit.id === 'A5BF'
     ) {
       it.todo(audit.name);

--- a/website/src/pages/docs/features/_meta.ts
+++ b/website/src/pages/docs/features/_meta.ts
@@ -23,4 +23,5 @@ export default {
   'envelop-plugins': 'Plugins',
   testing: 'Testing',
   jwt: 'JWT',
+  'landing-page': 'Landing Page',
 };

--- a/website/src/pages/docs/features/landing-page.mdx
+++ b/website/src/pages/docs/features/landing-page.mdx
@@ -6,7 +6,7 @@ description: Learn more about landing page customization in GraphQL Yoga
 
 When GraphQL Yoga hits 404, it returns a default landing page like below;
 
-![Landing Page](/img/landing-page.png)
+![image](https://github.com/dotansimha/graphql-yoga/assets/20847995/7bc058db-1823-4316-86ff-cf1847522da5)
 
 If you don't expect to hit 404 in that path, you can configure `graphqlEndpoint` to avoid this page.
 

--- a/website/src/pages/docs/features/landing-page.mdx
+++ b/website/src/pages/docs/features/landing-page.mdx
@@ -1,0 +1,67 @@
+---
+description: Learn more about landing page customization in GraphQL Yoga
+---
+
+# Landing Page
+
+When GraphQL Yoga hits 404, it returns a default landing page like below;
+
+![Landing Page](/img/landing-page.png)
+
+If you don't expect to hit 404 in that path, you can configure `graphqlEndpoint` to avoid this page.
+
+```ts
+import { createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  graphqlEndpoint: '/my-graphql-endpoint'
+})
+```
+
+How ever you can disable the landing page, and just get 404 error directly by setting `landingPage`
+to `false`.
+
+```ts
+import { createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  landingPage: false
+})
+```
+
+You can also customize the landing page by passing a custom renderer that returns `Response` to the
+`landingPage` option.
+
+```ts
+import { createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  landingPage: ({ url, fetchAPI }) => {
+    return new fetchAPI.Response(
+      /* HTML */ `
+        <!doctype html>
+        <html>
+          <head>
+            <title>404 Not Found</title>
+          </head>
+          <body>
+            <h1>404 Not Found</h1>
+            <p>Sorry, the page (${url.pathname}) you are looking for could not be found.</p>
+          </body>
+        </html>
+      `,
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'text/html'
+        }
+      }
+    )
+  }
+})
+```
+
+<Callout>
+  `Response` is part of the Fetch API, so if you want to learn more about it, you can check the [MDN
+  documentation](https://developer.mozilla.org/en-US/docs/Web/API/Response).
+</Callout>


### PR DESCRIPTION
Customize the landing page by passing a custom renderer that returns `Response` to the `landingPage`
option

Then we can customize the landing page for Mesh etc.