### PR TITLE
fix(apollo-usage-report): wait for hashing schema before preparing the report

### DIFF
--- a/.changeset/hungry-melons-admire.md
+++ b/.changeset/hungry-melons-admire.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-apollo-usage-report': patch
+---
+
+Wait for setting schemaId to prevent race condition

--- a/packages/plugins/apollo-usage-report/src/index.ts
+++ b/packages/plugins/apollo-usage-report/src/index.ts
@@ -174,7 +174,8 @@ export function useApolloUsageReport(options: ApolloUsageReportOptions = {}): Pl
 
           for (const trace of reqCtx.traces.values()) {
             if (!trace.schemaId || !trace.operationKey) {
-              throw new TypeError('Misformed trace, missing operation key or schema id');
+              logger.debug('Misformed trace, missing operation key or schema id');
+              continue;
             }
 
             const clientName = clientNameFactory(request);

--- a/packages/plugins/apollo-usage-report/src/index.ts
+++ b/packages/plugins/apollo-usage-report/src/index.ts
@@ -217,7 +217,7 @@ export async function hashSHA256(
   str: string,
   api: {
     crypto: Crypto;
-    TextEncoder: typeof TextEncoder;
+    TextEncoder: (typeof globalThis)['TextEncoder'];
   } = globalThis,
 ) {
   const { crypto, TextEncoder } = api;


### PR DESCRIPTION
Wait for setting schemaId to prevent race condition, previously it wasn't waiting so sometimes at the beginning, `Misformed trace, missing operation key or schema id` was thrown