### PR TITLE
feat: allow extra params in body

### DIFF
--- a/.changeset/eighty-books-wonder.md
+++ b/.changeset/eighty-books-wonder.md
@@ -1,0 +1,29 @@
+---
+'graphql-yoga': minor
+---
+
+By default, Yoga does not allow extra parameters in the request body other than `query`, `operationName`, `extensions`, and `variables`, then throws 400 HTTP Error.
+This change adds a new option called `extraParamNames` to allow extra parameters in the request body.
+
+```ts
+import { createYoga } from 'graphql-yoga';
+
+const yoga = createYoga({
+  /* other options */
+  extraParamNames: ['extraParam1', 'extraParam2'],
+});
+
+const res = await yoga.fetch('/graphql', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+        query: 'query { __typename }',
+        extraParam1: 'value1',
+        extraParam2: 'value2',
+    }),
+});
+
+console.assert(res.status === 200);
+```

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -402,6 +402,26 @@ describe('requests', () => {
     expect(body.errors?.[0].message).toBe('Unexpected parameter "test" in the request body.');
   });
 
+  it('does not error if there is a specified invalid parameter in the request body', async () => {
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      extraParamNames: ['test'],
+    });
+    const response = await yoga.fetch(`http://yoga/graphql`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/graphql+json',
+      },
+      body: JSON.stringify({ query: '{ ping }', test: 'a' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    expect(body.data.ping).toBe('pong');
+  });
+
   it('should use supported accept header when multiple are provided', async () => {
     const response = await yoga.fetch('http://yoga/test-graphql', {
       method: 'POST',

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -422,6 +422,27 @@ describe('requests', () => {
     expect(body.data.ping).toBe('pong');
   });
 
+  it('throws when there is an invalid parameter in the request body other than the specified invalid parameters', async () => {
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      extraParamNames: ['test'],
+    });
+    const response = await yoga.fetch(`http://yoga/graphql`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/graphql-response+json',
+        'content-type': 'application/graphql+json',
+      },
+      body: JSON.stringify({ query: '{ ping }', test2: 'a' }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.data).toBeUndefined();
+    expect(body.errors?.[0].message).toBe('Unexpected parameter "test2" in the request body.');
+  });
+
   it('should use supported accept header when multiple are provided', async () => {
     const response = await yoga.fetch('http://yoga/test-graphql', {
       method: 'POST',

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -163,6 +163,17 @@ export type YogaServerOptions<TServerContext, TUserContext> = {
    * @default false
    */
   batching?: BatchingOptions | undefined;
+
+  /**
+   * By default, GraphQL Yoga does not allow parameters in the request body except `query`, `variables`, `extensions`, and `operationName`.
+   *
+   * This option allows you to specify additional parameters that are allowed in the request body.
+   *
+   * @default []
+   *
+   * @example ['doc_id', 'id']
+   */
+  extraParamNames?: string[] | undefined;
 };
 
 export type BatchingOptions =
@@ -359,7 +370,7 @@ export class YogaServer<
           // @ts-expect-error Add plugins has context but this hook doesn't care
           addPlugin(useLimitBatching(batchingLimit));
           // @ts-expect-error Add plugins has context but this hook doesn't care
-          addPlugin(useCheckGraphQLQueryParams());
+          addPlugin(useCheckGraphQLQueryParams(options?.extraParamNames));
           const showLandingPage = !!(options?.landingPage ?? true);
           addPlugin(
             // @ts-expect-error Add plugins has context but this hook doesn't care

--- a/website/src/pages/docs/features/_meta.ts
+++ b/website/src/pages/docs/features/_meta.ts
@@ -24,4 +24,5 @@ export default {
   testing: 'Testing',
   jwt: 'JWT',
   'landing-page': 'Landing Page',
+  'request-customization': 'Request Customization',
 };

--- a/website/src/pages/docs/features/request-customization.mdx
+++ b/website/src/pages/docs/features/request-customization.mdx
@@ -4,10 +4,10 @@ description: You can customize the request handling in GraphQL Yoga
 
 # Request Customization
 
-For each type of request, GraphQL Yoga uses a specific parser to parse the incoming request and extract the GraphQL operation
-from it. Then it applies some validation logic to the extracted object, then it passes it to the
-GraphQL execution engine. Yoga mostly follows GraphQL-over-HTTP standards for this validation and parsing
-logic.
+For each type of request, GraphQL Yoga uses a specific parser to parse the incoming request and
+extract the GraphQL operation from it. Then it applies some validation logic to the extracted
+object, then it passes it to the GraphQL execution engine. Yoga mostly follows GraphQL-over-HTTP
+standards for this validation and parsing logic.
 [See the GraphQL-over-HTTP compliance test results of GraphQL Yoga](https://github.com/graphql/graphql-http/blob/main/implementations/graphql-yoga/README.md)
 
 The parsers are expected to return `GraphQLParams` object that contains the following properties:
@@ -165,8 +165,9 @@ const useMyParser: Plugin = () => {
 ## Request Validation
 
 Request validation is the process of validating the incoming request to ensure that it follows the
-GraphQL-over-HTTP spec. Besides the required validation rules, Yoga applies some extra rules to ensure the
-security and the performance of the server such as disallowing extra paramters in the request body. However, you can customize this kind of behaviors on your own risk.
+GraphQL-over-HTTP spec. Besides the required validation rules, Yoga applies some extra rules to
+ensure the security and the performance of the server such as disallowing extra paramters in the
+request body. However, you can customize this kind of behaviors on your own risk.
 
 ### Extra Parameters in `GraphQLParams`
 

--- a/website/src/pages/docs/features/request-customization.mdx
+++ b/website/src/pages/docs/features/request-customization.mdx
@@ -4,12 +4,11 @@ description: You can customize the request handling in GraphQL Yoga
 
 # Request Customization
 
-GraphQL Yoga uses specific request handling logic to handle incoming HTTP requests. For each type of
-request, Yoga uses a specific parser to parse the incoming request and extract the GraphQL operation
+For each type of request, GraphQL Yoga uses a specific parser to parse the incoming request and extract the GraphQL operation
 from it. Then it applies some validation logic to the extracted object, then it passes it to the
-GraphQL execution engine. Yoga follows GraphQL-over-HTTP standards for this validation and parsing
+GraphQL execution engine. Yoga mostly follows GraphQL-over-HTTP standards for this validation and parsing
 logic.
-[See the compliance test results of GraphQL Yoga](https://github.com/graphql/graphql-http/blob/main/implementations/graphql-yoga/README.md)
+[See the GraphQL-over-HTTP compliance test results of GraphQL Yoga](https://github.com/graphql/graphql-http/blob/main/implementations/graphql-yoga/README.md)
 
 The parsers are expected to return `GraphQLParams` object that contains the following properties:
 
@@ -166,8 +165,8 @@ const useMyParser: Plugin = () => {
 ## Request Validation
 
 Request validation is the process of validating the incoming request to ensure that it follows the
-GraphQL-over-HTTP spec. Besides the required validation rules, Yoga applies some rules to ensure the
-security and the performance of the server.
+GraphQL-over-HTTP spec. Besides the required validation rules, Yoga applies some extra rules to ensure the
+security and the performance of the server such as disallowing extra paramters in the request body. However, you can customize this kind of behaviors on your own risk.
 
 ### Extra Parameters in `GraphQLParams`
 

--- a/website/src/pages/docs/features/request-customization.mdx
+++ b/website/src/pages/docs/features/request-customization.mdx
@@ -1,0 +1,204 @@
+---
+description: You can customize the request handling in GraphQL Yoga
+---
+
+# Request Customization
+
+GraphQL Yoga uses specific request handling logic to handle incoming HTTP requests. For each type of
+request, Yoga uses a specific parser to parse the incoming request and extract the GraphQL operation
+from it. Then it applies some validation logic to the extracted object, then it passes it to the
+GraphQL execution engine. Yoga follows GraphQL-over-HTTP standards for this validation and parsing
+logic.
+[See the compliance test results of GraphQL Yoga](https://github.com/graphql/graphql-http/blob/main/implementations/graphql-yoga/README.md)
+
+The parsers are expected to return `GraphQLParams` object that contains the following properties:
+
+- `query`: The GraphQL operation as a string.
+- `variables`: The variables for the operation.
+- `operationName`: The name of the operation.
+- `extensions`: The extensions for the operation.
+
+It doesn't matter how the request is sent, Yoga engine expects the request to parsed in the form of
+a `GraphQLParams` object.
+
+## Request Parser
+
+Request parsers are responsible for extracting the GraphQL operation and the other relevant
+information from the incoming request. Each parser is responsible for a specific type of request
+based on the content type and the HTTP method.
+
+### GraphQL-over-HTTP Spec
+
+These parsers are implemented following the
+[GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/).
+
+#### `GET` Parser
+
+This request parser extracts the GraphQL operation from the query string by following
+GraphQL-over-HTTP spec.
+
+[See the implementation](https://github.com/dotansimha/graphql-yoga/blob/main/packages/graphql-yoga/src/plugins/request-parser/get.ts)
+[See the relevant part in GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/#sec-GET)
+
+##### Example Request
+
+```ts
+fetch('/graphql?query=query { __typename }')
+```
+
+#### `POST` JSON Parser
+
+This request parser extracts the GraphQL operation from the JSON body of the POST request by
+following GraphQL-over-HTTP spec.
+
+[See the implementation](https://github.com/dotansimha/graphql-yoga/blob/main/packages/graphql-yoga/src/plugins/request-parser/post-json.ts).
+
+##### Example Request
+
+```ts
+fetch('/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    query: 'query { __typename }'
+  })
+})
+```
+
+### GraphQL Multipart Request Spec
+
+The parser for multipart requests is implemented following the
+[GraphQL Multipart Request Spec](https://github.com/jaydenseric/graphql-multipart-request-spec).
+
+#### `POST` Multipart Parser
+
+This request parser extracts the GraphQL operation from the multipart request by following the
+GraphQL Multipart Request Spec. It handles the HTTP request by parsing it as `multipart/form-data`
+and extracting the GraphQL operation from it.
+
+[See the implementation](https://github.com/dotansimha/graphql-yoga/blob/main/packages/graphql-yoga/src/plugins/request-parser/post-multipart.ts).
+
+##### Example Request
+
+```ts
+const formData = new FormData()
+formData.append('operations', JSON.stringify({ query: 'query { __typename }' }))
+fetch('/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'multipart/form-data'
+  },
+  body: formData
+})
+```
+
+### Extra Parsers
+
+These parsers are not part of any spec but are de-facto standards in the GraphQL community.
+
+### `POST` GraphQL String Parser
+
+This request parser extracts the GraphQL operation from the body of the POST request as a string.
+
+[See the implementation](https://github.com/dotansimha/graphql-yoga/blob/main/packages/graphql-yoga/src/plugins/request-parser/post-graphql-string.ts).
+
+##### Example Request
+
+```ts
+fetch('/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/graphql'
+  },
+  body: 'query { __typename }'
+})
+```
+
+### `POST` FormUrlEncoded Parser
+
+This request parser extracts the GraphQL operation from the form data as url encoded in the POST
+body. The context is similar to the `GET` parser but the data is sent in the body of the request.
+
+[See the implementation](https://github.com/dotansimha/graphql-yoga/blob/main/packages/graphql-yoga/src/plugins/request-parser/post-form-url-encoded.ts)
+
+##### Example Request
+
+```ts
+fetch('/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  },
+  body: 'query=query { __typename }'
+})
+```
+
+### Write your own parser
+
+If you want to handle a specific type of request body that is not part of the list above, you can
+write your own parser. We use `onRequestParse` to hook into the request parsing process and add your
+own logic.
+
+Request parsers are functions that take the request object and return a promise that resolves to a
+`GraphQLParams` object.
+
+```ts
+import { GraphQLParams, Plugin } from 'graphql-yoga'
+
+const useMyParser: Plugin = () => {
+  return {
+    onRequestParse({ request, url, setRequestParser }) {
+      const contentType = request.headers.get('Content-Type')
+      if (contentType === 'application/my-content-type') {
+        setRequestParser(async function myParser() {
+          const body = await request.text()
+          const params: GraphQLParams = getParamsFromMyParser(body)
+          return params
+        })
+      }
+    }
+  }
+}
+```
+
+## Request Validation
+
+Request validation is the process of validating the incoming request to ensure that it follows the
+GraphQL-over-HTTP spec. Besides the required validation rules, Yoga applies some rules to ensure the
+security and the performance of the server.
+
+### Extra Parameters in `GraphQLParams`
+
+Yoga doesn't allow extra parameters in the request body other than `query`, `operationName`,
+`extensions`, and `variables`. And it returns a 400 HTTP error if it finds any extra parameters. But
+you can customize this behavior by passing an array of extra parameter names to the
+`extraParamNames` option.
+
+```ts
+import { createYoga } from 'graphql-yoga'
+
+const yoga = createYoga({
+  /* other options */
+  extraParamNames: ['extraParam1', 'extraParam2']
+})
+```
+
+Then you can send extra parameters in the request body.
+
+```ts
+const res = await yoga.fetch('/graphql', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    query: 'query { __typename }',
+    extraParam1: 'value1',
+    extraParam2: 'value2'
+  })
+})
+
+console.assert(res.status === 200)
+```


### PR DESCRIPTION
By default, Yoga does not allow extra parameters in the request body other than `query`, `operationName`, `extensions`, and `variables`, then throws 400 HTTP Error.
This change adds a new option called `extraParamNames` to allow extra parameters in the request body.

```ts
import { createYoga } from 'graphql-yoga';

const yoga = createYoga({
  /* other options */
  extraParamNames: ['extraParam1', 'extraParam2'],
});

const res = await yoga.fetch('/graphql', {
    method: 'POST',
    headers: {
        'Content-Type': 'application/json',
    },
    body: JSON.stringify({
        query: 'query { __typename }',
        extraParam1: 'value1',
        extraParam2: 'value2',
    }),
});

console.assert(res.status === 200);
```