### PR TITLE
fix: update ioredis import

### DIFF
--- a/examples/redis-pub-sub/src/main.ts
+++ b/examples/redis-pub-sub/src/main.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http';
 import { createPubSub, createSchema, createYoga } from 'graphql-yoga';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { createRedisEventTarget } from '@graphql-yoga/redis-event-target';
 
 const publishClient = new Redis();

--- a/website/src/pages/docs/features/response-caching.mdx
+++ b/website/src/pages/docs/features/response-caching.mdx
@@ -286,7 +286,7 @@ npm i @envelop/response-cache-redis
 ```ts filename="Create a custom Redis Cache"
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
 import { createRedisCache } from '@envelop/response-cache-redis'
-import Redis from 'ioredis'
+import { Redis } from 'ioredis'
 
 const redis = new Redis({
   host: 'my-redis-db.example.com',


### PR DESCRIPTION
This PR:

- Fixes the incorrect `Redis` import from `ioredis` npm library in examples. See [here](https://github.com/redis/ioredis?tab=readme-ov-file#basic-usage) for the correct usage from the ioredis docs