### PR TITLE
feat: replace/wrap the logic `params` handled - `ParamsHandler`

### DIFF
--- a/.changeset/friendly-actors-brake.md
+++ b/.changeset/friendly-actors-brake.md
@@ -1,0 +1,20 @@
+---
+'graphql-yoga': minor
+---
+
+Now it is possible to replace or wrap the logic how `GraphQLParams` handled;
+
+By default Yoga calls Envelop to handle the parameters, but now you can replace it with your own logic.
+
+Example: Wrap the GraphQL handling pipeline in an `AsyncLocalStorage`
+
+```ts
+function myPlugin(): Plugin {
+  const context = new AsyncLocalStorage();
+  return {
+    onParams({ paramsHandler, setParamsHandler }) {
+      const store = { foo: 'bar' }
+      setParamsHandler(payload => context.run(store, paramsHandler, payload))
+   }
+}
+```

--- a/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
+++ b/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
@@ -1,5 +1,5 @@
 import { createSchema, createYoga, type Plugin } from '../src';
-import { ParamsHandler, ParamsHandlerPayload } from '../src/plugins/types';
+import type { ParamsHandlerPayload } from '../src/plugins/types';
 import { eventStream } from './utilities';
 
 test('onParams -> setResult to single execution result', async () => {

--- a/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
+++ b/packages/graphql-yoga/__tests__/plugin-hooks.spec.ts
@@ -1,4 +1,5 @@
 import { createSchema, createYoga, type Plugin } from '../src';
+import { ParamsHandler, ParamsHandlerPayload } from '../src/plugins/types';
 import { eventStream } from './utilities';
 
 test('onParams -> setResult to single execution result', async () => {
@@ -58,6 +59,42 @@ test('onParams -> setResult to event stream execution result', async () => {
     }
   }
   expect(counter).toBe(2);
+});
+
+test('onParams -> replaces the params handler correctly', async () => {
+  const paramsHandler = jest.fn((_payload: ParamsHandlerPayload<{}>) => ({
+    data: { hello: 'world' },
+  }));
+  const plugin: Plugin = {
+    async onParams({ setParamsHandler }) {
+      setParamsHandler(paramsHandler);
+    },
+  };
+
+  const yoga = createYoga({ plugins: [plugin] });
+
+  const params = {
+    query: '{ hello }',
+  };
+  const request = new yoga.fetchAPI.Request('http://yoga/graphql', {
+    method: 'POST',
+    body: JSON.stringify(params),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const serverContext = {};
+
+  const result = await yoga.fetch(request, serverContext);
+
+  expect(result.status).toBe(200);
+  const body = await result.json();
+  expect(body).toEqual({ data: { hello: 'world' } });
+  expect(paramsHandler).toHaveBeenCalledTimes(1);
+  expect(paramsHandler).toHaveBeenCalledWith(
+    expect.objectContaining({ params, request, context: expect.objectContaining(serverContext) }),
+  );
 });
 
 test('context value identity stays the same in all hooks', async () => {

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -138,6 +138,7 @@ export interface OnParamsEventPayload<TServerContext = Record<string, unknown>> 
 }
 
 export interface ParamsHandlerPayload<TServerContext> {
+  request: Request;
   params: GraphQLParams;
   context: TServerContext & ServerAdapterInitialContext & YogaInitialContext;
 }

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -123,13 +123,28 @@ export type OnParamsHook<TServerContext> = (
 ) => PromiseOrValue<void>;
 
 export interface OnParamsEventPayload<TServerContext = Record<string, unknown>> {
-  params: GraphQLParams;
   request: Request;
+
+  params: GraphQLParams;
   setParams: (params: GraphQLParams) => void;
+  paramsHandler: ParamsHandler<TServerContext>;
+
+  setParamsHandler: (handler: ParamsHandler<TServerContext>) => void;
+
   setResult: (result: ExecutionResult | AsyncIterable<ExecutionResult>) => void;
+
   fetchAPI: FetchAPI;
   context: TServerContext;
 }
+
+export interface ParamsHandlerPayload<TServerContext> {
+  params: GraphQLParams;
+  context: TServerContext & ServerAdapterInitialContext & YogaInitialContext;
+}
+
+export type ParamsHandler<TServerContext> = (
+  payload: ParamsHandlerPayload<TServerContext>,
+) => PromiseOrValue<ExecutionResult | AsyncIterable<ExecutionResult>>;
 
 export type OnResultProcess<TServerContext> = (
   payload: OnResultProcessEventPayload<TServerContext>,

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -49,6 +49,7 @@ import {
   OnRequestParseDoneHook,
   OnRequestParseHook,
   OnResultProcess,
+  ParamsHandler,
   Plugin,
   RequestParser,
   ResultProcessorInput,
@@ -462,6 +463,15 @@ export class YogaServer<
     }
   }
 
+  handleParams: ParamsHandler<TServerContext> = ({ context, params }) => {
+    const enveloped = this.getEnveloped(context);
+
+    return processGraphQLParams({
+      params,
+      enveloped,
+    });
+  };
+
   async getResultForParams(
     {
       params,
@@ -473,6 +483,7 @@ export class YogaServer<
     context: TServerContext,
   ) {
     let result: ExecutionResult | AsyncIterable<ExecutionResult> | undefined;
+    let paramsHandler = this.handleParams;
 
     try {
       for (const onParamsHook of this.onParamsHooks) {
@@ -481,6 +492,10 @@ export class YogaServer<
           request,
           setParams(newParams) {
             params = newParams;
+          },
+          paramsHandler,
+          setParamsHandler(newHandler) {
+            paramsHandler = newHandler;
           },
           setResult(newResult) {
             result = newResult;
@@ -503,12 +518,11 @@ export class YogaServer<
 
         Object.assign(context, additionalContext);
 
-        const enveloped = this.getEnveloped(context);
-
         this.logger.debug(`Processing GraphQL Parameters`);
-        result = await processGraphQLParams({
+
+        result = await paramsHandler({
           params,
-          enveloped,
+          context: context as TServerContext & YogaInitialContext,
         });
 
         this.logger.debug(`Processing GraphQL Parameters done.`);

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -546,10 +546,10 @@ export class YogaServer<
     }
 
     result ??= await paramsHandler({
-        request,
-        params,
-        context: context as TServerContext & YogaInitialContext,
-      });
+      request,
+      params,
+      context: context as TServerContext & YogaInitialContext,
+    });
 
     for (const onExecutionResult of this.onExecutionResultHooks) {
       await onExecutionResult({

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -371,7 +371,7 @@ export class YogaServer<
       ...(options?.plugins ?? []),
       // To make sure those are called at the end
       {
-        onPluginInit: ({ addPlugin }) => {
+        onPluginInit({ addPlugin }) {
           if (options?.parserAndValidationCache !== false) {
             addPlugin(
               // @ts-expect-error Add plugins has context but this hook doesn't care


### PR DESCRIPTION
Now it is possible to replace or wrap the logic how `GraphQLParams` handled;

By default Yoga calls Envelop to handle the parameters, but now you can replace it with your own logic.

Closes https://github.com/dotansimha/graphql-yoga/pull/3734

Fixes YOGA-2

Example: Wrap the GraphQL handling pipeline in an `AsyncLocalStorage`

```ts
function myPlugin(): Plugin {
  const context = new AsyncLocalStorage();
  return {
    onParams({ paramsHandler, setParamsHandler }) {
      const store = { foo: 'bar' }
      setParamsHandler(payload => context.run(store, paramsHandler, payload))
   }
}
```