### PR TITLE
feat: pass context to onParams hook

### DIFF
--- a/.changeset/chatty-lobsters-exercise.md
+++ b/.changeset/chatty-lobsters-exercise.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-persisted-operations': minor
+---
+
+Forward server context into `extractPersistedOperationId` and `getPersistedOperation` handlers.

--- a/.changeset/quiet-cougars-camp.md
+++ b/.changeset/quiet-cougars-camp.md
@@ -1,0 +1,5 @@
+---
+'graphql-yoga': minor
+---
+
+Inject initial context into `onParams` hook.

--- a/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
+++ b/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
@@ -1,4 +1,4 @@
-import { createYoga, type Plugin } from '../src';
+import { createSchema, createYoga, type Plugin } from '../src';
 import { eventStream } from './utilities';
 
 test('onParams -> setResult to single execution result', async () => {
@@ -58,4 +58,50 @@ test('onParams -> setResult to event stream execution result', async () => {
     }
   }
   expect(counter).toBe(2);
+});
+
+test('context value identity stays the same in all hooks', async () => {
+  const contextValues = [] as Array<unknown>;
+  const yoga = createYoga({
+    schema: createSchema({ typeDefs: `type Query {a:String}` }),
+    plugins: [
+      {
+        onParams(ctx) {
+          contextValues.push(ctx.context);
+        },
+        onParse(ctx) {
+          contextValues.push(ctx.context);
+        },
+        onValidate(ctx) {
+          contextValues.push(ctx.context);
+        },
+        onContextBuilding(ctx) {
+          contextValues.push(ctx.context);
+          // mutate context
+          ctx.extendContext({ a: 1 } as Record<string, unknown>);
+          contextValues.push(ctx.context);
+        },
+        onExecute(ctx) {
+          contextValues.push(ctx.args.contextValue);
+        },
+        onResponse(ctx) {
+          contextValues.push(ctx.serverContext);
+        },
+      } satisfies Plugin,
+    ],
+  });
+
+  const response = await yoga.fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ query: '{__typename}' }),
+  });
+  expect(response.status).toEqual(200);
+  expect(await response.json()).toEqual({ data: { __typename: 'Query' } });
+  expect(contextValues).toHaveLength(7);
+  for (const value of contextValues) {
+    expect(value).toEqual(contextValues[0]);
+  }
 });

--- a/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
+++ b/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
@@ -102,6 +102,6 @@ test('context value identity stays the same in all hooks', async () => {
   expect(await response.json()).toEqual({ data: { __typename: 'Query' } });
   expect(contextValues).toHaveLength(7);
   for (const value of contextValues) {
-    expect(value).toEqual(contextValues[0]);
+    expect(value).toBe(contextValues[0]);
   }
 });

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -109,7 +109,7 @@ export type OnParamsHook<TServerContext> = (
   payload: OnParamsEventPayload<TServerContext>,
 ) => PromiseOrValue<void>;
 
-export interface OnParamsEventPayload<TServerContext = object> {
+export interface OnParamsEventPayload<TServerContext = Record<string, unknown>> {
   params: GraphQLParams;
   request: Request;
   setParams: (params: GraphQLParams) => void;

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -55,7 +55,7 @@ export type Plugin<
      * Use this hook with your own risk. It is still experimental and may change in the future.
      * @internal
      */
-    onParams?: OnParamsHook;
+    onParams?: OnParamsHook<TServerContext>;
     /**
      * Use this hook with your own risk. It is still experimental and may change in the future.
      * @internal
@@ -105,14 +105,17 @@ export interface OnRequestParseDoneEventPayload {
   setRequestParserResult: (params: GraphQLParams | GraphQLParams[]) => void;
 }
 
-export type OnParamsHook = (payload: OnParamsEventPayload) => PromiseOrValue<void>;
+export type OnParamsHook<TServerContext> = (
+  payload: OnParamsEventPayload<TServerContext>,
+) => PromiseOrValue<void>;
 
-export interface OnParamsEventPayload {
+export interface OnParamsEventPayload<TServerContext = object> {
   params: GraphQLParams;
   request: Request;
   setParams: (params: GraphQLParams) => void;
   setResult: (result: ExecutionResult | AsyncIterable<ExecutionResult>) => void;
   fetchAPI: FetchAPI;
+  context: TServerContext;
 }
 
 export type OnResultProcess<TServerContext> = (


### PR DESCRIPTION
Alternative approach for https://github.com/dotansimha/graphql-yoga/pull/3463

This is required for solving https://github.com/graphql-hive/platform/pull/5875 as the request can not be used as a internal cache key for batched requests.