### PR TITLE
fix: context properties are shared between batched requests

### DIFF
--- a/.changeset/graphql-yoga-3491-dependencies.md
+++ b/.changeset/graphql-yoga-3491-dependencies.md
@@ -1,0 +1,7 @@
+---
+'graphql-yoga': patch
+---
+dependencies updates:
+  - Updated dependency [`@whatwg-node/server@^0.9.55`
+    ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.55) (from `^0.9.54`, in
+    `dependencies`)

--- a/.changeset/pink-snails-thank.md
+++ b/.changeset/pink-snails-thank.md
@@ -1,0 +1,9 @@
+---
+'graphql-yoga': patch
+---
+
+Fix issue where context values being shared between batched requests.
+
+A bug within `@whatwg-node/server` caused properties assigned to a batched requests context to be
+propagated to all other batched requests contexts. It is resolved by updating the dependency of
+`@whatwg-node/server` to `0.9.55`.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
       "graphql": "16.8.1",
       "@envelop/core": "5.0.2",
       "@changesets/assemble-release-plan": "5.2.1",
-      "@types/react": "18.2.55"
+      "@types/react": "18.2.55",
+      "@whatwg-node/server": "0.9.55-alpha-20241113130917-104012bc963134ef9c02cd2d0f3d86e836b379be"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
       "graphql": "16.8.1",
       "@envelop/core": "5.0.2",
       "@changesets/assemble-release-plan": "5.2.1",
-      "@types/react": "18.2.55",
-      "@whatwg-node/server": "0.9.55-alpha-20241113130917-104012bc963134ef9c02cd2d0f3d86e836b379be"
+      "@types/react": "18.2.55"
     }
   }
 }

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -57,7 +57,7 @@
     "@graphql-yoga/logger": "workspace:^",
     "@graphql-yoga/subscription": "workspace:^",
     "@whatwg-node/fetch": "^0.10.1",
-    "@whatwg-node/server": "^0.9.54",
+    "@whatwg-node/server": "^0.9.55",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.5.2"

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -471,8 +471,7 @@ export class YogaServer<
     serverContext: TServerContext,
   ) {
     let result: ExecutionResult | AsyncIterable<ExecutionResult> | undefined;
-    const context: TServerContext & YogaInitialContext =
-      batched === true ? Object.create(serverContext) : serverContext;
+    const context: TServerContext = batched === true ? Object.create(serverContext) : serverContext;
 
     try {
       for (const onParamsHook of this.onParamsHooks) {
@@ -492,7 +491,7 @@ export class YogaServer<
 
       if (result == null) {
         const additionalContext =
-          serverContext.request === request
+          context.request === request
             ? {
                 params,
               }
@@ -549,7 +548,7 @@ export class YogaServer<
           result = newResult;
         },
         request,
-        context,
+        context: context as TServerContext & YogaInitialContext,
       });
     }
     return result;

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -462,16 +462,13 @@ export class YogaServer<
     {
       params,
       request,
-      batched,
     }: {
       params: GraphQLParams;
       request: Request;
-      batched: boolean;
     },
-    serverContext: TServerContext,
+    context: TServerContext,
   ) {
     let result: ExecutionResult | AsyncIterable<ExecutionResult> | undefined;
-    const context: TServerContext = batched === true ? Object.create(serverContext) : serverContext;
 
     try {
       for (const onParamsHook of this.onParamsHooks) {
@@ -609,9 +606,8 @@ export class YogaServer<
               {
                 params,
                 request,
-                batched: true,
               },
-              serverContext,
+              Object.create(serverContext),
             ),
           ),
         )
@@ -619,7 +615,6 @@ export class YogaServer<
           {
             params: requestParserResult,
             request,
-            batched: false,
           },
           serverContext,
         ))) as ResultProcessorInput;

--- a/website/src/pages/docs/features/envelop-plugins.mdx
+++ b/website/src/pages/docs/features/envelop-plugins.mdx
@@ -172,23 +172,20 @@ tokens etc.
 import { Plugin } from 'graphql-yoga'
 
 function useAuth(): Plugin {
- return {
-  onRequest({ request, fetchAPI, endResponse }) {
-    if (!request.headers.get('authorization')) {
-      endResponse(
-        new fetchAPI.Response(
-          null,
-          {
+  return {
+    onRequest({ request, fetchAPI, endResponse }) {
+      if (!request.headers.get('authorization')) {
+        endResponse(
+          new fetchAPI.Response(null, {
             status: 401,
             headers: {
               'Content-Type': 'application/json'
             }
-          }
+          })
         )
-      )
+      }
     }
   }
- }
 }
 ```
 

--- a/website/src/pages/docs/features/jwt.mdx
+++ b/website/src/pages/docs/features/jwt.mdx
@@ -50,7 +50,12 @@ For the setup mentioned above, you can use the following configuration for your 
 ```ts filename="server.ts"
 import { createYoga } from 'graphql-yoga'
 import jwt from 'jsonwebtoken'
-import { useJWT, createInlineSigningKeyProvider, createRemoteJwksSigningKeyProvider, extractFromHeader } from '@graphql-yoga/plugin-jwt'
+import {
+  createInlineSigningKeyProvider,
+  createRemoteJwksSigningKeyProvider,
+  extractFromHeader,
+  useJWT
+} from '@graphql-yoga/plugin-jwt'
 import { getUserById, getUserByLogin } from './db'
 
 const signingKey = process.env.JWT_SECRET
@@ -66,16 +71,14 @@ const yoga = createYoga({
       ],
       // Configure where to look for the JWT token: in the headers, or cookies.
       // By default, the plugin will look for the token in the 'authorization' header only.
-      tokenLookupLocations: [
-        extractFromHeader({ name: 'authorization', prefix: 'Bearer' }),
-      ],
+      tokenLookupLocations: [extractFromHeader({ name: 'authorization', prefix: 'Bearer' })],
       // Configure your token issuers/audience/algorithms verification options.
       // By default, the plugin will only verify the HS256/RS256 algorithms.
       // Please note that this should match the JWT signer issuer/audience/algorithms.
       tokenVerification: {
         issuer: 'http://my-issuer.com',
         audience: 'my-audience',
-        algorithms: ['HS256', 'RS256'],
+        algorithms: ['HS256', 'RS256']
       },
       // Configure context injection after the token is verified.
       // By default, the plugin will inject the token's payload into the context into the `jwt` field.
@@ -85,7 +88,7 @@ const yoga = createYoga({
       // By default, the plugin will reject the request if the token is missing or invalid.
       reject: {
         missingToken: true,
-        invalidToken: true,
+        invalidToken: true
       }
     })
   ]


### PR DESCRIPTION
While investigating an issue for usage reporting for batched requests, I realized that context assignments for one batch execution to one context are also shared/assigned to the other batch contexts.

~~`Object.create` creates a new object using the existing object as the prototype so the assignments seem to be inherited. 🫤~~ 

~~This bug was introduced in https://github.com/dotansimha/graphql-yoga/pull/3270~~ 

This bug originates from `@whatwg-node/server` See https://github.com/ardatan/whatwg-node/pull/1797 and https://github.com/ardatan/whatwg-node/pull/1796).