### PR TITLE
New Explicit Resource Management docs and improvements

### DIFF
--- a/.changeset/@graphql-yoga_apollo-managed-federation-3567-dependencies.md
+++ b/.changeset/@graphql-yoga_apollo-managed-federation-3567-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-yoga/apollo-managed-federation": patch
+---
+dependencies updates:
+  - Removed dependency [`@whatwg-node/disposablestack@^0.0.5` ↗︎](https://www.npmjs.com/package/@whatwg-node/disposablestack/v/0.0.5) (from `dependencies`)

--- a/.changeset/graphql-yoga-3567-dependencies.md
+++ b/.changeset/graphql-yoga-3567-dependencies.md
@@ -1,0 +1,5 @@
+---
+"graphql-yoga": patch
+---
+dependencies updates:
+  - Updated dependency [`@whatwg-node/server@^0.9.64` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.9.64) (from `^0.9.63`, in `dependencies`)

--- a/packages/graphql-yoga/package.json
+++ b/packages/graphql-yoga/package.json
@@ -56,7 +56,7 @@
     "@graphql-yoga/logger": "workspace:^",
     "@graphql-yoga/subscription": "workspace:^",
     "@whatwg-node/fetch": "^0.10.1",
-    "@whatwg-node/server": "^0.9.63",
+    "@whatwg-node/server": "^0.9.64",
     "dset": "^3.1.1",
     "lru-cache": "^10.0.0",
     "tslib": "^2.8.1"

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -18,6 +18,7 @@ import {
   ServerAdapter,
   ServerAdapterBaseObject,
   ServerAdapterInitialContext,
+  ServerAdapterOptions,
   ServerAdapterRequestHandler,
   useCORS,
   useErrorHandling,
@@ -75,7 +76,10 @@ import { maskError } from './utils/mask-error.js';
 /**
  * Configuration options for the server
  */
-export type YogaServerOptions<TServerContext, TUserContext> = {
+export type YogaServerOptions<TServerContext, TUserContext> = Omit<
+  ServerAdapterOptions<TServerContext>,
+  'plugins'
+> & {
   /**
    * Enable/disable logging or provide a custom logger.
    * @default true

--- a/packages/plugins/apollo-managed-federation/package.json
+++ b/packages/plugins/apollo-managed-federation/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@graphql-tools/federation": "^3.0.0",
-    "@whatwg-node/disposablestack": "^0.0.5",
     "tslib": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/plugins/apollo-managed-federation/src/index.ts
+++ b/packages/plugins/apollo-managed-federation/src/index.ts
@@ -1,4 +1,4 @@
-import { createGraphQLError, DisposableSymbols, type Plugin } from 'graphql-yoga';
+import { createGraphQLError, type Plugin } from 'graphql-yoga';
 import {
   FetchError,
   SupergraphSchemaManager,
@@ -107,8 +107,8 @@ export function useManagedFederation(options: ManagedFederationPluginOptions = {
         },
       );
     },
-    [DisposableSymbols.dispose]() {
-      return ensureSupergraphManager()[DisposableSymbols.dispose]();
+    onDispose() {
+      return _supergraphManager?.stop();
     },
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,7 +401,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.3
-        version: 1.0.3(@whatwg-node/server@0.9.63)
+        version: 1.0.3(@whatwg-node/server@0.9.64)
       graphql:
         specifier: 16.10.0
         version: 16.10.0
@@ -1605,8 +1605,8 @@ importers:
         specifier: ^0.10.1
         version: 0.10.1
       '@whatwg-node/server':
-        specifier: ^0.9.63
-        version: 0.9.63
+        specifier: ^0.9.64
+        version: 0.9.64
       dset:
         specifier: ^3.1.1
         version: 3.1.4
@@ -1832,9 +1832,6 @@ importers:
       '@graphql-tools/federation':
         specifier: ^3.0.0
         version: 3.0.3(@types/node@22.10.2)(graphql@16.10.0)
-      '@whatwg-node/disposablestack':
-        specifier: ^0.0.5
-        version: 0.0.5
       tslib:
         specifier: ^2.5.0
         version: 2.8.1
@@ -1965,7 +1962,7 @@ importers:
     dependencies:
       '@whatwg-node/server-plugin-cookies':
         specifier: ^1.0.3
-        version: 1.0.3(@whatwg-node/server@0.9.63)
+        version: 1.0.3(@whatwg-node/server@0.9.64)
       jsonwebtoken:
         specifier: ^9.0.0
         version: 9.0.2
@@ -2353,7 +2350,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-certificatemanager': 1.204.0
@@ -2630,7 +2626,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/aws-applicationautoscaling': 1.204.0
@@ -2817,7 +2812,6 @@ packages:
     deprecated: |-
       AWS CDK v1 has reached End-of-Support on 2023-06-01.
       This package is no longer being updated, and users should migrate to AWS CDK v2.
-
       For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
     peerDependencies:
       '@aws-cdk/cloud-assembly-schema': 1.204.0
@@ -8161,6 +8155,10 @@ packages:
 
   '@whatwg-node/server@0.9.63':
     resolution: {integrity: sha512-rHBN2murCcuuhQru/AQjA13lA9SzQAH9k8ENy4iZrAmY+C0yFYPud3HiFgPUgzR1B2KYUpIYKwC1UAUlkzASOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/server@0.9.64':
+    resolution: {integrity: sha512-4HSOWOjFvPLY7F6zqs/kbSBHInHIxd50xnwtp3NXUrI+d92iOBLHKm9aIULwAn2ABPcnfXb55VQwb4bEV3g6KA==}
     engines: {node: '>=18.0.0'}
 
   '@wry/caches@1.0.1':
@@ -24056,13 +24054,19 @@ snapshots:
       fast-querystring: 1.1.2
       tslib: 2.8.1
 
-  '@whatwg-node/server-plugin-cookies@1.0.3(@whatwg-node/server@0.9.63)':
+  '@whatwg-node/server-plugin-cookies@1.0.3(@whatwg-node/server@0.9.64)':
     dependencies:
       '@whatwg-node/cookie-store': 0.2.2
-      '@whatwg-node/server': 0.9.63
+      '@whatwg-node/server': 0.9.64
       tslib: 2.8.1
 
   '@whatwg-node/server@0.9.63':
+    dependencies:
+      '@whatwg-node/disposablestack': 0.0.5
+      '@whatwg-node/fetch': 0.10.1
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.9.64':
     dependencies:
       '@whatwg-node/disposablestack': 0.0.5
       '@whatwg-node/fetch': 0.10.1
@@ -27312,7 +27316,7 @@ snapshots:
       '@sinclair/typebox': 0.34.11
       '@whatwg-node/cookie-store': 0.2.2
       '@whatwg-node/fetch': 0.10.1
-      '@whatwg-node/server': 0.9.63
+      '@whatwg-node/server': 0.9.64
       hotscript: 1.0.13
       json-schema-to-ts: 3.1.1
       qs: 6.13.1

--- a/website/src/pages/docs/features/_meta.ts
+++ b/website/src/pages/docs/features/_meta.ts
@@ -24,5 +24,6 @@ export default {
   jwt: 'JWT',
   'landing-page': 'Landing Page',
   'request-customization': 'Request Customization',
+  'explicit-resource-management': 'Explicit Resource Management',
   'envelop-plugins': 'Custom Plugins',
 };

--- a/website/src/pages/docs/features/envelop-plugins.mdx
+++ b/website/src/pages/docs/features/envelop-plugins.mdx
@@ -361,7 +361,7 @@ In order to clean up resources when GraphQL Yoga is shut down, you can use the `
 ```ts
 export const useMyPlugin = () => {
   return {
-    async [Symbol.asyncDispose]() {
+    async onDispose() {
       // Clean up resources
       await stopConnection()
     }

--- a/website/src/pages/docs/features/envelop-plugins.mdx
+++ b/website/src/pages/docs/features/envelop-plugins.mdx
@@ -371,4 +371,4 @@ export const useMyPlugin = () => {
 
 GraphQL Yoga supports
 [explicit resource management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management),
-and you can [learn more here]() how to use that.
+and you can [learn more here](/docs/features/explicit-resource-management) how to use that.

--- a/website/src/pages/docs/features/envelop-plugins.mdx
+++ b/website/src/pages/docs/features/envelop-plugins.mdx
@@ -353,3 +353,22 @@ function useYogaSignature(): Plugin {
   }
 }
 ```
+
+### `onDispose`
+
+In order to clean up resources when GraphQL Yoga is shut down, you can use the `onDispose` hook.
+
+```ts
+export const useMyPlugin = () => {
+  return {
+    async [Symbol.asyncDispose]() {
+      // Clean up resources
+      await stopConnection()
+    }
+  }
+}
+```
+
+GraphQL Yoga supports
+[explicit resource management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management),
+and you can [learn more here]() how to use that.

--- a/website/src/pages/docs/features/envelop-plugins.mdx
+++ b/website/src/pages/docs/features/envelop-plugins.mdx
@@ -356,19 +356,42 @@ function useYogaSignature(): Plugin {
 
 ### `onDispose`
 
-In order to clean up resources when GraphQL Yoga is shut down, you can use the `onDispose` hook.
+If you have plugins that need some internal resources to be disposed of, you can use the `onDispose`
+hook to dispose of them. This hook will be invoked when the GraphQL Yoga instance is disposed like
+above.
 
 ```ts
-export const useMyPlugin = () => {
-  return {
-    async onDispose() {
-      // Clean up resources
-      await stopConnection()
-    }
+let dbConnection: Connection
+const plugin = {
+  onPluginInit: async () => {
+    dbConnection = await createConnection()
+  },
+  onDispose: async () => {
+    // Dispose of resources
+    await dbConnection.close()
   }
 }
 ```
 
-GraphQL Yoga supports
-[explicit resource management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management),
-and you can [learn more here](/docs/features/explicit-resource-management) how to use that.
+Or you can flush a queue of operations when the server is shutting down.
+
+```ts
+const backgroundJobs: Promise<void>[] = []
+
+const plugin = {
+  onRequestParse() {
+    backgroundJobs.push(
+      sendAnalytics({
+        /* ... */
+      })
+    )
+  },
+  onDispose: async () => {
+    // Flush the queue of background jobs
+    await Promise.all(backgroundJobs)
+  }
+}
+```
+
+But for this kind of purposes, `waitUntil` can be a better choice.
+[Learn more about explicit resource management here](/docs/features/explicit-resource-management).

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -73,21 +73,36 @@ by listening `process` exit signals.
 <Tabs items={['Explicit disposal', 'Automatic disposal on process exit']}>
 
 <Tabs.Tab>
+
+We can dispose of the GraphQL Yoga instance when the server is closed like below.
+
 ```ts
-import { createYoga, createSchema } from 'graphql-yoga';
-import { createServer } from 'http';
+import { createServer } from 'http'
+import { createSchema, createYoga } from 'graphql-yoga'
 
-const yoga = createYoga({ schema: createSchema({ typeDefs: /_ GraphQL _/
-`             type Query {                 hello: String             }         `, resolvers: {
-Query: { hello: () => 'world' } } }) });
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        hello: String
+      }
+    `,
+    resolvers: {
+      Query: { hello: () => 'world' }
+    }
+  })
+})
 
-const server = createServer(yoga); server.listen(4000, () => { console.info('Server is running on
-http://localhost:4000/graphql') }); server.once('close', async () => { await yoga.dispose();
-console.info('Server is disposed so is Yoga') });
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+server.once('close', async () => {
+  await yoga.dispose()
+  console.info('Server is disposed so is Yoga')
+})
+```
 
-// Then when the server is shutting down, it will dispose of Yoga server.close();
-
-````
 </Tabs.Tab>
 
 <Tabs.Tab>
@@ -95,26 +110,11 @@ console.info('Server is disposed so is Yoga') });
 import { createYoga, createSchema } from 'graphql-yoga';
 import { createServer } from 'http';
 
-createServer(
-    createYoga({
-        schema: createSchema({
-            typeDefs: /* GraphQL */ `
-                type Query {
-                    hello: String
-                }
-            `,
-            resolvers: {
-                Query: {
-                    hello: () => 'world'
-                }
-            }
-        }),
-        disposeOnProcessTerminate: true
-    })
-)
-.listen(4000, () => {
-    console.info('Server is running on http://localhost:4000/graphql')
-});
+createServer( createYoga({ schema: createSchema({ typeDefs: /_ GraphQL _/
+`                 type Query {                     hello: String                 }             `,
+resolvers: { Query: { hello: () => 'world' } } }), disposeOnProcessTerminate: true }) )
+.listen(4000, () => { console.info('Server is running on http://localhost:4000/graphql') });
+
 ````
 
 </Tabs.Tab>
@@ -143,19 +143,21 @@ const plugin = {
 Or you can flush a queue of operations when the server is shutting down.
 
 ```ts
-const backgroundJobs: Promise<void>[] = [];
+const backgroundJobs: Promise<void>[] = []
 
 const plugin = {
-    onRequestParse() {
-        backgroundJobs.push(
-            backgroundJobs.push(sendAnalytics({ /* ... */ }));
-        )
-    },
-    onDispose: async () => {
-        // Flush the queue of background jobs
-        await Promise.all(backgroundJobs);
-    }
-};
+  onRequestParse() {
+    backgroundJobs.push(
+      sendAnalytics({
+        /* ... */
+      })
+    )
+  },
+  onDispose: async () => {
+    // Flush the queue of background jobs
+    await Promise.all(backgroundJobs)
+  }
+}
 ```
 
 But for this kind of purposes, `waitUntil` can be a better choice.
@@ -208,3 +210,4 @@ console.log(await res.json()) // { data: { greetings: "Hello, John" } }
 await yoga.dispose()
 // The fetch request will be awaited here
 ```
+````

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -222,6 +222,6 @@ const res = await yoga.fetch('http://localhost:4000/graphql', {
 console.log(await res.json()) // { data: { greetings: "Hello, John" } }
 
 await yoga.dispose()
-// The fetch request will be awaited here
+// The fetch request for \`analytics\` will be awaited here
 ```
 

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -12,11 +12,14 @@ shutting down.
 GraphQL Yoga supports
 [Explicit Resource Management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management)
 approach that allows you to dispose of resources when they are no longer needed. This can be done in
-two ways.
+two ways shown below;
 
 <Tabs items={['`await using` syntax', '`dispose` method']}>
   <Tabs.Tab>
-    ```ts
+  We use the `await using` syntax to create a new instance of `yoga` and dispose
+of it when the block is exited. Notice that we are using a block to limit the scope of `yoga` within `{ }`.
+So resources will be disposed of when the block is exited.
+    ```ts {2,7}
     console.log('Yoga is starting')
     {
         await using yoga = createYoga({
@@ -38,6 +41,8 @@ two ways.
     ```
     </Tabs.Tab>
     <Tabs.Tab>
+    We create a new instance of `yoga` and
+dispose of it using the `dispose` method.
     ```ts
     console.log('Yoga is starting')
     const yoga = createYoga({
@@ -61,8 +66,7 @@ two ways.
 </Tabs>
 
 In the first example, we use the `await using` syntax to create a new instance of `yoga` and dispose
-of it when the block is exited. In the second example, we create a new instance of `yoga` and
-dispose of it using the `dispose` method.
+of it when the block is exited. In the second example,
 
 ### Dispose on Node.js
 
@@ -135,7 +139,7 @@ createServer(
 
 </Tabs>
 
-## Dispose Plugins
+## Disposable Plugins w/ `onDispose` hook
 
 If you have plugins that need some internal resources to be disposed of, you can use the `onDispose`
 hook to dispose of them. This hook will be invoked when the GraphQL Yoga instance is disposed like
@@ -224,4 +228,3 @@ console.log(await res.json()) // { data: { greetings: "Hello, John" } }
 await yoga.dispose()
 // The fetch request for \`analytics\` will be awaited here
 ```
-

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -181,7 +181,7 @@ But for this kind of purposes, `waitUntil` can be a better choice.
 If you have background jobs that need to be completed before the environment is shut down.
 `waitUntil` is better choice than `onDispose`. In this case, those jobs will keep running in the
 background but in case of disposal, they will be awaited. `waitUntil` works so similar to
-[Cloudflare Workers' `waitUntil` function.](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#parameters).
+[Cloudflare Workers' `waitUntil` function](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#parameters).
 
 But GraphQL Yoga handles `waitUntil` even if it is not provided by the environment.
 

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -14,7 +14,7 @@ GraphQL Yoga supports
 approach that allows you to dispose of resources when they are no longer needed. This can be done in
 two ways.
 
-<Tabs items={['`dispose` method', '`await using` syntax']}>
+<Tabs items={['`await using` syntax', '`dispose` method']}>
   <Tabs.Tab>
     ```ts
     console.log('Yoga is starting')
@@ -106,16 +106,30 @@ server.once('close', async () => {
 </Tabs.Tab>
 
 <Tabs.Tab>
+
+`disposeOnProcessTerminate` option will register an event listener for `process` termination in
+Node.js
+
 ```ts
-import { createYoga, createSchema } from 'graphql-yoga';
-import { createServer } from 'http';
+import { createServer } from 'http'
+import { createSchema, createYoga } from 'graphql-yoga'
 
-createServer( createYoga({ schema: createSchema({ typeDefs: /_ GraphQL _/
-`                 type Query {                     hello: String                 }             `,
-resolvers: { Query: { hello: () => 'world' } } }), disposeOnProcessTerminate: true }) )
-.listen(4000, () => { console.info('Server is running on http://localhost:4000/graphql') });
-
-````
+createServer(
+  createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hello: String
+        }
+      `,
+      resolvers: { Query: { hello: () => 'world' } }
+    }),
+    disposeOnProcessTerminate: true
+  })
+).listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
 
 </Tabs.Tab>
 
@@ -210,4 +224,7 @@ console.log(await res.json()) // { data: { greetings: "Hello, John" } }
 await yoga.dispose()
 // The fetch request will be awaited here
 ```
-````
+
+```
+
+```

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -1,5 +1,7 @@
 # Explicit Resource Management
 
+import { Tabs } from '@theguild/components'
+
 While implementing your GraphQL server with GraphQL Yoga, you need to control over the lifecycle of
 your resources. This is especially important when you are dealing with resources that need to be
 cleaned up when they are no longer needed, or clean up the operations in a queue when the server is

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -1,0 +1,208 @@
+# Explicit Resource Management
+
+While implementing your GraphQL server with GraphQL Yoga, you need to control over the lifecycle of
+your resources. This is especially important when you are dealing with resources that need to be
+cleaned up when they are no longer needed, or clean up the operations in a queue when the server is
+shutting down.
+
+## Dispose GraphQL Yoga
+
+GraphQL Yoga supports
+[Explicit Resource Management](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management)
+approach that allows you to dispose of resources when they are no longer needed. This can be done in
+two ways.
+
+<Tabs items={['`dispose` method', '`await using` syntax']}>
+  <Tabs.Tab>
+    ```ts
+    console.log('Yoga is starting')
+    {
+        await using yoga = createYoga({
+            schema: createSchema({
+                typeDefs: /* GraphQL */ `
+                    type Query {
+                        hello: String
+                    }
+                `,
+                resolvers: {
+                    Query: {
+                        hello: () => 'world'
+                    }
+                }
+            })
+        });
+    }
+    console.log('Yoga is disposed')
+    ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+    ```ts
+    console.log('Yoga is starting')
+    const yoga = createYoga({
+        schema: createSchema({
+            typeDefs: /* GraphQL */ `
+                type Query {
+                    hello: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    hello: () => 'world'
+                }
+            }
+        })
+    });
+    await yoga.dispose();
+    console.log('Yoga is disposed')
+    ```
+    </Tabs.Tab>
+</Tabs>
+
+In the first example, we use the `await using` syntax to create a new instance of `yoga` and dispose
+of it when the block is exited. In the second example, we create a new instance of `yoga` and
+dispose of it using the `dispose` method.
+
+### Dispose on Node.js
+
+When running GraphQL Yoga on Node.js, you can use process event listeners or server's `close` event
+to trigger GraphQL Yoga's disposal. Or you can configure GraphQL Yoga to handle this automatically
+by listening `process` exit signals.
+
+<Tabs items={['Explicit disposal', 'Automatic disposal on process exit']}>
+
+<Tabs.Tab>
+```ts
+import { createYoga, createSchema } from 'graphql-yoga';
+import { createServer } from 'http';
+
+const yoga = createYoga({ schema: createSchema({ typeDefs: /_ GraphQL _/
+`             type Query {                 hello: String             }         `, resolvers: {
+Query: { hello: () => 'world' } } }) });
+
+const server = createServer(yoga); server.listen(4000, () => { console.info('Server is running on
+http://localhost:4000/graphql') }); server.once('close', async () => { await yoga.dispose();
+console.info('Server is disposed so is Yoga') });
+
+// Then when the server is shutting down, it will dispose of Yoga server.close();
+
+````
+</Tabs.Tab>
+
+<Tabs.Tab>
+```ts
+import { createYoga, createSchema } from 'graphql-yoga';
+import { createServer } from 'http';
+
+createServer(
+    createYoga({
+        schema: createSchema({
+            typeDefs: /* GraphQL */ `
+                type Query {
+                    hello: String
+                }
+            `,
+            resolvers: {
+                Query: {
+                    hello: () => 'world'
+                }
+            }
+        }),
+        disposeOnProcessTerminate: true
+    })
+)
+.listen(4000, () => {
+    console.info('Server is running on http://localhost:4000/graphql')
+});
+````
+
+</Tabs.Tab>
+
+</Tabs>
+
+## Dispose Plugins
+
+If you have plugins that need some internal resources to be disposed of, you can use the `onDispose`
+hook to dispose of them. This hook will be invoked when the GraphQL Yoga instance is disposed like
+above.
+
+```ts
+let dbConnection: Connection
+const plugin = {
+  onPluginInit: async () => {
+    dbConnection = await createConnection()
+  },
+  onDispose: async () => {
+    // Dispose of resources
+    await dbConnection.close()
+  }
+}
+```
+
+Or you can flush a queue of operations when the server is shutting down.
+
+```ts
+const backgroundJobs: Promise<void>[] = [];
+
+const plugin = {
+    onRequestParse() {
+        backgroundJobs.push(
+            backgroundJobs.push(sendAnalytics({ /* ... */ }));
+        )
+    },
+    onDispose: async () => {
+        // Flush the queue of background jobs
+        await Promise.all(backgroundJobs);
+    }
+};
+```
+
+But for this kind of purposes, `waitUntil` can be a better choice.
+
+## Background jobs
+
+If you have background jobs that need to be completed before the environment is shut down.
+`waitUntil` is better choice than `onDispose`. In this case, those jobs will keep running in the
+background but in case of disposal, they will be awaited. `waitUntil` works so similar to
+[Cloudflare Workers' `waitUntil` function.](https://developers.cloudflare.com/workers/runtime-apis/handlers/fetch/#parameters).
+
+But GraphQL Yoga handles `waitUntil` even if it is not provided by the environment.
+
+```ts
+const yoga = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      greetings(name: String!): String
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: (_, args, context) => {
+        // This does not block the response
+        context.waitUntil(
+          fetch('http://my-analytics.com/analytics', {
+            method: 'POST',
+            body: JSON.stringify({
+              name: args.name,
+              userAgent: context.request.headers.get('User-Agent')
+            })
+          })
+        )
+        return `Hello, ${args.name}`
+      }
+    }
+  }
+})
+
+const res = await yoga.fetch('http://localhost:4000/graphql', {
+  query: /* GraphQL */ `
+    query {
+      greetings(name: "John")
+    }
+  `
+})
+
+console.log(await res.json()) // { data: { greetings: "Hello, John" } }
+
+await yoga.dispose()
+// The fetch request will be awaited here
+```

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -139,7 +139,7 @@ createServer(
 
 </Tabs>
 
-## Disposable Plugins w/ `onDispose` hook
+## Plugin Disposal
 
 If you have plugins that need some internal resources to be disposed of, you can use the `onDispose`
 hook to dispose of them. This hook will be invoked when the GraphQL Yoga instance is disposed like

--- a/website/src/pages/docs/features/explicit-resource-management.mdx
+++ b/website/src/pages/docs/features/explicit-resource-management.mdx
@@ -225,6 +225,3 @@ await yoga.dispose()
 // The fetch request will be awaited here
 ```
 
-```
-
-```


### PR DESCRIPTION
After the discussion with @n1ru4l ;
Some changes are done in `@whatwg-node/server`, so in order to configure the new feature (including the new hook);

- Allow to configure server adapter from Yoga options such as `disposeOnProcessTerminate`
- Allow to use the new hook
- Document `dispose` method, `onDispose` hook, `ctx.waitUntil` and everything related to the things related to the resource management and graceful shutdown

cc @EmrysMyrddin about https://github.com/graphql-hive/console/pull/6128