### PR TITLE
chore: add contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Setup
+
+1. Use corepack: `corepack enable`
+2. Install packages: `pnpm install`
+3. Build packages: `pnpm build`
+
+## Tests
+
+### Integration
+
+- Can only be run after [packages have been built](#setup).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+# Welcome
+
+> [!IMPORTANT] This guide extends the
+> [core Guild contributing guide](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md).
+> If you haven't read it yet or in recently (e.g. past year), please read it first.
+
 ## Setup
 
 1. Use corepack: `corepack enable`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Welcome
 
-> [!IMPORTANT] This guide extends the
+> [!IMPORTANT]
+>
+> This guide extends the
 > [core Guild contributing guide](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md).
 > If you haven't read it yet or in recently (e.g. past year), please read it first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 >
 > This guide extends the
 > [core Guild contributing guide](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md).
-> If you haven't read it yet or in recently (e.g. past year), please read it first.
+> If you haven't read it yet or recently (e.g. past year), please read it first.
 
 ## Setup
 


### PR DESCRIPTION
This begins a contributing doc. Certainly something I expect to evolve. Let's keep it brief and to the point. We have a lot of repos at The Guild so, if there is common contributing guide content, perhaps that gets factored out into a single place that all other repo contrib guides can link to.