### PR TITLE
fix: Update koa's integration guide for body parsing

### DIFF
--- a/website/src/pages/docs/integrations/integration-with-koa.mdx
+++ b/website/src/pages/docs/integrations/integration-with-koa.mdx
@@ -30,8 +30,8 @@ const yoga = createYoga<Koa.ParameterizedContext>()
 // Bind GraphQL Yoga to `/graphql` endpoint
 app.use(async ctx => {
   // Second parameter adds Koa's context into GraphQL Context
-  // Make sure it is not `ctx.request` not `ctx.req`
-  // Because sometimes Koa parses the body and puts it in `ctx.req`
+  // If you use any body parsing middleware in your applicatino,
+  // Make sure it is `ctx.request` and not `ctx.req`
   const response = await yoga.handleNodeRequestAndResponse(ctx.request, ctx.res, ctx)
 
   // Set status code

--- a/website/src/pages/docs/integrations/integration-with-koa.mdx
+++ b/website/src/pages/docs/integrations/integration-with-koa.mdx
@@ -30,7 +30,7 @@ const yoga = createYoga<Koa.ParameterizedContext>()
 // Bind GraphQL Yoga to `/graphql` endpoint
 app.use(async ctx => {
   // Second parameter adds Koa's context into GraphQL Context
-  // If you use any body parsing middleware in your applicatino,
+  // If you use any body parsing middleware in your application,
   // Make sure it is `ctx.request` and not `ctx.req`
   const response = await yoga.handleNodeRequestAndResponse(ctx.request, ctx.res, ctx)
 


### PR DESCRIPTION
## Why

I saw that these docs were updated recently, and this is also something we were struggling with in one of our applications. I noticed that we do need to use `ctx.request`, but the documentation was a bit confusing - it mentioned:

> Make sure it is **not** `ctx.request` **not** `ctx.req`

(two negatives)

We currently use [koa-body](https://www.npmjs.com/package/koa-body#options), and by **default**, it does:
- `patchNode: false` =  not place parsed body in `ctx.req` (Node.js `IncomingMessage` type)
- `patchKoa: true` = does place parsed body in `ctx.request` (Koa's [Request](https://github.com/koajs/koa/blob/master/docs/api/request.md), abstraction of Node's request)

From the investigation, it's known that we must use the `ctx.request` object that does have the parsed body.

Without koa-body, either one works.

## What
- Clarifying the docs about usage with koa body parsers