### PR TITLE
feat(apollo-usage-report): send Apollo clientName and clientVersion with trace

### DIFF
--- a/.changeset/changelog.md
+++ b/.changeset/changelog.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-apollo-usage-report": patch
+---
+
+- Send Apollo `clientName`, `clientVersion` and `agentVersion` (agent name) with trace.

--- a/.changeset/early-ghosts-pump.md
+++ b/.changeset/early-ghosts-pump.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': minor
+---
+
+Add `version` property to get version of Yoga

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "apollo"
   ],
   "scripts": {
-    "build": "pnpm --filter=@graphql-yoga/graphiql run build && pnpm --filter=@graphql-yoga/render-graphiql run build && pnpm --filter=graphql-yoga run generate-graphiql-html && bob build",
+    "build": "pnpm --filter=@graphql-yoga/graphiql run build && pnpm --filter=@graphql-yoga/render-graphiql run build && pnpm --filter=graphql-yoga run generate-graphiql-html&& pnpm --filter=graphql-yoga run inject-version && bob build",
     "build-website": "pnpm build && cd website && pnpm build",
     "changeset": "changeset",
     "check": "pnpm -r run check",

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "check": "tsc --pretty --noEmit",
     "generate-graphiql-html": "node scripts/generate-graphiql-html.js",
+    "inject-version": "node scripts/inject-version.js",
     "postinstall": "node node_modules/puppeteer/install.js",
     "prepack": "bob prepack"
   },
@@ -69,7 +70,9 @@
     "@jest/globals": "^29.2.1",
     "@n1ru4l/in-memory-live-query-store": "0.10.0",
     "@repeaterjs/repeater": "^3.0.4",
+    "@types/globby": "^9.1.0",
     "@types/node": "20.14.12",
+    "globby": "^14.0.2",
     "graphql": "^16.0.1",
     "graphql-http": "^1.18.0",
     "graphql-scalars": "1.22.2",

--- a/packages/graphql-yoga/scripts/inject-version.js
+++ b/packages/graphql-yoga/scripts/inject-version.js
@@ -1,0 +1,13 @@
+import { promises as fs } from 'node:fs';
+import { globby } from 'globby';
+import packageJson from '../package.json' with { type: 'json' };
+
+
+const files = await globby(['dist/**/*.js']);
+
+const yogaVersion = packageJson.version;
+
+for (const file of files) {
+    const content = await fs.readFile(file, 'utf-8');
+    await fs.writeFile(file, content.replace(/__YOGA_VERSION__/g, yogaVersion));
+}

--- a/packages/graphql-yoga/src/landing-page.html
+++ b/packages/graphql-yoga/src/landing-page.html
@@ -355,6 +355,7 @@
             </svg>
           </div>
           <h1>GraphQL Yoga</h1>
+          <p>Version: __YOGA_VERSION__</p>
         </div>
         <h2>The batteries-included cross-platform GraphQL Server.</h2>
         <div class="buttons">

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -218,6 +218,8 @@ export class YogaServer<
   private maskedErrorsOpts: YogaMaskedErrorOpts | null;
   private id: string;
 
+  version = '__YOGA_VERSION__';
+
   constructor(options?: YogaServerOptions<TServerContext, TUserContext>) {
     this.id = options?.id ?? 'yoga';
 

--- a/packages/plugins/apollo-usage-report/src/index.ts
+++ b/packages/plugins/apollo-usage-report/src/index.ts
@@ -1,6 +1,7 @@
 import { printSchema, stripIgnoredCharacters } from 'graphql';
 import {
   isAsyncIterable,
+  Maybe,
   Plugin,
   YogaInitialContext,
   YogaLogger,
@@ -39,6 +40,18 @@ type ApolloUsageReportOptions = ApolloInlineTracePluginOptions & {
    * Defaults to GraphOS endpoint (https://usage-reporting.api.apollographql.com/api/ingress/traces)
    */
   endpoint?: string;
+  /**
+   * Agent Version to report to the usage reporting API
+   */
+  agentVersion?: string;
+  /**
+   * Client name to report to the usage reporting API
+   */
+  clientName?: StringFromRequestFn | string;
+  /**
+   * Client version to report to the usage reporting API
+   */
+  clientVersion?: StringFromRequestFn | string;
 };
 
 export interface ApolloUsageReportRequestContext extends ApolloInlineRequestTraceContext {
@@ -57,6 +70,8 @@ function getEnvVar<T>(name: string, defaultValue?: T) {
 const DEFAULT_REPORTING_ENDPOINT =
   'https://usage-reporting.api.apollographql.com/api/ingress/traces';
 
+type StringFromRequestFn = (req: Request) => Maybe<string>;
+
 export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Plugin {
   const [instrumentation, ctxForReq] = useApolloInstrumentation(options) as [
     Plugin,
@@ -67,11 +82,36 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
   let fetchAPI: FetchAPI;
   let schemaId: string;
 
+  let yogaVersion: string;
+  let agentVersion = '0.0.0';
+
+  let clientNameFactory: StringFromRequestFn = req =>
+    req.headers.get('apollographql-client-name') || 'graphql-yoga';
+
+  if (typeof options.clientName === 'string') {
+    const clientName = options.clientName;
+    clientNameFactory = () => clientName;
+  } else if (typeof options.clientName === 'function') {
+    clientNameFactory = options.clientName;
+  }
+
+  let clientVersionFactory: StringFromRequestFn = req =>
+    req.headers.get('apollographql-client-version') || yogaVersion;
+
+  if (typeof options.clientVersion === 'string') {
+    const clientVersion = options.clientVersion;
+    clientVersionFactory = () => clientVersion;
+  } else if (typeof options.clientVersion === 'function') {
+    clientVersionFactory = options.clientVersion;
+  }
+
   return {
     onPluginInit({ addPlugin }) {
       addPlugin(instrumentation);
       addPlugin({
         onYogaInit(args) {
+          yogaVersion = args.yoga.version;
+          agentVersion = options.agentVersion || `graphql-yoga@${yogaVersion}`;
           fetchAPI = args.yoga.fetchAPI;
           logger = Object.fromEntries(
             (['error', 'warn', 'info', 'debug'] as const).map(level => [
@@ -134,15 +174,21 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
           // Each operation in a batched request can belongs to a different schema.
           // Apollo doesn't allow to send batch queries for multiple schemas in the same batch
           const tracesPerSchema: Record<string, Report['tracesPerQuery']> = {};
-          const { clientName, clientVersion } = getClientInfo(request);
 
           for (const trace of reqCtx.traces.values()) {
             if (!trace.schemaId || !trace.operationKey) {
               throw new TypeError('Misformed trace, missing operation key or schema id');
             }
 
-            trace.trace.clientName = clientName;
-            trace.trace.clientVersion = clientVersion;
+            const clientName = clientNameFactory(request);
+            if (clientName) {
+              trace.trace.clientName = clientName;
+            }
+
+            const clientVersion = clientVersionFactory(request);
+            if (clientVersion) {
+              trace.trace.clientVersion = clientVersion;
+            }
 
             tracesPerSchema[trace.schemaId] ||= {};
             tracesPerSchema[trace.schemaId][trace.operationKey] ||= { trace: [] };
@@ -151,7 +197,9 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
 
           for (const schemaId in tracesPerSchema) {
             const tracesPerQuery = tracesPerSchema[schemaId];
-            serverContext.waitUntil(sendTrace(options, logger, fetchAPI, schemaId, tracesPerQuery));
+            serverContext.waitUntil(
+              sendTrace(options, logger, fetchAPI.fetch, schemaId, tracesPerQuery, agentVersion),
+            );
           }
         },
       });
@@ -180,9 +228,10 @@ export async function hashSHA256(
 async function sendTrace(
   options: ApolloUsageReportOptions,
   logger: YogaLogger,
-  { fetch }: FetchAPI,
+  fetch: FetchAPI['fetch'],
   schemaId: string,
   tracesPerQuery: Report['tracesPerQuery'],
+  agentVersion: string,
 ) {
   const {
     graphRef = getEnvVar('APOLLO_GRAPH_REF'),
@@ -193,7 +242,7 @@ async function sendTrace(
   try {
     const body = Report.encode({
       header: {
-        agentVersion: 'graphql-yoga',
+        agentVersion,
         graphRef,
         executableSchemaId: schemaId,
       },
@@ -211,22 +260,13 @@ async function sendTrace(
       },
       body,
     });
+    const responseText = await response.text();
     if (response.ok) {
-      logger.debug('Traces sent:', await response.text());
+      logger.debug('Traces sent:', responseText);
     } else {
-      logger.error('Failed to send trace:', await response.text());
+      logger.error('Failed to send trace:', responseText);
     }
   } catch (err) {
     logger.error('Failed to send trace:', err);
   }
-}
-
-function getClientInfo(request: Request): {
-  clientName: string;
-  clientVersion: string;
-} {
-  return {
-    clientName: request.headers.get('apollographql-client-name') ?? '',
-    clientVersion: request.headers.get('apollographql-client-version') ?? '',
-  };
 }


### PR DESCRIPTION
## Description
Client name and version is missing now in Apollo Studio for traces which are sent by this plugin and is not possible to filter metrics by that.