### PR TITLE
Mark `createLRUCache` as an internal utility

### DIFF
--- a/.changeset/thirty-jokes-compare.md
+++ b/.changeset/thirty-jokes-compare.md
@@ -1,0 +1,6 @@
+---
+'graphql-yoga': patch
+---
+
+Mark `createLRUCache` utility as deprecated, and export it as `_createLRUCache` marking it as an
+internal utility

--- a/packages/graphql-yoga/src/index.ts
+++ b/packages/graphql-yoga/src/index.ts
@@ -10,7 +10,7 @@ export * from './subscription.js';
 export * from './types.js';
 export { maskError } from './utils/mask-error.js';
 export { type OnParamsEventPayload } from './plugins/types.js';
-export { createLRUCache } from './utils/create-lru-cache.js';
+export { _createLRUCache, createLRUCache } from './utils/create-lru-cache.js';
 export { mergeSchemas } from '@graphql-tools/schema';
 export {
   // Handy type utils

--- a/packages/graphql-yoga/src/plugins/use-parser-and-validation-cache.ts
+++ b/packages/graphql-yoga/src/plugins/use-parser-and-validation-cache.ts
@@ -1,6 +1,6 @@
 import type { DocumentNode, GraphQLError, GraphQLSchema, validate, ValidationRule } from 'graphql';
 import type { AfterValidateHook } from '@envelop/core';
-import { createLRUCache } from '../utils/create-lru-cache.js';
+import { _createLRUCache } from '../utils/create-lru-cache.js';
 import type { Plugin } from './types.js';
 
 interface Cache<T> {
@@ -15,13 +15,13 @@ export interface ParserAndValidationCacheOptions {
 }
 
 export function useParserAndValidationCache({
-  documentCache = createLRUCache(),
-  errorCache = createLRUCache(),
+  documentCache = _createLRUCache(),
+  errorCache = _createLRUCache(),
   validationCache = true,
 }: // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 ParserAndValidationCacheOptions): Plugin<{}> {
   const validationCacheByRules =
-    createLRUCache<WeakMap<GraphQLSchema, WeakMap<DocumentNode, GraphQLError[]>>>();
+    _createLRUCache<WeakMap<GraphQLSchema, WeakMap<DocumentNode, GraphQLError[]>>>();
   return {
     onParse({ params, setParsedDocument }) {
       const strDocument = params.source.toString();

--- a/packages/graphql-yoga/src/utils/create-lru-cache.ts
+++ b/packages/graphql-yoga/src/utils/create-lru-cache.ts
@@ -1,18 +1,47 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 import { LRUCache as LRU } from 'lru-cache';
 
+/**
+ * @deprecated In the next major, `createLRUCache` will be renamed to `_createLRUCache`,
+ * and the current `createLRUCache` will be removed.
+ */
+export const createLRUCache = _createLRUCache;
+
+/**
+ * @deprecated In the next major, `LRUCacheOptions` will be renamed to `_LRUCacheOptions`,
+ * and the current `LRUCacheOptions` will be removed.
+ */
+export type LRUCacheOptions = _LRUCacheOptions;
+
+/**
+ * @deprecated In the next major, `LRUCache` will be renamed to `_LRUCache`,
+ * and the current `LRUCache` will be removed.
+ */
+export type LRUCache<T extends {}> = _LRUCache<T>;
+
 const DEFAULT_MAX = 1024;
 const DEFAULT_TTL = 3_600_000;
 
-export type LRUCache<T extends {}> = LRU<string, T>;
-export interface LRUCacheOptions {
+/**
+ * @internal This is an internal utility, and you should use it with your own risk.
+ * This utility can have breaking changes in the future.
+ */
+export type _LRUCache<T extends {}> = LRU<string, T>;
+/**
+ * @internal This is an internal utility, and you should use it with your own risk.
+ * This utility can have breaking changes in the future.
+ */
+export interface _LRUCacheOptions {
   max?: number;
   ttl?: number;
 }
-
-export function createLRUCache<T extends {}>({
+/**
+ * @internal This is an internal utility, and you should use it with your own risk.
+ * This utility can have breaking changes in the future.
+ */
+export function _createLRUCache<T extends {}>({
   max = DEFAULT_MAX,
   ttl = DEFAULT_TTL,
-}: LRUCacheOptions = {}) {
+}: _LRUCacheOptions = {}) {
   return new LRU<string, T>({ max, ttl });
 }


### PR DESCRIPTION
Mark `createLRUCache` utility as deprecated, and export it as `_createLRUCache` marking it as an
internal utility