### PR TITLE
Update transport executors containing improvements and fixes

### DIFF
--- a/.changeset/@graphql-yoga_apollo-link-3501-dependencies.md
+++ b/.changeset/@graphql-yoga_apollo-link-3501-dependencies.md
@@ -1,0 +1,10 @@
+---
+'@graphql-yoga/apollo-link': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/executor-apollo-link@^1.0.3`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor-apollo-link/v/1.0.3) (from `^1.0.0`,
+    in `dependencies`)
+  - Updated dependency [`@graphql-tools/executor-http@^1.1.9`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor-http/v/1.1.9) (from `^1.0.4`, in
+    `dependencies`)

--- a/.changeset/@graphql-yoga_graphiql-3501-dependencies.md
+++ b/.changeset/@graphql-yoga_graphiql-3501-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-yoga/graphiql': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/url-loader@^8.0.15`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/url-loader/v/8.0.15) (from `8.0.2`, in
+    `dependencies`)

--- a/.changeset/@graphql-yoga_urql-exchange-3501-dependencies.md
+++ b/.changeset/@graphql-yoga_urql-exchange-3501-dependencies.md
@@ -1,0 +1,10 @@
+---
+'@graphql-yoga/urql-exchange': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/executor-http@^1.1.9`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor-http/v/1.1.9) (from `^1.0.4`, in
+    `dependencies`)
+  - Updated dependency [`@graphql-tools/executor-urql-exchange@^1.0.4`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor-urql-exchange/v/1.0.4) (from `^1.0.0`,
+    in `dependencies`)

--- a/.changeset/graphql-yoga-3501-dependencies.md
+++ b/.changeset/graphql-yoga-3501-dependencies.md
@@ -1,0 +1,7 @@
+---
+'graphql-yoga': patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/executor@^1.3.3`
+    ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.3.3) (from `^1.3.0`, in
+    `dependencies`)

--- a/.changeset/purple-lizards-divide.md
+++ b/.changeset/purple-lizards-divide.md
@@ -1,0 +1,9 @@
+---
+'@graphql-yoga/urql-exchange': patch
+'@graphql-yoga/plugin-defer-stream': patch
+'@graphql-yoga/apollo-link': patch
+'graphql-yoga': patch
+'@graphql-yoga/graphiql': patch
+---
+
+Update transport executors containing improvements and fixes

--- a/packages/client/apollo-link/package.json
+++ b/packages/client/apollo-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-yoga/apollo-link",
-  "version": "3.10.2",
+  "version": "3.10.1",
   "type": "module",
   "description": "",
   "repository": {
@@ -47,8 +47,8 @@
     "graphql": "^15.2.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-tools/executor-apollo-link": "^1.0.0",
-    "@graphql-tools/executor-http": "^1.0.4",
+    "@graphql-tools/executor-apollo-link": "^1.0.3",
+    "@graphql-tools/executor-http": "^1.1.9",
     "tslib": "^2.5.2"
   },
   "devDependencies": {

--- a/packages/client/urql-exchange/package.json
+++ b/packages/client/urql-exchange/package.json
@@ -48,8 +48,8 @@
     "wonka": "^6.0.0"
   },
   "dependencies": {
-    "@graphql-tools/executor-http": "^1.0.4",
-    "@graphql-tools/executor-urql-exchange": "^1.0.0",
+    "@graphql-tools/executor-http": "^1.1.9",
+    "@graphql-tools/executor-urql-exchange": "^1.0.4",
     "tslib": "^2.5.2"
   },
   "devDependencies": {

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@graphiql/plugin-explorer": "^3.0.0",
     "@graphiql/toolkit": "0.9.1",
-    "@graphql-tools/url-loader": "8.0.2",
+    "@graphql-tools/url-loader": "^8.0.15",
     "graphiql": "3.1.1",
     "graphql": "16.8.1",
     "json-bigint-patch": "0.0.8",

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@envelop/core": "^5.0.1",
-    "@graphql-tools/executor": "^1.3.0",
+    "@graphql-tools/executor": "^1.3.3",
     "@graphql-tools/schema": "^10.0.4",
     "@graphql-tools/utils": "^10.3.2",
     "@graphql-yoga/logger": "workspace:^",

--- a/packages/plugins/defer-stream/package.json
+++ b/packages/plugins/defer-stream/package.json
@@ -44,7 +44,7 @@
     "@graphql-tools/utils": "^10.0.0"
   },
   "devDependencies": {
-    "@graphql-tools/executor-http": "^1.0.4",
+    "@graphql-tools/executor-http": "^1.1.9",
     "@whatwg-node/fetch": "^0.10.1",
     "fetch-multipart-graphql": "3.2.1",
     "graphql": "^16.6.0",


### PR DESCRIPTION
Aside from other important fixes, one notable fix is https://github.com/ardatan/graphql-tools/pull/6658. 