### PR TITLE
Bump dependencies and export helpers

### DIFF
--- a/.changeset/@graphql-yoga_plugin-apollo-usage-report-3549-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apollo-usage-report-3549-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-yoga/plugin-apollo-usage-report": patch
+---
+dependencies updates:
+  - Removed dependency [`@graphql-tools/utils@^10.6.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.6.1) (from `peerDependencies`)
+  - Removed dependency [`@whatwg-node/fetch@^0.10.1` ↗︎](https://www.npmjs.com/package/@whatwg-node/fetch/v/0.10.1) (from `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-apq-3549-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-apq-3549-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-apq": patch
+---
+dependencies updates:
+  - Removed dependency [`@graphql-tools/utils@^10.6.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.6.1) (from `peerDependencies`)

--- a/.changeset/@graphql-yoga_plugin-persisted-operations-3549-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-persisted-operations-3549-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-persisted-operations": patch
+---
+dependencies updates:
+  - Removed dependency [`@graphql-tools/utils@^10.6.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.6.1) (from `peerDependencies`)

--- a/.changeset/graphql-yoga-3549-dependencies.md
+++ b/.changeset/graphql-yoga-3549-dependencies.md
@@ -1,0 +1,8 @@
+---
+"graphql-yoga": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-tools/executor@^1.3.7` ↗︎](https://www.npmjs.com/package/@graphql-tools/executor/v/1.3.7) (from `^1.3.5`, in `dependencies`)
+  - Updated dependency [`@graphql-tools/schema@^10.0.11` ↗︎](https://www.npmjs.com/package/@graphql-tools/schema/v/10.0.11) (from `^10.0.10`, in `dependencies`)
+  - Updated dependency [`@graphql-tools/utils@^10.6.2` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.6.2) (from `^10.6.1`, in `dependencies`)
+  - Updated dependency [`@whatwg-node/server@^0.9.63` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.63) (from `^0.9.60`, in `dependencies`)

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -55,9 +55,8 @@
     "@graphql-tools/utils": "^10.6.2",
     "@graphql-yoga/logger": "workspace:^",
     "@graphql-yoga/subscription": "workspace:^",
-    "@whatwg-node/disposablestack": "^0.0.5",
     "@whatwg-node/fetch": "^0.10.1",
-    "@whatwg-node/server": "^0.9.62",
+    "@whatwg-node/server": "^0.9.63",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.8.1"

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -50,13 +50,14 @@
   },
   "dependencies": {
     "@envelop/core": "^5.0.2",
-    "@graphql-tools/executor": "^1.3.5",
-    "@graphql-tools/schema": "^10.0.10",
-    "@graphql-tools/utils": "^10.6.1",
+    "@graphql-tools/executor": "^1.3.7",
+    "@graphql-tools/schema": "^10.0.11",
+    "@graphql-tools/utils": "^10.6.2",
     "@graphql-yoga/logger": "workspace:^",
     "@graphql-yoga/subscription": "workspace:^",
+    "@whatwg-node/disposablestack": "^0.0.5",
     "@whatwg-node/fetch": "^0.10.1",
-    "@whatwg-node/server": "^0.9.60",
+    "@whatwg-node/server": "^0.9.62",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.8.1"

--- a/packages/graphql-yoga/src/error.ts
+++ b/packages/graphql-yoga/src/error.ts
@@ -4,8 +4,6 @@ import type { YogaLogger } from '@graphql-yoga/logger';
 import type { ResultProcessorInput } from './plugins/types.js';
 import type { GraphQLHTTPExtensions, YogaMaskedErrorOpts } from './types.js';
 
-export { createGraphQLError };
-
 declare module 'graphql' {
   interface GraphQLErrorExtensions {
     http?: GraphQLHTTPExtensions;

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -38,9 +38,10 @@ export {
 } from '@envelop/core';
 export { createGraphQLError, isPromise, mapMaybePromise } from '@graphql-tools/utils';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
+export { processRegularResult } from './plugins/result-processor/regular.js';
 export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';
 export {
   type LandingPageRenderer,
   type LandingPageRendererOpts,
 } from './plugins/use-unhandled-route.js';
-export { DisposableSymbols } from '@whatwg-node/disposablestack';
+export { DisposableSymbols } from '@whatwg-node/server';

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -1,4 +1,3 @@
-export { createGraphQLError } from './error.js';
 export * from '@graphql-yoga/logger';
 export { type Plugin } from './plugins/types.js';
 export { type GraphiQLOptions } from './plugins/use-graphiql.js';
@@ -37,7 +36,7 @@ export {
   useLogger,
   usePayloadFormatter,
 } from '@envelop/core';
-export { isPromise, mapMaybePromise } from '@graphql-tools/utils';
+export { createGraphQLError, isPromise, mapMaybePromise } from '@graphql-tools/utils';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
 export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';
 export {

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -37,9 +37,11 @@ export {
   useLogger,
   usePayloadFormatter,
 } from '@envelop/core';
+export { isPromise, mapMaybePromise } from '@graphql-tools/utils';
 export { getSSEProcessor } from './plugins/result-processor/sse.js';
 export { useExecutionCancellation } from './plugins/use-execution-cancellation.js';
 export {
   type LandingPageRenderer,
   type LandingPageRendererOpts,
 } from './plugins/use-unhandled-route.js';
+export { DisposableSymbols } from '@whatwg-node/disposablestack';

--- a/packages/graphql-yoga/src/plugins/plugins.test.ts
+++ b/packages/graphql-yoga/src/plugins/plugins.test.ts
@@ -1,5 +1,5 @@
 import { AfterValidateHook } from '@envelop/core';
-import { createGraphQLError } from '../error.js';
+import { createGraphQLError } from '@graphql-tools/utils';
 import { createSchema } from '../schema.js';
 import { createYoga } from '../server.js';
 import { Plugin } from './types.js';

--- a/packages/graphql-yoga/src/plugins/request-validation/use-limit-batching.ts
+++ b/packages/graphql-yoga/src/plugins/request-validation/use-limit-batching.ts
@@ -1,4 +1,4 @@
-import { createGraphQLError } from '../../error.js';
+import { createGraphQLError } from '@graphql-tools/utils';
 import type { Plugin } from '../types.js';
 
 export function useLimitBatching(limit?: number): Plugin {

--- a/packages/graphql-yoga/src/plugins/result-processor/stringify.ts
+++ b/packages/graphql-yoga/src/plugins/result-processor/stringify.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql';
-import { createGraphQLError, isGraphQLError } from '../../error.js';
+import { createGraphQLError } from '@graphql-tools/utils';
+import { isGraphQLError } from '../../error.js';
 import { MaybeArray } from '../../types.js';
 import { ExecutionResultWithSerializer } from '../types.js';
 

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -513,9 +513,8 @@ export class YogaServer<
       /** Ensure that error thrown from subscribe is sent to client */
       // TODO: this should probably be something people can customize via a hook?
       if (isAsyncIterable(result)) {
-        const iterator = result[Symbol.asyncIterator]();
         result = mapAsyncIterator(
-          iterator,
+          result,
           v => v,
           (err: Error) => {
             if (err.name === 'AbortError') {

--- a/packages/plugins/apollo-managed-federation/src/index.ts
+++ b/packages/plugins/apollo-managed-federation/src/index.ts
@@ -1,4 +1,4 @@
-import { createGraphQLError, type Plugin } from 'graphql-yoga';
+import { createGraphQLError, DisposableSymbols, type Plugin } from 'graphql-yoga';
 import {
   FetchError,
   SupergraphSchemaManager,
@@ -7,7 +7,6 @@ import {
   type SupergraphSchemaManagerOptions,
   type SupergraphSchemaManagerSchemaEvent,
 } from '@graphql-tools/federation';
-import { DisposableSymbols } from '@whatwg-node/disposablestack';
 
 export type ManagedFederationPluginOptions = (
   | SupergraphSchemaManager

--- a/packages/plugins/apollo-usage-report/package.json
+++ b/packages/plugins/apollo-usage-report/package.json
@@ -37,8 +37,6 @@
     "check": "tsc --pretty --noEmit"
   },
   "peerDependencies": {
-    "@graphql-tools/utils": "^10.6.1",
-    "@whatwg-node/fetch": "^0.10.1",
     "graphql": "^15.2.0 || ^16.0.0",
     "graphql-yoga": "workspace:^"
   },

--- a/packages/plugins/apq/package.json
+++ b/packages/plugins/apq/package.json
@@ -37,7 +37,6 @@
     "check": "tsc --pretty --noEmit"
   },
   "peerDependencies": {
-    "@graphql-tools/utils": "^10.6.1",
     "graphql-yoga": "workspace:^"
   },
   "devDependencies": {

--- a/packages/plugins/defer-stream/src/validations/defer-stream-directive-label.ts
+++ b/packages/plugins/defer-stream/src/validations/defer-stream-directive-label.ts
@@ -1,9 +1,6 @@
 import { ASTVisitor, Kind, ValidationContext } from 'graphql';
-import {
-  createGraphQLError,
-  GraphQLDeferDirective,
-  GraphQLStreamDirective,
-} from '@graphql-tools/utils';
+import { createGraphQLError } from 'graphql-yoga';
+import { GraphQLDeferDirective, GraphQLStreamDirective } from '@graphql-tools/utils';
 
 /**
  * Stream directive on list field

--- a/packages/plugins/defer-stream/src/validations/defer-stream-directive-on-root-field.ts
+++ b/packages/plugins/defer-stream/src/validations/defer-stream-directive-on-root-field.ts
@@ -1,9 +1,6 @@
 import { ASTVisitor, ValidationContext } from 'graphql';
-import {
-  createGraphQLError,
-  GraphQLDeferDirective,
-  GraphQLStreamDirective,
-} from '@graphql-tools/utils';
+import { createGraphQLError } from 'graphql-yoga';
+import { GraphQLDeferDirective, GraphQLStreamDirective } from '@graphql-tools/utils';
 
 /**
  * Stream directive on list field

--- a/packages/plugins/defer-stream/src/validations/overlapping-fields-can-be-merged.ts
+++ b/packages/plugins/defer-stream/src/validations/overlapping-fields-can-be-merged.ts
@@ -21,7 +21,8 @@ import {
   ValidationContext,
   ValueNode,
 } from 'graphql';
-import { createGraphQLError, inspect, Maybe } from '@graphql-tools/utils';
+import { createGraphQLError } from 'graphql-yoga';
+import { inspect, Maybe } from '@graphql-tools/utils';
 
 /**
  * Returns a number indicating whether a reference string comes before, or after,

--- a/packages/plugins/defer-stream/src/validations/stream-directive-on-list-field.ts
+++ b/packages/plugins/defer-stream/src/validations/stream-directive-on-list-field.ts
@@ -1,5 +1,6 @@
 import { ASTVisitor, DirectiveNode, isListType, isWrappingType, ValidationContext } from 'graphql';
-import { createGraphQLError, GraphQLStreamDirective } from '@graphql-tools/utils';
+import { createGraphQLError } from 'graphql-yoga';
+import { GraphQLStreamDirective } from '@graphql-tools/utils';
 
 /**
  * Stream directive on list field

--- a/packages/plugins/persisted-operations/package.json
+++ b/packages/plugins/persisted-operations/package.json
@@ -37,7 +37,6 @@
     "check": "tsc --pretty --noEmit"
   },
   "peerDependencies": {
-    "@graphql-tools/utils": "^10.6.1",
     "graphql": "^15.2.0 || ^16.0.0",
     "graphql-yoga": "workspace:^"
   },


### PR DESCRIPTION
- Bump dependencies
- Export helpers for Yoga plugins
- Reorganize exports and imports
- Remove unnecessary peer deps

Closes https://github.com/dotansimha/graphql-yoga/issues/3217