### PR TITLE
enhance(jwt): `WebSockets` support

### DIFF
--- a/.changeset/rich-goats-rescue.md
+++ b/.changeset/rich-goats-rescue.md
@@ -3,7 +3,7 @@
 ---
 
 - Do not throw when \`request\` is not available in the context, it can be a WebSockets connection
-- Export helper `extractFromConnectionParams` to get the token from WebSocket `connectionParams` when GraphQL WS is used
+- Export helper `extractFromConnectionParams` to get the token from WebSocket `connectionParams` when GraphQL WS is used like [here](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#graphql-over-websocket-protocol-via-graphql-ws)
 
 ```ts
 import { extractFromConnectionParams, extractFromHeader, useJWT } from '@graphql-yoga/plugin-jwt'

--- a/.changeset/rich-goats-rescue.md
+++ b/.changeset/rich-goats-rescue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-jwt': patch
+---
+
+Do not throw when \`request\` is not available in the context, it can be a WebSockets connection

--- a/.changeset/rich-goats-rescue.md
+++ b/.changeset/rich-goats-rescue.md
@@ -2,4 +2,23 @@
 '@graphql-yoga/plugin-jwt': patch
 ---
 
-Do not throw when \`request\` is not available in the context, it can be a WebSockets connection
+- Do not throw when \`request\` is not available in the context, it can be a WebSockets connection
+- Export helper `extractFromConnectionParams` to get the token from WebSocket `connectionParams` when GraphQL WS is used
+
+```ts
+import { extractFromConnectionParams, extractFromHeader, useJWT } from '@graphql-yoga/plugin-jwt'
+
+const yoga = createYoga({
+  // ...
+  plugins: [
+    useJWT({
+      // So it will look for the token in the connectionParams.my-token field in case of a WebSockets connection
+      // It will check WS params and headers, and get the available one
+      lookupLocations: [
+        extractFromConnectionParams({ name: 'my-token' }), 
+        extractFromHeader({ name: 'authorization', prefix: 'Bearer ' })
+      ]
+    })
+  ]
+})
+```

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "packages/**/src/**/*.{ts,tsx}": [
       "cross-env \"ESLINT_USE_FLAT_CONFIG=false\" eslint --fix"
     ],
-    "**/*.{ts,tsx,graphql,yml,yaml,md,json,html,mdx,prettierignore,eslintignore,js,mjs,cjs}": [
+    "**/*.{ts,tsx,graphql,yml,yaml,md,json,html,mdx,prettierignore,eslintignore,js,mjs,cjs,md}": [
       "prettier --write"
     ]
   },

--- a/packages/plugins/jwt/package.json
+++ b/packages/plugins/jwt/package.json
@@ -48,9 +48,12 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.0",
+    "@types/ws": "^8.5.13",
     "graphql": "16.10.0",
     "graphql-scalars": "^1.22.2",
-    "graphql-yoga": "workspace:*"
+    "graphql-ws": "5.16.0",
+    "graphql-yoga": "workspace:*",
+    "ws": "^8.18.0"
   },
   "publishConfig": {
     "directory": "dist",

--- a/packages/plugins/jwt/src/__tests__/jwt.spec.ts
+++ b/packages/plugins/jwt/src/__tests__/jwt.spec.ts
@@ -647,9 +647,8 @@ describe('jwt plugin', () => {
 
     useServer(
       {
-         
         execute: (args: any) => args.execute(args),
-         
+
         subscribe: (args: any) => args.subscribe(args),
         onSubscribe: async (ctx, msg) => {
           const { schema, execute, subscribe, contextFactory, parse, validate } =

--- a/packages/plugins/jwt/src/__tests__/jwt.spec.ts
+++ b/packages/plugins/jwt/src/__tests__/jwt.spec.ts
@@ -1,14 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createHmac } from 'node:crypto';
-import { createServer } from 'node:http';
+import { createServer, Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { createClient } from 'graphql-ws';
+import { useServer } from 'graphql-ws/lib/use/ws';
 import { createSchema, createYoga, Plugin } from 'graphql-yoga';
 import jwt, { Algorithm, SignOptions } from 'jsonwebtoken';
+import WebSocket from 'ws';
 import { useCookies } from '@whatwg-node/server-plugin-cookies';
 import { JwtPluginOptions } from '../config';
 import { useJWT } from '../plugin';
 import {
   createInlineSigningKeyProvider,
   createRemoteJwksSigningKeyProvider,
+  extractFromConnectionParams,
   extractFromCookie,
   extractFromHeader,
 } from '../utils';
@@ -43,6 +48,14 @@ I3OrgFkoqk03cpX4AL2GYC2ejytAqboL6pFTfmTgg2UtvKIeaTyF
 `;
 
 describe('jwt plugin', () => {
+  let server: Server | undefined;
+  afterEach(async () => {
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close(err => (err ? reject(err) : resolve()));
+      });
+    }
+  });
   test('incoming http request is reject when auth token is not present', async () => {
     const test = createTestServer({
       signingKeyProviders: [createInlineSigningKeyProvider('topsecret')],
@@ -603,6 +616,104 @@ describe('jwt plugin', () => {
     // no token is passed
     response = await test.queryWithoutAuth();
     expect(response.status).toBe(401);
+  });
+
+  test('handles GraphQL WS requests', async () => {
+    expect.assertions(2);
+    const secret = 'topsecret';
+    const test = createTestServer({
+      signingKeyProviders: [createInlineSigningKeyProvider(secret)],
+      tokenLookupLocations: [
+        extractFromHeader({
+          name: 'Authorization',
+          prefix: 'Bearer',
+        }),
+        extractFromConnectionParams({
+          name: 'token',
+        }),
+      ],
+    });
+    const token = buildJWT({ sub: '123' }, { key: secret }, '');
+
+    // token in header is valid
+    const response = await test.queryWithAuth(`Bearer ${token}`);
+    expect(response.status).toBe(200);
+
+    server = createServer(test.yoga);
+    const wss = new WebSocket.Server({
+      server,
+      path: test.yoga.graphqlEndpoint,
+    });
+
+    useServer(
+      {
+         
+        execute: (args: any) => args.execute(args),
+         
+        subscribe: (args: any) => args.subscribe(args),
+        onSubscribe: async (ctx, msg) => {
+          const { schema, execute, subscribe, contextFactory, parse, validate } =
+            test.yoga.getEnveloped({
+              ...ctx,
+              req: ctx.extra.request,
+              socket: ctx.extra.socket,
+              params: msg.payload,
+            });
+
+          const args = {
+            schema,
+            operationName: msg.payload.operationName,
+            document: parse(msg.payload.query),
+            variableValues: msg.payload.variables,
+            contextValue: await contextFactory(),
+            execute,
+            subscribe,
+          };
+
+          const errors = validate(args.schema, args.document);
+          if (errors.length) return errors;
+          return args;
+        },
+      },
+      wss,
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      server?.once('error', err => reject(err));
+      server?.listen(0, () => resolve());
+    });
+
+    const url = `ws://localhost:${(server.address() as AddressInfo).port}${test.yoga.graphqlEndpoint}`;
+
+    const client = createClient({
+      webSocketImpl: WebSocket,
+      url,
+      retryAttempts: 0,
+      connectionParams: {
+        token,
+      },
+    });
+
+    const iterator = client.iterate({
+      query: '{ ctx }',
+    });
+    for await (const result of iterator) {
+      expect(result).toMatchObject({
+        data: {
+          ctx: {
+            jwt: {
+              payload: {
+                sub: '123',
+              },
+              token: {
+                value: token,
+              },
+            },
+          },
+        },
+      });
+    }
+    await client.dispose();
   });
 });
 

--- a/packages/plugins/jwt/src/config.ts
+++ b/packages/plugins/jwt/src/config.ts
@@ -4,11 +4,15 @@ import { extractFromHeader } from './utils.js';
 
 type AtleastOneItem<T> = [T, ...T[]];
 
-export type ExtractTokenFunction = (params: {
+export type ExtractTokenFunctionParams = {
   request: Request;
-  serverContext: object | undefined;
+  serverContext: Record<string, unknown>;
   url: URL;
-}) => PromiseOrValue<undefined | { token: string; prefix?: string }>;
+};
+
+export type ExtractTokenFunction = (
+  params: ExtractTokenFunctionParams,
+) => PromiseOrValue<undefined | { token: string; prefix?: string }>;
 
 export type GetSigningKeyFunction = (kid?: string) => Promise<string> | string;
 

--- a/packages/plugins/jwt/src/index.ts
+++ b/packages/plugins/jwt/src/index.ts
@@ -2,6 +2,7 @@ export type { JwtPluginOptions, ExtractTokenFunction, GetSigningKeyFunction } fr
 export {
   extractFromCookie,
   extractFromHeader,
+  extractFromConnectionParams,
   createInlineSigningKeyProvider,
   createRemoteJwksSigningKeyProvider,
 } from './utils.js';

--- a/packages/plugins/jwt/src/plugin.ts
+++ b/packages/plugins/jwt/src/plugin.ts
@@ -1,12 +1,18 @@
-import type { Plugin, YogaLogger } from 'graphql-yoga';
-import jsonwebtoken, { type Jwt, type JwtPayload, type VerifyOptions } from 'jsonwebtoken';
-import { type OnRequestParseEventPayload } from 'packages/graphql-yoga/src/plugins/types.js';
-import { normalizeConfig, type JwtPluginOptions } from './config.js';
-import '@whatwg-node/server-plugin-cookies';
 import { GraphQLError } from 'graphql';
+import type { FetchAPI, Plugin, YogaLogger } from 'graphql-yoga';
+import jsonwebtoken, { type Jwt, type JwtPayload, type VerifyOptions } from 'jsonwebtoken';
+import { ExtractTokenFunctionParams, normalizeConfig, type JwtPluginOptions } from './config.js';
 import { badRequestError, unauthorizedError } from './utils.js';
 
 export type JWTExtendContextFields = {
+  payload: JwtPayload;
+  token: {
+    value: string;
+    prefix?: string;
+  };
+};
+
+type PluginPayload = {
   payload: JwtPayload;
   token: {
     value: string;
@@ -19,17 +25,10 @@ export function useJWT(options: JwtPluginOptions): Plugin<{
 }> {
   let logger: YogaLogger;
   const normalizedOptions = normalizeConfig(options);
-  const payloadByRequest = new WeakMap<
-    Request,
-    {
-      payload: JwtPayload;
-      token: {
-        value: string;
-        prefix?: string;
-      };
-    }
-  >();
-  const lookupToken = async (payload: OnRequestParseEventPayload<object>) => {
+  const payloadByContext = new WeakMap<object, PluginPayload>();
+  const payloadByRequest = new WeakMap<Request, PluginPayload>();
+  const validatedRequestAndContextSet = new WeakSet<object>();
+  const lookupToken = async (payload: ExtractTokenFunctionParams) => {
     for (const lookupLocation of normalizedOptions.tokenLookupLocations) {
       const token = await lookupLocation(payload);
 
@@ -57,104 +56,140 @@ export function useJWT(options: JwtPluginOptions): Plugin<{
     return null;
   };
 
-  return {
-    onYogaInit({ yoga }) {
-      logger = yoga.logger;
-    },
-    async onRequestParse(payload) {
-      // Try to find token in request, and reject the request if needed.
-      const lookupResult = await lookupToken(payload);
+  const lookupAndValidate = async (payload: ExtractTokenFunctionParams) => {
+    // Mark the context and request as validated, so we don't process them again.
+    if (payload.serverContext) {
+      if (validatedRequestAndContextSet.has(payload.serverContext)) {
+        return;
+      }
+      validatedRequestAndContextSet.add(payload.serverContext);
+    }
+    if (payload.request) {
+      if (validatedRequestAndContextSet.has(payload.request)) {
+        return;
+      }
+      validatedRequestAndContextSet.add(payload.request);
+    }
+    // Try to find token in request, and reject the request if needed.
+    const lookupResult = await lookupToken(payload);
 
-      if (!lookupResult) {
-        // If token is missing, we can reject the request based on the configuration.
-        if (normalizedOptions.reject.missingToken) {
-          logger.debug(`Token is missing in incoming HTTP request, JWT plugin failed to locate.`);
-          throw unauthorizedError(`Unauthenticated`);
+    if (!lookupResult) {
+      // If token is missing, we can reject the request based on the configuration.
+      if (normalizedOptions.reject.missingToken) {
+        logger.debug(`Token is missing in incoming HTTP request, JWT plugin failed to locate.`);
+        throw unauthorizedError(`Unauthenticated`);
+      }
+
+      return;
+    }
+
+    try {
+      // Decode the token first, in order to get the key id to use.
+      let decodedToken: Jwt | null;
+      try {
+        decodedToken = jsonwebtoken.decode(lookupResult.token, { complete: true });
+      } catch (e) {
+        logger.warn(`Failed to decode JWT authentication token: `, e);
+        throw badRequestError(`Invalid authentication token provided`);
+      }
+
+      if (!decodedToken) {
+        logger.warn(
+          `Failed to extract payload from incoming token, please make sure the token is a valid JWT.`,
+        );
+
+        throw badRequestError(`Invalid authentication token provided`);
+      }
+
+      // Fetch the signing key based on the key id.
+      const signingKey = await getSigningKey(decodedToken?.header.kid);
+
+      if (!signingKey) {
+        logger.warn(
+          `Signing key is not available for the key id: ${decodedToken?.header.kid}. Please make sure signing key providers are configured correctly.`,
+        );
+
+        throw Error(`Authentication is not available at the moment.`);
+      }
+
+      // Verify the token with the signing key.
+      const verified = await verify(
+        logger,
+        lookupResult.token,
+        signingKey,
+        normalizedOptions.tokenVerification,
+      );
+
+      if (!verified) {
+        logger.debug(`Token failed to verify, JWT plugin failed to authenticate.`);
+        throw unauthorizedError(`Unauthenticated`);
+      }
+
+      if (verified) {
+        // Link the verified payload with the request (see `onContextBuilding` for the reading part)
+        const pluginPayload: PluginPayload = {
+          payload: verified,
+          token: {
+            value: lookupResult.token,
+            prefix: lookupResult.prefix,
+          },
+        };
+        if (payload.request) {
+          payloadByRequest.set(payload.request, pluginPayload);
+        } else {
+          payloadByContext.set(payload.serverContext, pluginPayload);
+        }
+      }
+    } catch (e) {
+      // User-facing errors should be handled based on the configuration.
+      // These errors are handled based on the value of "reject.invalidToken" config.
+      if (e instanceof GraphQLError) {
+        if (normalizedOptions.reject.invalidToken) {
+          throw e;
         }
 
         return;
       }
 
-      try {
-        // Decode the token first, in order to get the key id to use.
-        let decodedToken: Jwt | null;
-        try {
-          decodedToken = jsonwebtoken.decode(lookupResult.token, { complete: true });
-        } catch (e) {
-          logger.warn(`Failed to decode JWT authentication token: `, e);
-          throw badRequestError(`Invalid authentication token provided`);
-        }
+      // Server/internal errors should be thrown, so they can be handled by the error handler and be masked.
+      throw e;
+    }
+  };
 
-        if (!decodedToken) {
-          logger.warn(
-            `Failed to extract payload from incoming token, please make sure the token is a valid JWT.`,
-          );
-
-          throw badRequestError(`Invalid authentication token provided`);
-        }
-
-        // Fetch the signing key based on the key id.
-        const signingKey = await getSigningKey(decodedToken?.header.kid);
-
-        if (!signingKey) {
-          logger.warn(
-            `Signing key is not available for the key id: ${decodedToken?.header.kid}. Please make sure signing key providers are configured correctly.`,
-          );
-
-          throw Error(`Authentication is not available at the moment.`);
-        }
-
-        // Verify the token with the signing key.
-        const verified = await verify(
-          logger,
-          lookupResult.token,
-          signingKey,
-          normalizedOptions.tokenVerification,
-        );
-
-        if (!verified) {
-          logger.debug(`Token failed to verify, JWT plugin failed to authenticate.`);
-          throw unauthorizedError(`Unauthenticated`);
-        }
-
-        if (verified) {
-          // Link the verified payload with the request (see `onContextBuilding` for the reading part)
-          payloadByRequest.set(payload.request, {
-            payload: verified,
-            token: {
-              value: lookupResult.token,
-              prefix: lookupResult.prefix,
-            },
-          });
-        }
-      } catch (e) {
-        // User-facing errors should be handled based on the configuration.
-        // These errors are handled based on the value of "reject.invalidToken" config.
-        if (e instanceof GraphQLError) {
-          if (normalizedOptions.reject.invalidToken) {
-            throw e;
-          }
-
-          return;
-        }
-
-        // Server/internal errors should be thrown, so they can be handled by the error handler and be masked.
-        throw e;
-      }
+  let fetchAPI: FetchAPI;
+  return {
+    onYogaInit({ yoga }) {
+      logger = yoga.logger;
+      fetchAPI = yoga.fetchAPI;
     },
-    onContextBuilding({ context, extendContext }) {
+    async onRequestParse(payload) {
+      await lookupAndValidate(payload);
+    },
+    async onContextBuilding({ context, extendContext }) {
       if (normalizedOptions.extendContextFieldName === null) {
         return;
       }
 
-      if (context.request == null) {
-        throw new Error(
-          'Request is not available on context! Make sure you use this plugin with GraphQL Yoga.',
-        );
+      // Get the payload and inject it into the GraphQL context.
+      let result: PluginPayload | undefined;
+      if (context.request) {
+        result = payloadByRequest.get(context.request);
+      }
+      result ||= payloadByContext.get(context);
+      if (!result) {
+        // If it is not Yoga request(GraphQL WS connection), we need to lookup and validate the token still
+        await lookupAndValidate({
+          request: context.request,
+          get url() {
+            return new fetchAPI.URL(context.request.url);
+          },
+          serverContext: context,
+        });
+        result = context.request
+          ? payloadByRequest.get(context.request)
+          : payloadByContext.get(context);
       }
 
-      // Get the payload and inject it into the GraphQL context.
-      const result = payloadByRequest.get(context.request);
       if (result && normalizedOptions.extendContextFieldName) {
         extendContext({
           [normalizedOptions.extendContextFieldName]: {

--- a/packages/plugins/jwt/src/utils.ts
+++ b/packages/plugins/jwt/src/utils.ts
@@ -7,6 +7,10 @@ export function extractFromHeader(options: {
   prefix?: string;
 }): ExtractTokenFunction {
   return ({ request }) => {
+    if (!request) {
+      return;
+    }
+
     const header = request.headers.get(options.name);
 
     if (header == null) {
@@ -46,6 +50,9 @@ export function extractFromHeader(options: {
 
 export function extractFromCookie(options: { name: string }): ExtractTokenFunction {
   return async ({ request }) => {
+    if (!request) {
+      return;
+    }
     const cookieStore = request.cookieStore;
 
     if (!cookieStore) {
@@ -64,6 +71,29 @@ export function extractFromCookie(options: { name: string }): ExtractTokenFuncti
       prefix: undefined,
       token: cookie.value,
     };
+  };
+}
+
+export function extractFromConnectionParams(options: { name: string }): ExtractTokenFunction {
+  return ({ serverContext }) => {
+    if (
+      typeof serverContext?.['connectionParams'] === 'object' &&
+      serverContext['connectionParams'] != null &&
+      options.name in serverContext['connectionParams'] &&
+      typeof serverContext['connectionParams'] === 'object' &&
+      serverContext['connectionParams'] != null &&
+      options.name in serverContext['connectionParams']
+    ) {
+      // @ts-expect-error - TS doesn't understand the type guard above
+      const token = serverContext['connectionParams'][options.name];
+      if (typeof token === 'string') {
+        return {
+          prefix: undefined,
+          token,
+        };
+      }
+    }
+    return;
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1976,15 +1976,24 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.0
         version: 9.0.7
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.5.13
       graphql:
         specifier: 16.10.0
         version: 16.10.0
       graphql-scalars:
         specifier: ^1.22.2
         version: 1.24.0(graphql@16.10.0)
+      graphql-ws:
+        specifier: 5.16.0
+        version: 5.16.0(graphql@16.10.0)
       graphql-yoga:
         specifier: workspace:*
         version: link:../../graphql-yoga/dist
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.0
     publishDirectory: dist
 
   packages/plugins/persisted-operations:
@@ -26671,7 +26680,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -26700,7 +26709,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/website/src/pages/docs/features/jwt.mdx
+++ b/website/src/pages/docs/features/jwt.mdx
@@ -183,10 +183,31 @@ const yoga = createYoga({
   // ...
   plugins: [
     useJWT({
-      // So it will look for the token in the connectionParams.my-token field in case of a WebSockets connection
-      lookupLocations: [extractFromConnectionParams({ name: 'my-token' })]
+      // So it will look for the token in the connectionParams.token field in case of a WebSockets connection
+      lookupLocations: [extractFromConnectionParams({ name: 'token' })]
     })
   ]
+})
+```
+
+##### Client-side example
+
+After setting up JWT Plugin and Yoga server with WebSocket support, you can pass `token` from the
+client like below with `graphql-ws` client.
+
+```ts
+import { createClient } from 'graphql-ws'
+import { getCurrentToken } from './my-auth'
+
+const client = createClient({
+  url: 'ws://localhost:4000/graphql',
+  // The object returned by this function will be passed to the server as `connectionParams` to be used by the JWT plugin
+  connectionParams: async () => {
+    return {
+      // the token is fetched from the storage
+      token: await getCurrentToken()
+    }
+  }
 })
 ```
 

--- a/website/src/pages/docs/features/jwt.mdx
+++ b/website/src/pages/docs/features/jwt.mdx
@@ -173,7 +173,8 @@ const yoga = createYoga({
 #### WebSockets Connection Params
 
 You can configure the plugin to look for the token in the connection params of a WebSocket
-connection if you use `graphql-ws`.
+connection if you use `graphql-ws` as
+[here](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#graphql-over-websocket-protocol-via-graphql-ws).
 
 ```ts
 import { extractFromConnectionParams, useJWT } from '@graphql-yoga/plugin-jwt'

--- a/website/src/pages/docs/features/jwt.mdx
+++ b/website/src/pages/docs/features/jwt.mdx
@@ -170,6 +170,25 @@ const yoga = createYoga({
 })
 ```
 
+#### WebSockets Connection Params
+
+You can configure the plugin to look for the token in the connection params of a WebSocket
+connection if you use `graphql-ws`.
+
+```ts
+import { extractFromConnectionParams, useJWT } from '@graphql-yoga/plugin-jwt'
+
+const yoga = createYoga({
+  // ...
+  plugins: [
+    useJWT({
+      // So it will look for the token in the connectionParams.my-token field in case of a WebSockets connection
+      lookupLocations: [extractFromConnectionParams({ name: 'my-token' })]
+    })
+  ]
+})
+```
+
 #### Custom Function
 
 You can configure the plugin to use a custom function to look for the token:


### PR DESCRIPTION
- Support non-Yoga server implementations with Envelop hooks, so it works with GraphQL WS.
- Export `extractFromConnectionParams` helper to extract tokens from the connection params of the WebSocket connection

Fixes https://github.com/graphql-hive/gateway/issues/366