### PR TITLE
docs: fix `integration-with-bun.mdx` TypeScript issue

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-bun.mdx
+++ b/website/src/pages/docs/integrations/integration-with-bun.mdx
@@ -40,7 +40,7 @@ const yoga = createYoga({
 })
 
 const server = Bun.serve({
-  fetch: yoga
+  fetch: (request) => yoga(request)
 })
 
 console.info(


### PR DESCRIPTION
Fix a TypeScript issue resulting from a breaking change in Bun or GraphQL Yoga. (Unforuntately, it seems somebody didn't play nice with SemVer conventions)

The error occurs with the following versions:
- bun@1.1.24
- graphql-yoga@5.7.0 

The error as well as discussions about solutions are detailed here:
- https://github.com/dotansimha/graphql-yoga/issues/3003#issuecomment-2255533003
- https://github.com/dotansimha/graphql-yoga/discussions/2644#discussioncomment-10273630
- https://github.com/dotansimha/graphql-yoga/discussions/2644#discussioncomment-10360551

This PR uses the discussed solution to fix the error.