### PR TITLE
docs: update outdated url (page not found)

### DIFF
--- a/website/src/pages/docs/prepare-for-production.mdx
+++ b/website/src/pages/docs/prepare-for-production.mdx
@@ -51,7 +51,7 @@ use the following plugins.
 - [Max Directives](https://escape.tech/graphql-armor/docs/plugins/max-directives)
 
 You can read more about these plugins in the
-[GraphQL Armor documentation](https://escape.tech/graphql-armor/docs/plugins).
+[GraphQL Armor documentation](https://escape.tech/graphql-armor/docs/category/plugins).
 
 <Callout>
   Depending on the type/complexity of GraphQL operations that are executed you might need to adjust


### PR DESCRIPTION
https://the-guild.dev/graphql/yoga-server/docs/prepare-for-production#public-api

```diff
- https://escape.tech/graphql-armor/docs/plugins
+ https://escape.tech/graphql-armor/docs/category/plugins
```

The [outdated URL](https://escape.tech/graphql-armor/docs/plugins) for the GraphQL Armor plugin's category returns a 404 (page not found). [Updated URL &rarr;](https://escape.tech/graphql-armor/docs/category/plugins)