### PR TITLE
fix(apollo-sandbox-renderer): avoid deprecated includeCookies option

### DIFF
--- a/.changeset/clever-ducks-report.md
+++ b/.changeset/clever-ducks-report.md
@@ -1,0 +1,6 @@
+---
+'@graphql-yoga/render-apollo-sandbox': patch
+---
+
+Avoid passing deprecated includeCookies option to Apollo Embedded Sandbox; use
+initialState.includeCookies

--- a/packages/render-apollo-sandbox/src/index.ts
+++ b/packages/render-apollo-sandbox/src/index.ts
@@ -17,10 +17,6 @@ export interface ApolloSandboxOptions {
    */
   endpointIsEditable?: boolean;
   /**
-   * You can set `includeCookies` to `true` if you instead want Sandbox to pass `{ credentials: 'include' }` for its requests.If you pass the `handleRequest` option, this option is ignored.Read more about the `fetch` API and credentials [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials).This config option is deprecated in favor of using the connection settings cookie toggle in Sandbox and setting the default value via `initialState.includeCookies`.
-   */
-  includeCookies?: boolean;
-  /**
    * An object containing additional options related to the state of the embedded Sandbox on page load.
    */
   initialState?: InitialState;
@@ -126,7 +122,6 @@ export function renderApolloSandbox(sandboxOpts?: ApolloSandboxOptions): GraphiQ
       ? JSON.stringify(graphiqlOpts.endpoint)
       : 'location.pathname';
     const finalOpts: ApolloSandboxOptions = {
-      includeCookies,
       ...sandboxOpts,
       initialState,
     };


### PR DESCRIPTION
Fixes #4326 

This PR removes `includeCookies` from the root options object passed to `new EmbeddedSandbox(...)` and keeps the default cookie behavior only in `initialState.includeCookies`.

Apollo recommends setting cookie defaults via `initialState.includeCookies` (and optionally exposing the UI toggle via `hideCookieToggle: false`). Passing `includeCookies` at the top-level is deprecated and overrides connection settings.
