### PR TITLE
fix(persisted-operations): include  in context params

### DIFF
--- a/.changeset/chilly-poets-bathe.md
+++ b/.changeset/chilly-poets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-persisted-operations': patch
+---
+
+Include `operationName` in context params for persisted operations

--- a/packages/plugins/persisted-operations/src/index.ts
+++ b/packages/plugins/persisted-operations/src/index.ts
@@ -143,6 +143,7 @@ export function usePersistedOperations<
       if (typeof persistedQuery === 'object') {
         setParams({
           query: `__PERSISTED_OPERATION_${persistedOperationKey}__`,
+          operationName: params.operationName,
           variables: params.variables,
           extensions: params.extensions,
         });
@@ -150,6 +151,7 @@ export function usePersistedOperations<
       } else {
         setParams({
           query: persistedQuery,
+          operationName: params.operationName,
           variables: params.variables,
           extensions: params.extensions,
         });


### PR DESCRIPTION
According to the [GraphQL Yoga Context](https://the-guild.dev/graphql/yoga-server/docs/features/context#default-context), the default provided values in params includes `query`, `operationName`, `variables`, and `extensions`. When following the [the APQ Specification of Apollo](https://github.com/apollographql/apollo-link-persisted-queries#apollo-engine), the client sends `operationName` within the request, which would be helpful to keep in the context values if already exist. The current implementation strips the provided `operationName` value. I think it would be a good idea to add one, what do you think?