### PR TITLE
fix(sofa): respect error extensions in case of 404

### DIFF
--- a/.changeset/@graphql-yoga_plugin-sofa-3559-dependencies.md
+++ b/.changeset/@graphql-yoga_plugin-sofa-3559-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/plugin-sofa": patch
+---
+dependencies updates:
+  - Updated dependency [`sofa-api@^0.18.8` ↗︎](https://www.npmjs.com/package/sofa-api/v/0.18.8) (from `^0.18.7`, in `dependencies`)

--- a/.changeset/soft-turtles-deny.md
+++ b/.changeset/soft-turtles-deny.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-sofa': patch
+---
+
+Fix the issue when SOFA returns 404 response from error extensions returned by a resolver, it will cause the server to continue the request handling with Yoga but instead it should return the response with 404 and the body SOFA returns.

--- a/packages/plugins/sofa/package.json
+++ b/packages/plugins/sofa/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "^10.3.2",
-    "sofa-api": "^0.18.7"
+    "sofa-api": "^0.18.8"
   },
   "devDependencies": {
     "graphql-yoga": "workspace:*"

--- a/packages/plugins/sofa/src/index.ts
+++ b/packages/plugins/sofa/src/index.ts
@@ -112,7 +112,9 @@ export function useSofa(config: SofaPluginConfig): Plugin {
     async onRequest({ request, endResponse, serverContext, url }) {
       if (url.pathname.startsWith(config.basePath)) {
         const res = await sofaHandler.handleRequest(request, serverContext);
-        endResponse(res);
+        if (res) {
+          endResponse(res);
+        }
       }
     },
   };

--- a/packages/plugins/sofa/src/index.ts
+++ b/packages/plugins/sofa/src/index.ts
@@ -1,7 +1,6 @@
 import { ExecutionArgs, ExecutionResult, SubscriptionArgs } from 'graphql';
-import { Plugin, YogaInitialContext, YogaServerInstance } from 'graphql-yoga';
+import { mapMaybePromise, Plugin, YogaInitialContext, YogaServerInstance } from 'graphql-yoga';
 import { useSofa as createSofaHandler } from 'sofa-api';
-import { isPromise } from '@graphql-tools/utils';
 import { SofaHandler } from './types.js';
 
 type SofaHandlerConfig = Parameters<typeof createSofaHandler>[0];
@@ -33,15 +32,10 @@ export function useSofa(config: SofaPluginConfig): Plugin {
         schema: onSchemaChangeEventPayload.schema,
         context(serverContext: YogaInitialContext) {
           const enveloped = getEnveloped(serverContext);
-          const contextValue$ = enveloped.contextFactory(serverContext);
-          if (isPromise(contextValue$)) {
-            return contextValue$.then(contextValue => {
-              envelopedByContext.set(contextValue, enveloped);
-              return contextValue;
-            });
-          }
-          envelopedByContext.set(contextValue$, enveloped);
-          return contextValue$;
+          return mapMaybePromise(enveloped.contextFactory(serverContext), contextValue$ => {
+            envelopedByContext.set(contextValue$, enveloped);
+            return contextValue$;
+          });
         },
         execute(
           ...args:
@@ -115,10 +109,10 @@ export function useSofa(config: SofaPluginConfig): Plugin {
         },
       });
     },
-    async onRequest({ request, serverContext, endResponse }) {
-      const response = await sofaHandler(request, serverContext as Record<string, unknown>);
-      if (response != null && response.status !== 404) {
-        endResponse(response);
+    async onRequest({ request, endResponse, serverContext, url }) {
+      if (url.pathname.startsWith(config.basePath)) {
+        const res = await sofaHandler.handleRequest(request, serverContext);
+        endResponse(res);
       }
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2353,7 +2353,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-certificatemanager': 1.204.0
@@ -2630,7 +2629,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-applicationautoscaling': 1.204.0
@@ -2817,7 +2815,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
@@ -26455,7 +26452,7 @@ snapshots:
       eslint: 9.17.0(jiti@2.4.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.17.0(jiti@2.4.1))
       eslint-plugin-react: 7.37.2(eslint@9.17.0(jiti@2.4.1))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.17.0(jiti@2.4.1))
@@ -26490,7 +26487,7 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -26594,7 +26591,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1)))(eslint@9.17.0(jiti@2.4.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.1))(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2046,8 +2046,8 @@ importers:
         specifier: 16.10.0
         version: 16.10.0
       sofa-api:
-        specifier: ^0.18.7
-        version: 0.18.7(graphql@16.10.0)
+        specifier: ^0.18.8
+        version: 0.18.8(graphql@16.10.0)
     devDependencies:
       graphql-yoga:
         specifier: workspace:*
@@ -15151,8 +15151,8 @@ packages:
     resolution: {integrity: sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
-  sofa-api@0.18.7:
-    resolution: {integrity: sha512-0boXHTAgSuNTLPsfAEmlgW7bvew8b/4YRM8iZwY7NiJgC4HVYPYHu5NtrLFiY618rdgHqk7Up7PEekgEAxJaTw==}
+  sofa-api@0.18.8:
+    resolution: {integrity: sha512-wTDvSyFB4LjnOTRRi86rCZ5TtYAL0fbFlMVlUnOXGBfcc4t+4BFuBxMEMkbkw0aouIMFP+2E1QemRpPqr/rW6Q==}
     peerDependencies:
       graphql: 16.10.0
 
@@ -33031,10 +33031,10 @@ snapshots:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
 
-  sofa-api@0.18.7(graphql@16.10.0):
+  sofa-api@0.18.8(graphql@16.10.0):
     dependencies:
       '@graphql-tools/utils': 10.6.4(graphql@16.10.0)
-      '@whatwg-node/fetch': 0.9.23
+      '@whatwg-node/fetch': 0.10.1
       ansi-colors: 4.1.3
       fets: 0.8.4
       graphql: 16.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20059,7 +20059,7 @@ snapshots:
       graphql: 16.10.0
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.10.0)
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       jose: 5.9.6
       js-yaml: 4.1.0
       lodash: 4.17.21
@@ -20085,7 +20085,7 @@ snapshots:
 
   '@graphql-tools/schema@10.0.10(graphql@16.10.0)':
     dependencies:
-      '@graphql-tools/merge': 9.0.11(graphql@16.10.0)
+      '@graphql-tools/merge': 9.0.14(graphql@16.10.0)
       '@graphql-tools/utils': 10.6.4(graphql@16.10.0)
       graphql: 16.10.0
       tslib: 2.8.1
@@ -20784,7 +20784,7 @@ snapshots:
     dependencies:
       consola: 3.2.3
       detect-libc: 2.0.3
-      https-proxy-agent: 7.0.5(supports-color@9.4.0)
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.0.0
       semver: 7.6.3
@@ -21423,7 +21423,7 @@ snapshots:
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
       yargs: 17.7.2
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -21531,7 +21531,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.3
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -25826,11 +25826,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.7(supports-color@9.4.0):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 9.4.0
 
   debug@4.4.0(supports-color@9.4.0):
     dependencies:
@@ -26122,7 +26120,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -27114,7 +27112,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -27444,7 +27442,7 @@ snapshots:
 
   follow-redirects@1.15.9(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
@@ -28267,14 +28265,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.5(supports-color@9.4.0):
+  https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.0(supports-color@9.4.0)
@@ -29423,7 +29421,7 @@ snapshots:
   lambda-local@2.2.0:
     dependencies:
       commander: 10.0.1
-      dotenv: 16.4.5
+      dotenv: 16.4.7
       winston: 3.17.0
 
   langium@3.0.0:
@@ -30726,7 +30724,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cron-parser: 4.9.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       decache: 4.6.2
       dot-prop: 9.0.0
       dotenv: 16.4.5
@@ -30752,7 +30750,7 @@ snapshots:
       hasha: 5.2.2
       http-proxy: 1.18.1(debug@4.3.7)
       http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.3.7)
-      https-proxy-agent: 7.0.5(supports-color@9.4.0)
+      https-proxy-agent: 7.0.5
       inquirer: 6.5.2
       inquirer-autocomplete-prompt: 1.4.0(inquirer@6.5.2)
       ipx: 2.1.0(@netlify/blobs@8.1.0)(ioredis@5.4.1)
@@ -32982,7 +32980,7 @@ snapshots:
 
   socket.io-adapter@2.5.5:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -32992,7 +32990,7 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -33001,7 +32999,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       engine.io: 6.6.2
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
@@ -33504,7 +33502,7 @@ snapshots:
 
   tabtab@3.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
       es6-promisify: 6.1.1
       inquirer: 6.5.2
       minimist: 1.2.8
@@ -34469,7 +34467,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/website/src/pages/docs/features/sofa-api.mdx
+++ b/website/src/pages/docs/features/sofa-api.mdx
@@ -4,6 +4,8 @@ description:
   all of that into REST API.
 ---
 
+import { Callout } from '@theguild/components'
+
 # Sofa API
 
 Sofa takes your GraphQL Schema, looks for available queries, mutations and subscriptions and turns
@@ -155,3 +157,8 @@ server.listen(4000, () => {
 ```
 
 You can start the server and visit http://localhost:4000/swagger to see the Swagger UI.
+
+<Callout>
+  Check out the [SOFA documentation](https://sofa-api.com) for more information about SOFA, and the
+  all features it provides.
+</Callout>


### PR DESCRIPTION
Fix the issue when SOFA returns 404 response from error extensions returned by a resolver, it will cause the server to continue the request handling with Yoga but instead it should return the response with 404 and the body SOFA returns.

That line was causing a 404 response to continue with Yoga's handler;
https://github.com/dotansimha/graphql-yoga/pull/3559/files#diff-ede815ebc73ee3925e49864ba3ac573940f77e8542cf395ccbf405b284c006aeL120

As in this test case;
```ts
  it('forwards error extensions correctly', async () => {
    const yoga = createYoga({
      schema: createSchema({
        typeDefs: /* GraphQL */ `
          type Query {
            me: Account
          }
          type Account {
            id: ID!
            name: String!
          }
        `,
        resolvers: {
          Query: {
            me: () => {
              throw createGraphQLError('account not found', {
                extensions: {
                  code: 'ACCOUNT_NOT_FOUND',
                  http: { status: 404 },
                },
              });
            },
          },
        },
      }),
      plugins: [
        useSofa({
          basePath: '/api',
        }),
      ],
    });
    for (let i = 0; i < 10; i++) {
      const res = await yoga.fetch('http://localhost/api/me');
      expect(res.status).toBe(404);
      const json = await res.json();
      expect(json).toEqual({
        errors: [
          {
            message: 'account not found',
            extensions: {
              code: 'ACCOUNT_NOT_FOUND',
            },
            path: ['me'],
          },
        ],
      });
    }
  });
```