### PR TITLE
docs: `isDev` flag to control `originalError` field in the masked error extensions

### DIFF
--- a/website/src/content/docs/features/error-masking.mdx
+++ b/website/src/content/docs/features/error-masking.mdx
@@ -133,6 +133,16 @@ This will add a more detailed error with a proper stacktrace to the errors exten
 }
 ```
 
+If you use this environment variable but you want to disable this feature explicitly, you can configure it inside `createYoga` directly.
+
+```ts
+createYoga({
+  maskedErrors: {
+    isDev: false // This will prevent the masking to add `originalError` to `extensions` even if `NODE_ENV` is set to `development`
+  }
+})
+```
+
 ## Exposing expected errors
 
 Sometimes it is feasible to throw errors within your GraphQL resolvers whose message should be sent


### PR DESCRIPTION
It wasn't not clear how to enable/disable the exposure of `originalError` in the masked error extensions.

Related https://github.com/graphql-hive/graphql-yoga/issues/3330#issuecomment-3488686940

Related https://github.com/graphql-hive/graphql-yoga/issues/3894