### PR TITLE
fix: add `crossorigin` link attribute

### DIFF
--- a/packages/graphql-yoga/src/graphiql.html
+++ b/packages/graphql-yoga/src/graphiql.html
@@ -8,6 +8,7 @@
       href="https://raw.githubusercontent.com/dotansimha/graphql-yoga/main/website/public/favicon.ico"
     />
     <link
+      crossorigin
       rel="stylesheet"
       href="https://unpkg.com/@graphql-yoga/graphiql@__GRAPHIQL_VERSION__/dist/style.css"
     />


### PR DESCRIPTION
see documentation https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#avoiding_coep_blockage_with_cors

![image](https://github.com/user-attachments/assets/be43757f-ce77-45da-a3c2-866e751f3359)

