### PR TITLE
Update Bun integration docs

### DIFF
--- a/website/src/content/docs/integrations/integration-with-bun.mdx
+++ b/website/src/content/docs/integrations/integration-with-bun.mdx
@@ -40,8 +40,10 @@ const yoga = createYoga({
 })
 
 const server = Bun.serve({
-  fetch: yoga.fetch
-})
+  routes: {
+    [yoga.graphqlEndpoint]: yoga.fetch,
+  },
+});
 
 console.info(
   `Server is running on ${new URL(


### PR DESCRIPTION
`fetch: yoga` returns a type error. `fetch: yoga.fetch` achieves expected behavior.