### PR TITLE
Remove `@apollo/gateway` reference

### DIFF
--- a/website/src/pages/docs/features/apollo-federation.mdx
+++ b/website/src/pages/docs/features/apollo-federation.mdx
@@ -11,21 +11,6 @@ import { Callout } from '@theguild/components'
 [Apollo Federation](https://apollographql.com/docs/federation) is a specification that applies
 microservice architecture through GraphQL APIs.
 
-Thanks to [Envelop's Apollo Federation](https://envelop.dev/plugins/use-apollo-federation) plugin,
-we can use GraphQL Yoga to build our gateway server.
-
-<Callout>
-  As documented in the [Apollo Federation
-  docs](https://www.apollographql.com/docs/federation/gateway/#setup), `@apollo/gateway` package
-  doesn't support GraphQL v16 so you have to install `graphql@15`.
-</Callout>
-
-<Callout>
-  Please note that Apollo Federation implementation doesn't support GraphQL Subscriptions. If you
-  need to use Subscriptions with a Federated Gateway you can use [Schema
-  Stitching](https://graphql-tools.com/docs/schema-stitching/stitch-federation).
-</Callout>
-
 ## Gateway
 
 You can use GraphQL Yoga to implement a Gateway exposing an Apollo Federation supergraph. For this,


### PR DESCRIPTION
We don't use `@apollo/gateway` or the Envelop plugin anymore.