### PR TITLE
fix: multipart response specification compatibility

### DIFF
--- a/.changeset/light-pants-protect.md
+++ b/.changeset/light-pants-protect.md
@@ -2,6 +2,6 @@
 'graphql-yoga': patch
 ---
 
-Restores compatibility with [RFC1341: The Multipart Content-Type](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) by include preceding `\r\n` for initial boundary delimiter when using the multipart response protocol.
+Restores compatibility with [RFC1341: The Multipart Content-Type](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) by including preceding `\r\n` for initial boundary delimiter when using the multipart response protocol.
 
 This makes Yoga compatible with libraries that strictly follow the response protocol, such as [fetch-multipart-graphql](https://github.com/relay-tools/fetch-multipart-graphql).

--- a/.changeset/light-pants-protect.md
+++ b/.changeset/light-pants-protect.md
@@ -1,0 +1,7 @@
+---
+'graphql-yoga': patch
+---
+
+Restores compatibility with [RFC1341: The Multipart Content-Type](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) by include preceding `\r\n` for initial boundary delimiter when using the multipart response protocol.
+
+This makes Yoga compatible with libraries that strictly follow the response protocol, such as [fetch-multipart-graphql](https://github.com/relay-tools/fetch-multipart-graphql).

--- a/examples/defer-stream/__integration-tests__/__snapshots__/defer-stream.spec.ts.snap
+++ b/examples/defer-stream/__integration-tests__/__snapshots__/defer-stream.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Defer / Stream defer: defer 1`] = `
-"---
+"
+---
 Content-Type: application/json; charset=utf-8
 Content-Length: 50
 
@@ -16,7 +17,8 @@ Content-Length: 78
 `;
 
 exports[`Defer / Stream stream: stream 1`] = `
-"---
+"
+---
 Content-Type: application/json; charset=utf-8
 Content-Length: 39
 

--- a/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/multipart.ts
@@ -34,6 +34,7 @@ export function processMultipartResult(result: ResultProcessorInput, fetchAPI: F
           },
         };
       }
+      controller.enqueue(textEncoder.encode('\r\n'));
       controller.enqueue(textEncoder.encode(`---`));
     },
     async pull(controller) {

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -252,25 +252,23 @@ describe('fetch-multipart-graphql', () => {
             `,
           }),
           onNext(next) {
-            expect(next).toMatchInlineSnapshot(`
-[
-  {
-    "data": {},
-    "hasNext": true,
-  },
-  {
-    "hasNext": false,
-    "incremental": [
-      {
-        "data": {
-          "a": "a",
-        },
-        "path": [],
-      },
-    ],
-  },
-]
-`);
+            expect(next).toEqual([
+              {
+                data: {},
+                hasNext: true,
+              },
+              {
+                hasNext: false,
+                incremental: [
+                  {
+                    data: {
+                      a: 'a',
+                    },
+                    path: [],
+                  },
+                ],
+              },
+            ]);
           },
           onError(err) {
             reject(err);

--- a/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__integration-tests__/defer-stream.spec.ts
@@ -166,13 +166,14 @@ it('memory/cleanup leak by source that never publishes a value', async () => {
 
     const chunkStr = Buffer.from(next.value).toString('utf-8');
     expect(chunkStr).toMatchInlineSnapshot(`
-    "---
-    Content-Type: application/json; charset=utf-8
-    Content-Length: 33
+"
+---
+Content-Type: application/json; charset=utf-8
+Content-Length: 33
 
-    {"data":{"hi":[]},"hasNext":true}
-    ---"
-    `);
+{"data":{"hi":[]},"hasNext":true}
+---"
+`);
 
     await expect(iterator.next()).rejects.toMatchInlineSnapshot(`[Error: aborted]`);
 
@@ -247,9 +248,6 @@ describe('fetch-multipart-graphql', () => {
                 ... on Query @defer {
                   a
                 }
-                ... on Query @defer {
-                  b
-                }
               }
             `,
           }),
@@ -257,17 +255,15 @@ describe('fetch-multipart-graphql', () => {
             expect(next).toMatchInlineSnapshot(`
 [
   {
+    "data": {},
+    "hasNext": true,
+  },
+  {
     "hasNext": false,
     "incremental": [
       {
         "data": {
           "a": "a",
-        },
-        "path": [],
-      },
-      {
-        "data": {
-          "b": "b",
         },
         "path": [],
       },

--- a/packages/plugins/defer-stream/__tests__/defer-stream.spec.ts
+++ b/packages/plugins/defer-stream/__tests__/defer-stream.spec.ts
@@ -105,19 +105,20 @@ describe('Defer/Stream', () => {
     const finalText = await response.text();
 
     expect(finalText).toMatchInlineSnapshot(`
-      "---
-      Content-Type: application/json; charset=utf-8
-      Content-Length: 26
+"
+---
+Content-Type: application/json; charset=utf-8
+Content-Length: 26
 
-      {"data":{},"hasNext":true}
-      ---
-      Content-Type: application/json; charset=utf-8
-      Content-Length: 74
+{"data":{},"hasNext":true}
+---
+Content-Type: application/json; charset=utf-8
+Content-Length: 74
 
-      {"incremental":[{"data":{"goodbye":"goodbye"},"path":[]}],"hasNext":false}
-      -----
-      "
-    `);
+{"incremental":[{"data":{"goodbye":"goodbye"},"path":[]}],"hasNext":false}
+-----
+"
+`);
   });
 
   it('should execute on stream directive', async () => {
@@ -140,7 +141,8 @@ describe('Defer/Stream', () => {
     const finalText = await response.text();
 
     expect(finalText).toMatchInlineSnapshot(`
-"---
+"
+---
 Content-Type: application/json; charset=utf-8
 Content-Length: 44
 

--- a/packages/plugins/defer-stream/package.json
+++ b/packages/plugins/defer-stream/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@graphql-tools/executor-http": "^1.0.4",
     "@whatwg-node/fetch": "^0.9.17",
+    "fetch-multipart-graphql": "3.2.1",
     "graphql": "^16.6.0",
     "graphql-yoga": "workspace:*",
     "tslib": "^2.5.2"


### PR DESCRIPTION
Closes https://github.com/dotansimha/graphql-yoga/issues/3399

Restores compatibility with [RFC1341: The Multipart Content-Type](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) by include preceding `\r\n` for initial boundary delimiter when using the multipart response protocol.

This makes Yoga compatible with libraries that strictly follow the response protocol, such as [fetch-multipart-graphql](https://github.com/relay-tools/fetch-multipart-graphql).