### PR TITLE
docs(typo): remove extra quotation

### DIFF
--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -109,7 +109,7 @@ useResponseCache({
   // You can use configuration object to define the scope
   scopePerSchemaCoordinate: {
     'Query.me': 'PRIVATE', // on a field
-    'User: 'PRIVATE', // or a type
+    User: 'PRIVATE', // or a type
   }
 })
 ```


### PR DESCRIPTION
https://the-guild.dev/graphql/yoga-server/docs/features/response-caching#enforce-session-based-caching

```diff
- 'User: 'PRIVATE' // Unterminated string literal.
+ User: 'PRIVATE'
```