### PR TITLE
Avoid timeouts when testing SSE subscriptions in browser

### DIFF
--- a/packages/graphql-yoga/__integration-tests__/browser.spec.ts
+++ b/packages/graphql-yoga/__integration-tests__/browser.spec.ts
@@ -171,7 +171,7 @@ export function createTestSchema() {
           async *subscribe(_root, args) {
             for (let count = 1; count <= args.to; count++) {
               yield { count };
-              await new Promise(resolve => setTimeout(resolve, 100));
+              await new Promise(resolve => setTimeout(resolve, 200));
             }
           },
         },


### PR DESCRIPTION
Testing with timeouts is always flakey and should be avoided.