### PR TITLE
apollo-inline-trace - tracing should not fail if non-nullable field throw an error

### DIFF
--- a/.changeset/changelog1.md
+++ b/.changeset/changelog1.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-apollo-usage-report": patch
+---
+
+- fixed: get specific or the nearest possible trace node if something fails at `non-nullable` GraphQL query field

--- a/.changeset/changelog2.md
+++ b/.changeset/changelog2.md
@@ -1,0 +1,6 @@
+---
+"@graphql-yoga/plugin-apollo-inline-trace": patch
+---
+
+- updated: `@envelop/on-resolve@^4.1.1` dependency
+- fixed: package `@envelop/core@^5.0.2` was added to devDependencies and `@envelop/on-resolve` was removed

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     },
     "overrides": {
       "graphql": "16.8.1",
-      "@envelop/core": "5.0.1",
+      "@envelop/core": "5.0.2",
       "@changesets/assemble-release-plan": "5.2.1",
       "@types/react": "18.2.55"
     }

--- a/packages/plugins/apollo-inline-trace/__tests__/apollo-inline-trace.yoga-gateway.spec.ts
+++ b/packages/plugins/apollo-inline-trace/__tests__/apollo-inline-trace.yoga-gateway.spec.ts
@@ -1,0 +1,310 @@
+import { FormattedExecutionResult, GraphQLFormattedError, versionInfo } from 'graphql';
+import { createYoga, YogaServerInstance } from 'graphql-yoga';
+import { Trace } from '@apollo/usage-reporting-protobuf';
+import { useApolloInlineTrace } from '@graphql-yoga/plugin-apollo-inline-trace';
+import { getStitchedSchemaFromLocalSchemas } from './fixtures/getStitchedSchemaFromLocalSchemas';
+import { getSubgraph1Schema } from './fixtures/subgraph1';
+import { getSubgraph2Schema } from './fixtures/subgraph2';
+
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip);
+
+describeIf(versionInfo.major >= 16)('Inline Trace - Yoga gateway', () => {
+  let yoga: YogaServerInstance<Record<string, unknown>, Record<string, unknown>>;
+
+  beforeAll(async () => {
+    const gatewaySchema = await getStitchedSchemaFromLocalSchemas({
+      subgraph1: await getSubgraph1Schema(),
+      subgraph2: await getSubgraph2Schema(),
+    });
+
+    yoga = createYoga({
+      schema: gatewaySchema,
+      plugins: [useApolloInlineTrace()],
+      maskedErrors: false,
+    });
+  });
+
+  function expectTrace(trace: Trace) {
+    const expectedTrace: Partial<Trace> = {
+      root: {
+        child: expect.any(Array),
+      },
+      startTime: {
+        seconds: expect.any(Number),
+        nanos: expect.any(Number),
+      },
+      endTime: {
+        seconds: expect.any(Number),
+        nanos: expect.any(Number),
+      },
+      durationNs: expect.any(Number),
+      fieldExecutionWeight: expect.any(Number),
+    };
+
+    expect(trace).toMatchObject(expectedTrace);
+    // its ok to be "equal" since executions can happen in the same tick
+    expect(trace.startTime!.seconds).toBeLessThanOrEqual(trace.endTime!.seconds!);
+    if (trace.startTime!.seconds === trace.endTime!.seconds) {
+      expect(trace.startTime!.nanos).toBeLessThanOrEqual(trace.endTime!.nanos!);
+    }
+  }
+
+  function expectTraceNode(
+    node: Trace.INode,
+    responseName: string,
+    type: string,
+    parentType: string,
+  ) {
+    const expectedTraceNode: Partial<Trace.INode> = {
+      responseName,
+      type,
+      parentType,
+      startTime: expect.any(Number),
+      endTime: expect.any(Number),
+    };
+
+    expect(node).toMatchObject(expectedTraceNode);
+    // its ok to be "equal" since executions can happen in the same tick
+    expect(node.startTime).toBeLessThanOrEqual(node.endTime!);
+  }
+
+  it('nullableFail - multi federated query - should return result with expected data and errors', async () => {
+    const query = /* GraphQL */ `
+      query {
+        testNestedField {
+          nullableFail {
+            id
+            email
+            sub1
+          }
+          subgraph2 {
+            id
+            email
+            sub2
+          }
+        }
+      }
+    `;
+
+    const expectedData = {
+      testNestedField: {
+        nullableFail: null,
+        subgraph2: {
+          email: 'user2@example.com',
+          id: 'user2',
+          sub2: true,
+        },
+      },
+    };
+
+    const expectedErrors: GraphQLFormattedError[] = [
+      {
+        message: 'My original subgraph error!',
+        path: ['testNestedField', 'nullableFail'],
+      },
+    ];
+
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+      headers: {
+        'content-type': 'application/json',
+        'apollo-federation-include-trace': 'ftv1',
+      },
+    });
+
+    const result: FormattedExecutionResult = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.errors).toMatchObject(expectedErrors);
+    expect(result.data).toMatchObject(expectedData);
+    expect(result.extensions?.ftv1).toEqual(expect.any(String));
+
+    const ftv1 = result.extensions?.ftv1 as string;
+    const trace = Trace.decode(Buffer.from(ftv1, 'base64'));
+
+    expectTrace(trace);
+
+    const nullableFail = trace.root?.child?.[0].child?.[0] as Trace.INode;
+
+    expectTraceNode(nullableFail, 'nullableFail', 'TestUser1', 'TestNestedField');
+
+    expect(nullableFail.error).toHaveLength(1);
+    expect(JSON.parse(nullableFail.error![0].json!)).toMatchObject(expectedErrors[0]);
+  });
+
+  it('nullableFail - simple federated query - should return result with expected data and errors', async () => {
+    const query = /* GraphQL */ `
+      query {
+        testNestedField {
+          nullableFail {
+            id
+            email
+            sub1
+          }
+        }
+      }
+    `;
+
+    const expectedData = {
+      testNestedField: {
+        nullableFail: null,
+      },
+    };
+
+    const expectedErrors: GraphQLFormattedError[] = [
+      {
+        message: 'My original subgraph error!',
+        path: ['testNestedField', 'nullableFail'],
+      },
+    ];
+
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+      headers: {
+        'content-type': 'application/json',
+        'apollo-federation-include-trace': 'ftv1',
+      },
+    });
+
+    const result: FormattedExecutionResult = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.errors).toMatchObject(expectedErrors);
+    expect(result.data).toMatchObject(expectedData);
+    expect(result.extensions?.ftv1).toEqual(expect.any(String));
+
+    const ftv1 = result.extensions?.ftv1 as string;
+    const trace = Trace.decode(Buffer.from(ftv1, 'base64'));
+
+    expectTrace(trace);
+
+    const nullableFail = trace.root?.child?.[0].child?.[0] as Trace.INode;
+
+    expectTraceNode(nullableFail, 'nullableFail', 'TestUser1', 'TestNestedField');
+
+    expect(nullableFail.error).toHaveLength(1);
+    expect(JSON.parse(nullableFail.error![0].json!)).toMatchObject(expectedErrors[0]);
+  });
+
+  it('nonNullableFail - multi federated query - should return result with expected data and errors', async () => {
+    const query = /* GraphQL */ `
+      query {
+        testNestedField {
+          nonNullableFail {
+            id
+            email
+            sub1
+          }
+          subgraph2 {
+            id
+            email
+            sub2
+          }
+        }
+      }
+    `;
+
+    /**
+     * The whole query result is { testNestedField: null } even if subgraph2 query not fail, but it should be ok according GraphQL documentation.
+     * "If the field which experienced an error was declared as Non-Null, the null result will bubble up to the next nullable field."
+     * https://spec.graphql.org/draft/#sel-GAPHRPTCAACEzBg6S
+     */
+    const expectedData = {
+      testNestedField: null,
+    };
+
+    const expectedErrors: GraphQLFormattedError[] = [
+      {
+        message: 'Cannot return null for non-nullable field TestNestedField.nonNullableFail.',
+        path: ['testNestedField', 'nonNullableFail'],
+      },
+    ];
+
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+      headers: {
+        'content-type': 'application/json',
+        'apollo-federation-include-trace': 'ftv1',
+      },
+    });
+
+    const result: FormattedExecutionResult = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.errors).toMatchObject(expectedErrors);
+    expect(result.data).toMatchObject(expectedData);
+    expect(result.extensions?.ftv1).toEqual(expect.any(String));
+
+    const ftv1 = result.extensions?.ftv1 as string;
+    const trace = Trace.decode(Buffer.from(ftv1, 'base64'));
+
+    expectTrace(trace);
+
+    const nonNullableFail = trace.root?.child?.[0].child?.[0] as Trace.INode;
+
+    expectTraceNode(nonNullableFail, 'nonNullableFail', 'TestUser1!', 'TestNestedField');
+
+    expect(nonNullableFail.error).toHaveLength(1);
+    expect(JSON.parse(nonNullableFail.error![0].json!)).toMatchObject(expectedErrors[0]);
+  });
+
+  it('nonNullableFail - simple federated query - should return result with expected data and errors', async () => {
+    const query = /* GraphQL */ `
+      query {
+        testNestedField {
+          nonNullableFail {
+            id
+            email
+            sub1
+          }
+        }
+      }
+    `;
+
+    const expectedData = {
+      testNestedField: null,
+    };
+
+    const expectedErrors: GraphQLFormattedError[] = [
+      {
+        message: 'My original subgraph error!',
+        path: ['testNestedField', 'nonNullableFail'],
+      },
+    ];
+
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+      headers: {
+        'content-type': 'application/json',
+        'apollo-federation-include-trace': 'ftv1',
+      },
+    });
+
+    const result: FormattedExecutionResult = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.errors).toMatchObject(expectedErrors);
+    expect(result.data).toMatchObject(expectedData);
+    expect(result.extensions?.ftv1).toEqual(expect.any(String));
+
+    const ftv1 = result.extensions?.ftv1 as string;
+    const trace = Trace.decode(Buffer.from(ftv1, 'base64'));
+
+    expectTrace(trace);
+
+    /**
+     * NOTE: nonNullableFail field is missing here in case of "simple federated query" where only one subgraph is called
+     * therefore the error is assigned to the nearest possible trace node which is testNestedField in this case.
+     */
+    const testNestedField = trace.root?.child?.[0] as Trace.INode;
+
+    expectTraceNode(testNestedField, 'testNestedField', 'TestNestedField', 'Query');
+
+    expect(testNestedField.error).toHaveLength(1);
+    expect(JSON.parse(testNestedField.error![0].json!)).toMatchObject(expectedErrors[0]);
+  });
+});

--- a/packages/plugins/apollo-inline-trace/__tests__/fixtures/getStitchedSchemaFromLocalSchemas.ts
+++ b/packages/plugins/apollo-inline-trace/__tests__/fixtures/getStitchedSchemaFromLocalSchemas.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { GraphQLSchema } from 'graphql';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { getStitchedSchemaFromSupergraphSdl } from '@graphql-tools/federation';
+
+export async function getStitchedSchemaFromLocalSchemas(
+  localSchemas: Record<string, GraphQLSchema>,
+): Promise<GraphQLSchema> {
+  // dynamic import is used only due to incompatibility with graphql@15
+  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import('@apollo/gateway');
+  const introspectAndCompose = await new IntrospectAndCompose({
+    subgraphs: Object.keys(localSchemas).map(name => ({ name, url: `http://localhost/${name}` })),
+  }).initialize({
+    healthCheck: async () => Promise.resolve(),
+    update: () => undefined,
+    getDataSource: ({ name }) => {
+      const [_name, schema] = Object.entries(localSchemas).find(([key]) => key === name) ?? [];
+      if (schema) {
+        return new LocalGraphQLDataSource(schema);
+      }
+      throw new Error(`Unknown subgraph ${name}`);
+    },
+  });
+
+  return getStitchedSchemaFromSupergraphSdl({
+    supergraphSdl: introspectAndCompose.supergraphSdl,
+    onSubschemaConfig: cofig => {
+      const [_name, schema] =
+        Object.entries(localSchemas).find(([key]) => key === cofig.name.toLowerCase()) ?? [];
+      if (schema) {
+        cofig.executor = createDefaultExecutor(schema);
+      } else {
+        throw new Error(`Unknown subgraph ${cofig.name}`);
+      }
+    },
+  });
+}

--- a/packages/plugins/apollo-inline-trace/__tests__/fixtures/subgraph1.ts
+++ b/packages/plugins/apollo-inline-trace/__tests__/fixtures/subgraph1.ts
@@ -1,0 +1,53 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { GraphQLSchema, parse } from 'graphql';
+import { createGraphQLError } from 'graphql-yoga';
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField
+  }
+
+  type TestNestedField {
+    subgraph1: TestUser1
+    nonNullableFail: TestUser1!
+    nullableFail: TestUser1
+  }
+
+  type TestUser1 {
+    id: String!
+    email: String!
+    sub1: Boolean!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph1: () => ({
+        id: 'user1',
+        email: 'user1@example.com',
+        sub1: true,
+      }),
+      nonNullableFail: () => {
+        throw createGraphQLError('My original subgraph error!', {
+          extensions: {
+            code: 'BAD_REQUEST',
+          },
+        });
+      },
+      nullableFail: () => {
+        throw createGraphQLError('My original subgraph error!', {
+          extensions: {
+            code: 'BAD_REQUEST',
+          },
+        });
+      },
+    }),
+  },
+};
+
+export async function getSubgraph1Schema(): Promise<GraphQLSchema> {
+  // dynamic import is used only due to incompatibility with graphql@15
+  const { buildSubgraphSchema } = await import('@apollo/subgraph');
+  return buildSubgraphSchema({ typeDefs, resolvers });
+}

--- a/packages/plugins/apollo-inline-trace/__tests__/fixtures/subgraph2.ts
+++ b/packages/plugins/apollo-inline-trace/__tests__/fixtures/subgraph2.ts
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { GraphQLSchema, parse } from 'graphql';
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField
+  }
+
+  type TestNestedField {
+    subgraph2: TestUser2
+  }
+
+  type TestUser2 {
+    id: String!
+    email: String!
+    sub2: Boolean!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph2: () => ({
+        id: 'user2',
+        email: 'user2@example.com',
+        sub2: true,
+      }),
+    }),
+  },
+};
+
+export async function getSubgraph2Schema(): Promise<GraphQLSchema> {
+  // dynamic import is used only due to incompatibility with graphql@15
+  const { buildSubgraphSchema } = await import('@apollo/subgraph');
+  return buildSubgraphSchema({ typeDefs, resolvers });
+}

--- a/packages/plugins/apollo-inline-trace/package.json
+++ b/packages/plugins/apollo-inline-trace/package.json
@@ -44,13 +44,13 @@
   },
   "dependencies": {
     "@apollo/usage-reporting-protobuf": "^4.1.1",
-    "@envelop/on-resolve": "^4.0.0",
+    "@envelop/on-resolve": "^4.1.1",
     "tslib": "^2.5.2"
   },
   "devDependencies": {
     "@apollo/gateway": "^2.9.3",
     "@apollo/subgraph": "^2.9.3",
-    "@envelop/on-resolve": "^4.0.0",
+    "@envelop/core": "^5.0.2",
     "@graphql-tools/delegate": "^10.1.1",
     "@graphql-tools/federation": "^2.2.24",
     "@whatwg-node/fetch": "^0.9.22",

--- a/packages/plugins/apollo-inline-trace/package.json
+++ b/packages/plugins/apollo-inline-trace/package.json
@@ -48,7 +48,11 @@
     "tslib": "^2.5.2"
   },
   "devDependencies": {
+    "@apollo/gateway": "^2.9.3",
+    "@apollo/subgraph": "^2.9.3",
     "@envelop/on-resolve": "^4.0.0",
+    "@graphql-tools/delegate": "^10.1.1",
+    "@graphql-tools/federation": "^2.2.24",
     "@whatwg-node/fetch": "^0.9.22",
     "graphql": "^16.6.0",
     "graphql-yoga": "workspace:*"

--- a/packages/plugins/apollo-inline-trace/src/index.ts
+++ b/packages/plugins/apollo-inline-trace/src/index.ts
@@ -357,7 +357,7 @@ function handleErrors(
     let node = ctx.rootNode;
 
     if (Array.isArray(errToReport.path)) {
-      const specificNode = ctx.nodes.get(errToReport.path.join('.'));
+      const specificNode = getSpecificOrNearestNode(ctx.nodes, errToReport.path);
       if (specificNode) {
         node = specificNode;
       } else {
@@ -375,4 +375,24 @@ function handleErrors(
       }),
     );
   }
+}
+
+/**
+ * If something fails at "non-nullable" GraphQL field in case of federated query, the error path might not be in trace nodes
+ * but the error should be assigned to the nearest possible trace node.
+ */
+function getSpecificOrNearestNode(
+  nodes: Map<string, Trace.Node>,
+  path: (string | number)[],
+): Trace.Node | undefined {
+  // iterates through "path" backwards
+  for (let i = path.length; i > 0; i--) {
+    const pathString = path.slice(0, i).join('.');
+    const node = nodes.get(pathString);
+    if (node) {
+      return node;
+    }
+  }
+
+  return;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   graphql: 16.8.1
-  '@envelop/core': 5.0.1
+  '@envelop/core': 5.0.2
   '@changesets/assemble-release-plan': 5.2.1
   '@types/react': 18.2.55
 
@@ -132,7 +132,7 @@ importers:
     dependencies:
       '@envelop/graphql-jit':
         specifier: 8.0.0
-        version: 8.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 8.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@faker-js/faker':
         specifier: 8.0.2
         version: 8.0.2
@@ -237,7 +237,7 @@ importers:
         version: 2.4.7(encoding@0.1.13)(graphql@16.8.1)
       '@envelop/apollo-federation':
         specifier: 5.0.0
-        version: 5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.1)(encoding@0.1.13)(graphql@16.8.1)
+        version: 5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.2)(encoding@0.1.13)(graphql@16.8.1)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -524,7 +524,7 @@ importers:
     dependencies:
       '@envelop/graphql-modules':
         specifier: 6.0.0
-        version: 6.0.0(@envelop/core@5.0.1)(graphql-modules@2.1.2(graphql@16.8.1))(graphql@16.8.1)
+        version: 6.0.0(@envelop/core@5.0.2)(graphql-modules@2.1.2(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-tools/load-files':
         specifier: 7.0.0
         version: 7.0.0(graphql@16.8.1)
@@ -627,7 +627,7 @@ importers:
     dependencies:
       '@envelop/generic-auth':
         specifier: 7.0.0
-        version: 7.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 7.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -658,7 +658,7 @@ importers:
     dependencies:
       '@escape.tech/graphql-armor':
         specifier: 3.0.0
-        version: 3.0.0(@envelop/core@5.0.1)(@escape.tech/graphql-armor-types@0.6.0)
+        version: 3.0.0(@envelop/core@5.0.2)(@escape.tech/graphql-armor-types@0.6.0)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -848,7 +848,7 @@ importers:
     dependencies:
       '@envelop/live-query':
         specifier: 7.0.0
-        version: 7.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 7.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@graphql-tools/utils':
         specifier: 10.0.1
         version: 10.0.1(graphql@16.8.1)
@@ -1341,7 +1341,7 @@ importers:
     dependencies:
       '@envelop/graphql-jit':
         specifier: 8.0.0
-        version: 8.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 8.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@graphql-yoga/render-graphiql':
         specifier: workspace:*
         version: link:../../packages/render-graphiql/dist
@@ -1569,8 +1569,8 @@ importers:
   packages/graphql-yoga:
     dependencies:
       '@envelop/core':
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: 5.0.2
+        version: 5.0.2
       '@graphql-tools/executor':
         specifier: ^1.3.0
         version: 1.3.1(graphql@16.8.1)
@@ -1604,13 +1604,13 @@ importers:
     devDependencies:
       '@envelop/disable-introspection':
         specifier: 6.0.0
-        version: 6.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 6.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@envelop/graphql-jit':
         specifier: 8.0.0
-        version: 8.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 8.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@envelop/live-query':
         specifier: 7.0.0
-        version: 7.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 7.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@graphql-yoga/render-graphiql':
         specifier: workspace:*
         version: link:../render-graphiql/dist
@@ -1747,10 +1747,10 @@ importers:
         version: 2.8.4(graphql@16.8.1)
       '@envelop/apollo-federation':
         specifier: ^5.0.0
-        version: 5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.1)(encoding@0.1.13)(graphql@16.8.1)
+        version: 5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.2)(encoding@0.1.13)(graphql@16.8.1)
       '@envelop/core':
-        specifier: 5.0.1
-        version: 5.0.1
+        specifier: 5.0.2
+        version: 5.0.2
       '@graphql-yoga/nestjs':
         specifier: workspace:*
         version: link:../nestjs
@@ -1780,8 +1780,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       '@envelop/on-resolve':
-        specifier: ^4.0.0
-        version: 4.1.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        specifier: ^4.1.1
+        version: 4.1.1(@envelop/core@5.0.2)(graphql@16.8.1)
       '@graphql-tools/utils':
         specifier: ^10.0.0
         version: 10.5.4(graphql@16.8.1)
@@ -1795,6 +1795,9 @@ importers:
       '@apollo/subgraph':
         specifier: ^2.9.3
         version: 2.9.3(graphql@16.8.1)
+      '@envelop/core':
+        specifier: 5.0.2
+        version: 5.0.2
       '@graphql-tools/delegate':
         specifier: ^10.1.1
         version: 10.1.1(graphql@16.8.1)
@@ -1852,7 +1855,7 @@ importers:
     devDependencies:
       '@envelop/on-resolve':
         specifier: ^4.0.0
-        version: 4.1.0(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 4.1.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@whatwg-node/fetch':
         specifier: ^0.9.22
         version: 0.9.22
@@ -1991,7 +1994,7 @@ importers:
     dependencies:
       '@envelop/prometheus':
         specifier: 11.0.0
-        version: 11.0.0(@envelop/core@5.0.1)(graphql@16.8.1)(prom-client@15.1.3)
+        version: 11.0.0(@envelop/core@5.0.2)(graphql@16.8.1)(prom-client@15.1.3)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -2008,7 +2011,7 @@ importers:
     dependencies:
       '@envelop/response-cache':
         specifier: ^6.1.2
-        version: 6.2.1(@envelop/core@5.0.1)(graphql@16.8.1)
+        version: 6.2.1(@envelop/core@5.0.2)(graphql@16.8.1)
     devDependencies:
       graphql:
         specifier: 16.8.1
@@ -3690,46 +3693,46 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@apollo/gateway': ^0.54.0
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
-  '@envelop/core@5.0.1':
-    resolution: {integrity: sha512-wxA8EyE1fPnlbP0nC/SFI7uU8wSNf4YjxZhAPu0P63QbgIvqHtHsH4L3/u+rsTruzhk3OvNRgQyLsMfaR9uzAQ==}
+  '@envelop/core@5.0.2':
+    resolution: {integrity: sha512-tVL6OrMe6UjqLosiE+EH9uxh2TQC0469GwF4tE014ugRaDDKKVWwFwZe0TBMlcyHKh5MD4ZxktWo/1hqUxIuhw==}
     engines: {node: '>=18.0.0'}
 
   '@envelop/disable-introspection@6.0.0':
     resolution: {integrity: sha512-+DxCvKdzsHat/aWr6dqDsebbGk6ZGiM7VZlnpwKS8g4+PDHg7AfMBnDP8CtUODgifU+kgZME4TFzU288MNpNDg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/extended-validation@4.0.0':
     resolution: {integrity: sha512-pvJ/OL+C+lpNiiCXezHT+vP3PTq37MQicoOB1l5MdgOOZZWRAp0NDOgvEKcXUY7AWNpvNHgSE0QFSRfGwsfwFQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/generic-auth@7.0.0':
     resolution: {integrity: sha512-FxGzoSjIXJlv+aiVyhQ8oHoz41ol4gJe8KAzNX7FP3qrhldbrqcC5Q+J/VtNlo5jXYX0YuLHH6ehF80tQDZJ4Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/graphql-jit@8.0.0':
     resolution: {integrity: sha512-+Sfp5DON/krxr4fP1kT6GQeQYqphP2g69CybqAMLRTALCCKs/ZfATvK/Bx+ysPV5K8g/tRwVuDbub1JAuLDxSw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/graphql-modules@6.0.0':
     resolution: {integrity: sha512-U6LoSMFd/eVt/vcI+6cj3OWciPnCTCIz+7Frc+oJ3Bg2utDIba3ngepzQPYb9t2da+AjCw+O2NmBwoUHWH0mAQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
       graphql-modules: ^1 || ^2.0.0
 
@@ -3737,21 +3740,28 @@ packages:
     resolution: {integrity: sha512-rLnSN1B+5zcy3FsWE+16/CMiqjD/LXXcRUXJ0RaXRjzHClpQxgSzrAixNeOmx1vXLff4AgkjOZANJl39rD4dwQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/on-resolve@4.1.0':
     resolution: {integrity: sha512-2AXxf8jbBIepBUiY0KQtyCO6gnT7LKBEYdaARZBJ7ujy1+iQHQPORKvAwl51kIdD6v5x38eldZnm7A19jFimOg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
+      graphql: 16.8.1
+
+  '@envelop/on-resolve@4.1.1':
+    resolution: {integrity: sha512-Zkc+OJMpmxStcx7DlCf/IqnKhCag8LJCfE0rzjnECdSQMBfdTY/9V5CtwdCM8kOAZAC0B4o9tVMwc/I8PfthqQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/prometheus@11.0.0':
     resolution: {integrity: sha512-gNnq3kxyIGlMzc9Ze4Vc23UC/08PiXLlAOkPwzDqCW+gz5IM7D/9CJLp8Vn7SyRHTWmAgog5lHYLJlB00EMJ0A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
       prom-client: ^15.0.0
 
@@ -3759,7 +3769,7 @@ packages:
     resolution: {integrity: sha512-sk+O5ieDoUjMGYAJkbi49MReH6wfDG7Avx39O2dY8/tgbbAfp/k7gju6Vcz7jVKaqqGn8ikd8eLVRpHULZCBpQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
   '@envelop/types@5.0.0':
@@ -4756,7 +4766,7 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@apollo/server': ^4.0.0
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
     peerDependenciesMeta:
       '@apollo/server':
@@ -19678,10 +19688,10 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
-  '@envelop/apollo-federation@5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.1)(encoding@0.1.13)(graphql@16.8.1)':
+  '@envelop/apollo-federation@5.0.0(@apollo/gateway@2.4.7(encoding@0.1.13)(graphql@16.8.1))(@envelop/core@5.0.2)(encoding@0.1.13)(graphql@16.8.1)':
     dependencies:
       '@apollo/gateway': 2.4.7(encoding@0.1.13)(graphql@16.8.1)
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       apollo-server-caching: 3.3.0
       apollo-server-types: 3.8.0(encoding@0.1.13)(graphql@16.8.1)
       graphql: 16.8.1
@@ -19689,50 +19699,50 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@envelop/core@5.0.1':
+  '@envelop/core@5.0.2':
     dependencies:
       '@envelop/types': 5.0.0
       tslib: 2.6.3
 
-  '@envelop/disable-introspection@6.0.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/disable-introspection@6.0.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@envelop/extended-validation@4.0.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/extended-validation@4.0.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@envelop/generic-auth@7.0.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/generic-auth@7.0.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
-      '@envelop/extended-validation': 4.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
+      '@envelop/core': 5.0.2
+      '@envelop/extended-validation': 4.0.0(@envelop/core@5.0.2)(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@envelop/graphql-jit@8.0.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/graphql-jit@8.0.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
       graphql-jit: 0.8.4(graphql@16.8.1)
       tslib: 2.6.3
       value-or-promise: 1.0.12
 
-  '@envelop/graphql-modules@6.0.0(@envelop/core@5.0.1)(graphql-modules@2.1.2(graphql@16.8.1))(graphql@16.8.1)':
+  '@envelop/graphql-modules@6.0.0(@envelop/core@5.0.2)(graphql-modules@2.1.2(graphql@16.8.1))(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
       graphql-modules: 2.1.2(graphql@16.8.1)
       tslib: 2.6.3
 
-  '@envelop/live-query@7.0.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/live-query@7.0.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@n1ru4l/graphql-live-query': 0.10.0(graphql@16.8.1)
       '@n1ru4l/graphql-live-query-patch': 0.7.0(graphql@16.8.1)
@@ -19740,22 +19750,27 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.3
 
-  '@envelop/on-resolve@4.1.0(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/on-resolve@4.1.0(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       graphql: 16.8.1
 
-  '@envelop/prometheus@11.0.0(@envelop/core@5.0.1)(graphql@16.8.1)(prom-client@15.1.3)':
+  '@envelop/on-resolve@4.1.1(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
-      '@envelop/on-resolve': 4.1.0(@envelop/core@5.0.1)(graphql@16.8.1)
+      '@envelop/core': 5.0.2
+      graphql: 16.8.1
+
+  '@envelop/prometheus@11.0.0(@envelop/core@5.0.2)(graphql@16.8.1)(prom-client@15.1.3)':
+    dependencies:
+      '@envelop/core': 5.0.2
+      '@envelop/on-resolve': 4.1.1(@envelop/core@5.0.2)(graphql@16.8.1)
       graphql: 16.8.1
       prom-client: 15.1.3
       tslib: 2.6.3
 
-  '@envelop/response-cache@6.2.1(@envelop/core@5.0.1)(graphql@16.8.1)':
+  '@envelop/response-cache@6.2.1(@envelop/core@5.0.2)(graphql@16.8.1)':
     dependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@whatwg-node/fetch': 0.9.22
       fast-json-stable-stringify: 2.1.0
@@ -20255,41 +20270,41 @@ snapshots:
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
 
   '@escape.tech/graphql-armor-cost-limit@2.2.0':
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@escape.tech/graphql-armor-max-aliases@2.4.0':
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@escape.tech/graphql-armor-max-depth@2.3.0':
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@escape.tech/graphql-armor-max-directives@2.2.0':
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@escape.tech/graphql-armor-max-tokens@2.4.0':
     dependencies:
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@escape.tech/graphql-armor-types@0.6.0':
@@ -20297,7 +20312,7 @@ snapshots:
       graphql: 16.8.1
     optional: true
 
-  '@escape.tech/graphql-armor@3.0.0(@envelop/core@5.0.1)(@escape.tech/graphql-armor-types@0.6.0)':
+  '@escape.tech/graphql-armor@3.0.0(@envelop/core@5.0.2)(@escape.tech/graphql-armor-types@0.6.0)':
     dependencies:
       '@escape.tech/graphql-armor-block-field-suggestions': 2.2.0
       '@escape.tech/graphql-armor-cost-limit': 2.2.0
@@ -20307,7 +20322,7 @@ snapshots:
       '@escape.tech/graphql-armor-max-tokens': 2.4.0
       graphql: 16.8.1
     optionalDependencies:
-      '@envelop/core': 5.0.1
+      '@envelop/core': 5.0.2
       '@escape.tech/graphql-armor-types': 0.6.0
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.42.0)':


### PR DESCRIPTION
## Description
If non-nullable field in GQL schema throw an error then the tracing plugin is not able to find correct trace node by its path and throw an error [here](https://github.com/dotansimha/graphql-yoga/blob/708d908a8c2b34d267738faeafd37c995d68ed1b/packages/plugins/apollo-inline-trace/src/index.ts#L364).
See the details in test called `'FAILING TEST - nonNullableFail - simple query - tracing plugin will throw "Could not find node with path testNestedField.failing" error'` in this PR.

I am not sure what is the reason why the path is missing in the "ctx.nodes", but probably the reason is that:
https://spec.graphql.org/draft/#sel-GAPHRPTCAACEzBg6S
> If the field which experienced an error was declared as Non-Null, the null result will bubble up to the next nullable field.

## A possible solution could be:
- assign an error to the nearest possible trace node
- I'm also not sure if tracing should be able to break the entire GQL call... 🤔 and maybe the error should always be assigned to the "root node" if `specificNode` will not be found
```ts
// put errors on the root node by default
let node = ctx.rootNode;

if (Array.isArray(errToReport.path)) {
  const specificNode = getNearestNode(ctx.nodes,errToReport.path);
  if (specificNode) {
    node = specificNode;
  } else {
    throw new Error(`Could not find node with path ${errToReport.path.join('.')}`);
  }
}

... ... ...
...

/**
 * If something fails at "non-nullable" GQL field, the error path will not be in trace nodes
 * but the error should be assigned to the nearest possible trace node
 */
function getNearestNode(nodes: Map<string, Trace.Node>, path: (string | number)[]): Trace.Node | undefined {
  // iterates through "path" backwards
  for (let i = path.length; i > 0; i--) {
    const pathString = path.slice(0, i).join('.');
    const node = nodes.get(pathString);
    if (node) {
      return node;
    }
  }

  return;
}
```
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

**Test Environment**:
- `@graphql-yoga/plugin-apollo-inline-trace@3.8.0`:
- NodeJS: `node@20`