### PR TITLE
Remove disingenuous comparison

### DIFF
--- a/website/src/pages/docs/comparison.mdx
+++ b/website/src/pages/docs/comparison.mdx
@@ -20,7 +20,6 @@ Federation - see benchmarks
 
 | Name                                                                           | Language | Server  | Latency avg | Requests |
 | ------------------------------------------------------------------------------ | -------- | ------- | ----------: | -------: |
-| [GraphQL Yoga with Response Cache](https://github.com/dotansimha/graphql-yoga) | Node.js  | http    |     46.54ms |   2.2kps |
 | [GraphQL Yoga with JIT](https://github.com/dotansimha/graphql-yoga)            | Node.js  | http    |    764.83ms |    120ps |
 | [GraphQL Yoga](https://github.com/dotansimha/graphql-yoga)                     | Node.js  | http    |    916.90ms |    100ps |
 | [Apollo Server](https://github.com/apollographql/apollo-server)                | Node.js  | Express |  1,234.12ms |     64ps |


### PR DESCRIPTION
See title, it's a bad look no matter how you turn it to have a comparison where one of the implementations uses a cache and the other libraries dont. 

The JIT is fine, but also there it'd be more fair to have a row for apollo-server with jit.

Additionally it'd be best if the implementations dont diverge at all also in the usage if the underlying server because at this point the comparison is completely useless.

But at least with this PR it's not disingenuous anymore and only negligent