### PR TITLE
apollo-usage-report - get missing operationName from the OperationDefinitionNode

### DIFF
--- a/.changeset/changelog1.md
+++ b/.changeset/changelog1.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-apollo-usage-report": patch
+---
+
+fixed: move logic from `onEnveloped` hook to `onParse` hook (`onParseEnd`) which prevents the `operationName` could be missing.


### PR DESCRIPTION
## Description
If someone send GraphQL query without `operationName` in request body, we should try to get it from the `OperationDefinitionNode` after the query parsing is finished.

I added this logic to the `onParse` (`onParseEnd`) handler, but I'm not sure if all the logic of the `onEnveloped` handler should be moved to the `onParseEnd` handler?

- e.g. the `operationName` is missing if someone send request with body
```json
{
  "query": "query TestQueryName{me{userAccount{id loginName}}}"
}
```
and the result in Apollo Studio metrics is: ❌ 
<img width="1730" alt="screenshot_1" src="https://github.com/user-attachments/assets/59b5be87-dc91-4ec7-973f-b34ca11609c6">

- if someone send request with body
```json
{
  "query": "query TestQueryName{me{userAccount{id loginName}}}",
  "operationName": "TestQueryName"
}
```
the result in Apollo Studio metrics is: ✅ 
<img width="1732" alt="screenshot_2" src="https://github.com/user-attachments/assets/c47a3634-b49d-4882-8f15-9d2ba619f24d">
