### PR TITLE
Update AWS Lambda docs with streaming support

### DIFF
--- a/examples/aws-lambda/package.json
+++ b/examples/aws-lambda/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "2.68.0",
-    "@types/aws-lambda": "8.10.116",
+    "@types/aws-lambda": "8.10.140",
     "@types/node": "18.16.16",
     "aws-cdk": "2.83.0",
     "aws-cdk-lib": "2.83.0",

--- a/website/src/pages/docs/integrations/integration-with-aws-lambda.mdx
+++ b/website/src/pages/docs/integrations/integration-with-aws-lambda.mdx
@@ -41,17 +41,21 @@ const yoga = createYoga<{
   })
 })
 
-export async function handler(
+export const handler = awslambda.streamifyResponse(async function handler(
   event: APIGatewayEvent,
+  responseStream: Writable<Uint8Array>,
   lambdaContext: Context
 ): Promise<APIGatewayProxyResult> {
   const response = await yoga.fetch(
+    // Construct the URL
     event.path +
       '?' +
+      // Parse query string parameters
       new URLSearchParams((event.queryStringParameters as Record<string, string>) || {}).toString(),
     {
       method: event.httpMethod,
       headers: event.headers as HeadersInit,
+      // Parse the body
       body: event.body
         ? Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')
         : undefined
@@ -62,15 +66,22 @@ export async function handler(
     }
   )
 
-  const responseHeaders = Object.fromEntries(response.headers.entries())
-
-  return {
+  // Create the metadata object for the response
+  const metadata = {
     statusCode: response.status,
-    headers: responseHeaders,
-    body: await response.text(),
-    isBase64Encoded: false
+    headers: Object.fromEntries(response.headers.entries())
   }
-}
+
+  // Attach the metadata to the response stream
+  responseStream = awslambda.HttpResponseStream.from(responseStream, metadata)
+
+  if (response.body) {
+    // Pipe the response body to the response stream
+    response.body.pipe(responseStream)
+  } else {
+    responseStream.end()
+  }
+})
 ```
 
 > You can also check a full example on our GitHub repository


### PR DESCRIPTION
AWS Lambda can take a response stream as body, so we can pass Yoga's response stream to the lambda function to have a better control over Lambda's HTTP logic.