### PR TITLE
Fix for issues mentioned in PR #3448

### DIFF
--- a/.changeset/changelog1.md
+++ b/.changeset/changelog1.md
@@ -1,0 +1,6 @@
+---
+"@graphql-yoga/plugin-apollo-usage-report": patch
+---
+
+### Fixed
+- do not set default values for `clientName` and `clientVersion`

--- a/.changeset/changelog2.md
+++ b/.changeset/changelog2.md
@@ -1,0 +1,6 @@
+---
+'graphql-yoga': patch
+---
+
+### Fixed
+- propagation of Yoga `version`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "apollo"
   ],
   "scripts": {
-    "build": "pnpm --filter=@graphql-yoga/graphiql run build && pnpm --filter=@graphql-yoga/render-graphiql run build && pnpm --filter=graphql-yoga run generate-graphiql-html&& pnpm --filter=graphql-yoga run inject-version && bob build",
+    "build": "pnpm --filter=@graphql-yoga/graphiql run build && pnpm --filter=@graphql-yoga/render-graphiql run build && pnpm --filter=graphql-yoga run generate-graphiql-html && bob build && pnpm --filter=graphql-yoga run inject-version",
     "build-website": "pnpm build && cd website && pnpm build",
     "changeset": "changeset",
     "check": "pnpm -r run check",

--- a/packages/plugins/apollo-usage-report/src/index.ts
+++ b/packages/plugins/apollo-usage-report/src/index.ts
@@ -88,8 +88,7 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
     ]),
   ) as YogaLogger;
 
-  let clientNameFactory: StringFromRequestFn = req =>
-    req.headers.get('apollographql-client-name') || 'graphql-yoga';
+  let clientNameFactory: StringFromRequestFn = req => req.headers.get('apollographql-client-name');
 
   if (typeof options.clientName === 'string') {
     const clientName = options.clientName;
@@ -99,7 +98,7 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
   }
 
   let clientVersionFactory: StringFromRequestFn = req =>
-    req.headers.get('apollographql-client-version') || yoga.version;
+    req.headers.get('apollographql-client-version');
 
   if (typeof options.clientVersion === 'string') {
     const clientVersion = options.clientVersion;


### PR DESCRIPTION
## Description
Fixes issues mentioned in PR https://github.com/dotansimha/graphql-yoga/pull/3448

1. yoga version is not propagated well and string `__YOGA_VERSION__` is sent to the trace
2. `clientName` and `clientVersion` **should not have any default values**, because it is real identification of client (mobile app, web, ...). The client can send only the `name` or both (`name` and `version`) or  even "nothing". Setting the default values in this case can make a lot of confusion and if the client does not send this information (`name` or `version`) any default values should not be definitely set!
3. from this point of view, it doesn't make sense to add `clientName` and `clientVersion` to `type ApolloUsageReportOptions` as a`string` (custom function is good idea 👍 )
<img width="1015" alt="screenshot" src="https://github.com/user-attachments/assets/4f8b0178-1a9c-4055-98a6-fc96380f86bc">