### PR TITLE
fix(jwt/introspection): ability to disable introspection based on JWT result

### DIFF
--- a/.changeset/funny-baboons-prove.md
+++ b/.changeset/funny-baboons-prove.md
@@ -1,0 +1,5 @@
+---
+'@graphql-yoga/plugin-jwt': patch
+---
+
+Ensure the JWT context has been added before any GraphQL Execution hooks when the plugin is used via Yoga

--- a/.changeset/tasty-seas-juggle.md
+++ b/.changeset/tasty-seas-juggle.md
@@ -1,0 +1,26 @@
+---
+'@graphql-yoga/plugin-disable-introspection': minor
+---
+
+Expose the server context as the second parameter, so introspection can be disabled based on the
+context
+
+```ts "Disabling GraphQL schema introspection based on the context" {7}
+import { createYoga } from 'graphql-yoga'
+import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'
+
+// Provide your schema
+const yoga = createYoga({
+  graphiql: false,
+  plugins: [
+    useDisableIntrospection({
+      isDisabled: (_req, ctx) => !ctx.jwt,
+    })
+  ]
+})
+
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```

--- a/packages/plugins/disable-introspection/src/index.ts
+++ b/packages/plugins/disable-introspection/src/index.ts
@@ -5,7 +5,9 @@ type UseDisableIntrospectionArgs = {
   isDisabled?: (request: Request, context: Record<string, unknown>) => PromiseOrValue<boolean>;
 };
 
-export const useDisableIntrospection = (props?: UseDisableIntrospectionArgs): Plugin => {
+export function useDisableIntrospection<TContext extends Record<string, unknown>>(
+  props?: UseDisableIntrospectionArgs,
+): Plugin<TContext> {
   const store = new WeakMap<Request, boolean>();
   return {
     async onRequestParse({ request, serverContext }) {
@@ -19,4 +21,4 @@ export const useDisableIntrospection = (props?: UseDisableIntrospectionArgs): Pl
       }
     },
   };
-};
+}

--- a/packages/plugins/disable-introspection/src/index.ts
+++ b/packages/plugins/disable-introspection/src/index.ts
@@ -2,15 +2,14 @@ import { NoSchemaIntrospectionCustomRule } from 'graphql';
 import type { Plugin, PromiseOrValue } from 'graphql-yoga';
 
 type UseDisableIntrospectionArgs = {
-  isDisabled?: (request: Request) => PromiseOrValue<boolean>;
+  isDisabled?: (request: Request, context: Record<string, unknown>) => PromiseOrValue<boolean>;
 };
 
-const store = new WeakMap<Request, boolean>();
-
 export const useDisableIntrospection = (props?: UseDisableIntrospectionArgs): Plugin => {
+  const store = new WeakMap<Request, boolean>();
   return {
-    async onRequest({ request }) {
-      const isDisabled = props?.isDisabled ? await props.isDisabled(request) : true;
+    async onRequestParse({ request, serverContext }) {
+      const isDisabled = props?.isDisabled ? await props.isDisabled(request, serverContext) : true;
       store.set(request, isDisabled);
     },
     onValidate({ addValidationRule, context }) {

--- a/packages/plugins/jwt/src/config.ts
+++ b/packages/plugins/jwt/src/config.ts
@@ -6,8 +6,8 @@ type AtleastOneItem<T> = [T, ...T[]];
 
 export type ExtractTokenFunctionParams = {
   request: Request;
-  serverContext: Record<string, unknown>;
   url: URL;
+  serverContext: Record<string, unknown>;
 };
 
 export type ExtractTokenFunction = (

--- a/website/src/pages/docs/features/introspection.mdx
+++ b/website/src/pages/docs/features/introspection.mdx
@@ -76,11 +76,15 @@ via another auth plugin like [JWT Plugin](/docs/features/jwt).
 ```ts "Disabling GraphQL schema introspection based on the context" {7}
 import { createYoga } from 'graphql-yoga'
 import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'
+import { useJWT } from '@graphql-yoga/plugin-jwt'
 
 // Provide your schema
 const yoga = createYoga({
   graphiql: false,
   plugins: [
+    useJWT({
+      /* .. */
+    }),
     useDisableIntrospection({
       isDisabled: (_req, ctx) => !ctx.jwt
     })

--- a/website/src/pages/docs/features/introspection.mdx
+++ b/website/src/pages/docs/features/introspection.mdx
@@ -68,6 +68,31 @@ server.listen(4000, () => {
 })
 ```
 
+## Disable Introspection based on the context
+
+You can also disable introspection based on the context. This is useful when you want to disable it
+via another auth plugin like [JWT Plugin](/docs/features/jwt).
+
+```ts "Disabling GraphQL schema introspection based on the context" {7}
+import { createYoga } from 'graphql-yoga'
+import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'
+
+// Provide your schema
+const yoga = createYoga({
+  graphiql: false,
+  plugins: [
+    useDisableIntrospection({
+      isDisabled: (_req, ctx) => !ctx.jwt
+    })
+  ]
+})
+
+const server = createServer(yoga)
+server.listen(4000, () => {
+  console.info('Server is running on http://localhost:4000/graphql')
+})
+```
+
 ## Disabling Field Suggestions
 
 <Callout>

--- a/website/src/pages/docs/features/jwt.mdx
+++ b/website/src/pages/docs/features/jwt.mdx
@@ -404,3 +404,41 @@ const yoga = createYoga({
   ]
 })
 ```
+
+### Disable Introspection based on JWT
+
+If you disabled rejection on missing token and/or invalid token, you can disable introspection based
+on the validity of JWT token still. You can combine JWT plugin with
+[Disable Introspection plugin](/docs/features/introspection#disabling-introspection) in this case.
+
+```sh npm2yarn
+npm i @graphql-yoga/plugin-disable-introspection
+```
+
+Then you can use it like this:
+
+```ts
+import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'
+import { useJWT } from '@graphql-yoga/plugin-jwt'
+
+const yoga = createYoga({
+  // ...
+  plugins: [
+    useJWT({
+      reject: {
+        missingToken: false,
+        invalidToken: false
+      }
+    }),
+    useDisableIntrospection({
+      disableIf(_req, ctx) {
+        // If there is no JWT token(unauthorized), disable introspection
+        if (!ctx.jwt) {
+          return true
+        }
+        return false
+      }
+    })
+  ]
+})
+```


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-yoga/discussions/3614 so you can combine JWT plugin with introspection plugin in this case.

```ts
import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'
import { useJWT } from '@graphql-yoga/plugin-jwt'

const yoga = createYoga({
  // ...
  plugins: [
    useJWT({
      reject: {
        missingToken: false,
        invalidToken: false
      }
    }),
    useDisableIntrospection({
      disableIf(_req, ctx) {
        // If there is no JWT token(unauthorized), disable introspection
        if (!ctx.jwt) {
          return true
        }
        return false
      }
    })
  ]
})
```
The following changes are needed;

JWT Plugin changes;
Ensure the JWT context has been added before any GraphQL Execution hooks when the plugin is used via Yoga

Introspection plugin changes;
Expose the server context as the second parameter, so introspection can be disabled based on the
context

```ts "Disabling GraphQL schema introspection based on the context" {7}
import { createYoga } from 'graphql-yoga'
import { useDisableIntrospection } from '@graphql-yoga/plugin-disable-introspection'

// Provide your schema
const yoga = createYoga({
  graphiql: false,
  plugins: [
    useDisableIntrospection({
      isDisabled: (_req, ctx) => !ctx.jwt,
    })
  ]
})

const server = createServer(yoga)
server.listen(4000, () => {
  console.info('Server is running on http://localhost:4000/graphql')
})
```