### PR TITLE
feat: support modifying `graphqlEndpoint` after the initialization

### DIFF
--- a/.changeset/sixty-peaches-throw.md
+++ b/.changeset/sixty-peaches-throw.md
@@ -2,7 +2,7 @@
 'graphql-yoga': minor
 ---
 
-Support to change `graphqlEndpoint` after the initialization;
+Support changing `graphqlEndpoint` after initialization;
 
 ```ts
 const yoga = createYoga({

--- a/.changeset/sixty-peaches-throw.md
+++ b/.changeset/sixty-peaches-throw.md
@@ -1,0 +1,23 @@
+---
+'graphql-yoga': minor
+---
+
+Support to change `graphqlEndpoint` after the initialization;
+
+```ts
+const yoga = createYoga({
+  schema,
+  logging: false,
+  plugins: [
+    {
+      onYogaInit({ yoga }) {
+        // Inside the plugin
+        yoga.graphqlEndpoint = `/(graphql|my-custom-path)`;
+      },
+    },
+  ],
+});
+
+// Or after the initialization
+yoga.graphqlEndpoint = `/(graphql|my-custom-path)`;
+```

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -1,6 +1,6 @@
 import { OnExecuteHook } from '@envelop/core';
 import { Request } from '@whatwg-node/fetch';
-import { createSchema, createYoga, YogaInitialContext } from '../src';
+import { createGraphQLError, createSchema, createYoga, YogaInitialContext } from '../src';
 
 describe('requests', () => {
   const schema = createSchema({
@@ -551,5 +551,89 @@ describe('requests', () => {
     expect(onExecuteFn.mock.calls[1]?.[0].args.contextValue).not.toBe(
       onExecuteFn.mock.calls[0]![0].args.contextValue,
     );
+  });
+  it('allows you to change the graphql endpoint after the initialization', async () => {
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      graphqlEndpoint: '/graphql',
+      plugins: [
+        {
+          onYogaInit({ yoga }) {
+            yoga.graphqlEndpoint = '/new-endpoint';
+          },
+        },
+      ],
+    });
+    const response = await yoga.fetch('http://yoga/new-endpoint', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ ping }' }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    expect(body.data.ping).toBe('pong');
+
+    // Old endpoint should not work
+    const oldResponse = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ ping }' }),
+    });
+
+    expect(oldResponse.status).toBe(404);
+  });
+  it('allows you to extend the existing endpoint with a pattern', async () => {
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      plugins: [
+        {
+          onYogaInit({ yoga }) {
+            yoga.graphqlEndpoint = `/(graphql|mcp)`;
+          },
+          onRequestParse({ url, setRequestParser }) {
+            if (url.pathname === '/mcp') {
+              setRequestParser(async req => {
+                const body = await req.json();
+                if (body.ping === true) {
+                  return {
+                    query: '{ ping }',
+                  };
+                }
+                throw createGraphQLError('Invalid request body', {
+                  extensions: {
+                    code: 'BAD_REQUEST',
+                  },
+                });
+              });
+            }
+          },
+        },
+      ],
+    });
+    const response = await yoga.fetch('http://yoga/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ping: true }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    expect(body.data.ping).toBe('pong');
+
+    // Old endpoint should still work
+    const oldResponse = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ ping }' }),
+    });
+
+    expect(oldResponse.status).toBe(200);
+    const oldBody = await oldResponse.json();
+    expect(oldBody.errors).toBeUndefined();
+    expect(oldBody.data.ping).toBe('pong');
   });
 });

--- a/packages/graphql-yoga/src/plugins/use-graphiql.ts
+++ b/packages/graphql-yoga/src/plugins/use-graphiql.ts
@@ -2,7 +2,6 @@ import { PromiseOrValue } from '@envelop/core';
 import { YogaLogger } from '@graphql-yoga/logger';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import graphiqlHTML from '../graphiql-html.js';
-import { FetchAPI } from '../types.js';
 import { Plugin } from './types.js';
 
 export function shouldRenderGraphiQL({ headers, method }: Request): boolean {
@@ -159,6 +158,7 @@ export type GraphiQLOptionsOrFactory<TServerContext> =
 
 export interface GraphiQLPluginConfig<TServerContext> {
   getGraphQLEndpoint(): string;
+  getGraphQLEndpointURLPattern(): URLPattern;
   options?: GraphiQLOptionsOrFactory<TServerContext>;
   render?: GraphiQLRenderer;
   logger?: YogaLogger;
@@ -184,17 +184,6 @@ export function useGraphiQL<TServerContext extends Record<string, any>>(
   }
 
   const renderer = config?.render ?? renderGraphiQL;
-  let urlPattern: URLPattern;
-  let graphqlEndpointForUrlPattern: string | undefined;
-  const getUrlPattern = ({ URLPattern }: FetchAPI, graphqlEndpoint: string) => {
-    if (graphqlEndpointForUrlPattern !== graphqlEndpoint) {
-      graphqlEndpointForUrlPattern = graphqlEndpoint;
-      urlPattern = new URLPattern({
-        pathname: graphqlEndpoint,
-      });
-    }
-    return urlPattern;
-  };
   return {
     onRequest({ request, serverContext, fetchAPI, endResponse, url }) {
       const graphqlEndpoint = config.getGraphQLEndpoint();
@@ -204,7 +193,7 @@ export function useGraphiQL<TServerContext extends Record<string, any>>(
           request.url.endsWith(`${graphqlEndpoint}/`) ||
           url.pathname === graphqlEndpoint ||
           url.pathname === `${graphqlEndpoint}/` ||
-          getUrlPattern(fetchAPI, graphqlEndpoint).test(url))
+          config.getGraphQLEndpointURLPattern().test(url))
       ) {
         logger.debug(`Rendering GraphiQL`);
         return handleMaybePromise(

--- a/packages/graphql-yoga/src/plugins/use-graphiql.ts
+++ b/packages/graphql-yoga/src/plugins/use-graphiql.ts
@@ -158,7 +158,7 @@ export type GraphiQLOptionsOrFactory<TServerContext> =
   | boolean;
 
 export interface GraphiQLPluginConfig<TServerContext> {
-  graphqlEndpoint: string;
+  getGraphQLEndpoint(): string;
   options?: GraphiQLOptionsOrFactory<TServerContext>;
   render?: GraphiQLRenderer;
   logger?: YogaLogger;
@@ -185,21 +185,26 @@ export function useGraphiQL<TServerContext extends Record<string, any>>(
 
   const renderer = config?.render ?? renderGraphiQL;
   let urlPattern: URLPattern;
-  const getUrlPattern = ({ URLPattern }: FetchAPI) => {
-    urlPattern ||= new URLPattern({
-      pathname: config.graphqlEndpoint,
-    });
+  let graphqlEndpointForUrlPattern: string | undefined;
+  const getUrlPattern = ({ URLPattern }: FetchAPI, graphqlEndpoint: string) => {
+    if (graphqlEndpointForUrlPattern !== graphqlEndpoint) {
+      graphqlEndpointForUrlPattern = graphqlEndpoint;
+      urlPattern = new URLPattern({
+        pathname: graphqlEndpoint,
+      });
+    }
     return urlPattern;
   };
   return {
     onRequest({ request, serverContext, fetchAPI, endResponse, url }) {
+      const graphqlEndpoint = config.getGraphQLEndpoint();
       if (
         shouldRenderGraphiQL(request) &&
-        (request.url.endsWith(config.graphqlEndpoint) ||
-          request.url.endsWith(`${config.graphqlEndpoint}/`) ||
-          url.pathname === config.graphqlEndpoint ||
-          url.pathname === `${config.graphqlEndpoint}/` ||
-          getUrlPattern(fetchAPI).test(url))
+        (request.url.endsWith(graphqlEndpoint) ||
+          request.url.endsWith(`${graphqlEndpoint}/`) ||
+          url.pathname === graphqlEndpoint ||
+          url.pathname === `${graphqlEndpoint}/` ||
+          getUrlPattern(fetchAPI, graphqlEndpoint).test(url))
       ) {
         logger.debug(`Rendering GraphiQL`);
         return handleMaybePromise(

--- a/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
+++ b/packages/graphql-yoga/src/plugins/use-unhandled-route.ts
@@ -34,27 +34,22 @@ export const defaultRenderLandingPage: LandingPageRenderer = function defaultRen
 };
 
 export function useUnhandledRoute(args: {
-  graphqlEndpoint: string;
+  getGraphQLEndpoint(): string;
+  getGraphQLEndpointURLPattern(): URLPattern;
   landingPageRenderer?: LandingPageRenderer;
   showLandingPage: boolean;
 }): Plugin {
-  let urlPattern: URLPattern;
-  function getUrlPattern({ URLPattern }: FetchAPI) {
-    urlPattern ||= new URLPattern({
-      pathname: args.graphqlEndpoint,
-    });
-    return urlPattern;
-  }
   const landingPageRenderer: LandingPageRenderer =
     args.landingPageRenderer || defaultRenderLandingPage;
   return {
     onRequest({ request, fetchAPI, endResponse, url }): PromiseOrValue<void> {
+      const graphqlEndpoint = args.getGraphQLEndpoint();
       if (
-        !request.url.endsWith(args.graphqlEndpoint) &&
-        !request.url.endsWith(`${args.graphqlEndpoint}/`) &&
-        url.pathname !== args.graphqlEndpoint &&
-        url.pathname !== `${args.graphqlEndpoint}/` &&
-        !getUrlPattern(fetchAPI).test(url)
+        !request.url.endsWith(graphqlEndpoint) &&
+        !request.url.endsWith(`${graphqlEndpoint}/`) &&
+        url.pathname !== graphqlEndpoint &&
+        url.pathname !== `${graphqlEndpoint}/` &&
+        !args.getGraphQLEndpointURLPattern().test(url)
       ) {
         if (
           args.showLandingPage === true &&
@@ -65,9 +60,9 @@ export function useUnhandledRoute(args: {
             request,
             fetchAPI,
             url,
-            graphqlEndpoint: args.graphqlEndpoint,
+            graphqlEndpoint,
             get urlPattern() {
-              return getUrlPattern(fetchAPI);
+              return args.getGraphQLEndpointURLPattern();
             },
           });
           if (isPromise(landingPage$)) {

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -231,7 +231,7 @@ export class YogaServer<
    */
   public readonly getEnveloped: GetEnvelopedFn<TUserContext & TServerContext & YogaInitialContext>;
   public logger: YogaLogger;
-  public readonly graphqlEndpoint: string;
+  public graphqlEndpoint: string;
   public fetchAPI: FetchAPI;
   protected plugins: Array<
     Plugin<TUserContext & TServerContext & YogaInitialContext, TServerContext, TUserContext>
@@ -245,6 +245,12 @@ export class YogaServer<
   private onResultProcessHooks: OnResultProcess<TServerContext>[];
   private maskedErrorsOpts: YogaMaskedErrorOpts | null;
   private id: string;
+  private _graphqlEndpointURLPattern:
+    | {
+        graphqlEndpoint: string;
+        urlPattern: URLPattern;
+      }
+    | undefined;
 
   readonly version = '__YOGA_VERSION__';
 
@@ -311,7 +317,6 @@ export class YogaServer<
     }
 
     this.graphqlEndpoint = options?.graphqlEndpoint || '/graphql';
-    const graphqlEndpoint = this.graphqlEndpoint;
 
     this.plugins = [
       useEngine({
@@ -344,7 +349,7 @@ export class YogaServer<
       options?.cors !== false && useCORS(options?.cors),
       options?.graphiql !== false &&
         useGraphiQL({
-          graphqlEndpoint,
+          getGraphQLEndpoint: () => this.graphqlEndpoint,
           options: options?.graphiql,
           render: options?.renderGraphiQL,
           logger: this.logger,
@@ -386,7 +391,8 @@ export class YogaServer<
       useLimitBatching(batchingLimit),
       useCheckGraphQLQueryParams(options?.extraParamNames),
       useUnhandledRoute({
-        graphqlEndpoint,
+        getGraphQLEndpoint: () => this.graphqlEndpoint,
+        getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
         showLandingPage: options?.landingPage !== false,
         landingPageRenderer:
           typeof options?.landingPage === 'function' ? options.landingPage : undefined,
@@ -454,6 +460,18 @@ export class YogaServer<
         }
       }
     }
+  }
+
+  getUrlPatternForGraphQLEndpoint() {
+    if (this._graphqlEndpointURLPattern?.graphqlEndpoint !== this.graphqlEndpoint) {
+      this._graphqlEndpointURLPattern = {
+        graphqlEndpoint: this.graphqlEndpoint,
+        urlPattern: new this.fetchAPI.URLPattern({
+          pathname: this.graphqlEndpoint,
+        }),
+      };
+    }
+    return this._graphqlEndpointURLPattern.urlPattern;
   }
 
   handleParams: ParamsHandler<TServerContext> = ({ request, context, params }) => {

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -231,7 +231,6 @@ export class YogaServer<
    */
   public readonly getEnveloped: GetEnvelopedFn<TUserContext & TServerContext & YogaInitialContext>;
   public logger: YogaLogger;
-  public graphqlEndpoint: string;
   public fetchAPI: FetchAPI;
   protected plugins: Array<
     Plugin<TUserContext & TServerContext & YogaInitialContext, TServerContext, TUserContext>
@@ -245,12 +244,11 @@ export class YogaServer<
   private onResultProcessHooks: OnResultProcess<TServerContext>[];
   private maskedErrorsOpts: YogaMaskedErrorOpts | null;
   private id: string;
-  private _graphqlEndpointURLPattern:
-    | {
-        graphqlEndpoint: string;
-        urlPattern: URLPattern;
-      }
-    | undefined;
+
+  // @ts-expect-error - This is set by `this.graphqlEndpoint` setter in the constructor, but TypeScript doesn't recognize it.
+  private _graphqlEndpoint: string;
+  // @ts-expect-error - This is set by `this.graphqlEndpoint` setter in the constructor, but TypeScript doesn't recognize it.
+  private _graphqlEndpointURLPattern: URLPattern;
 
   readonly version = '__YOGA_VERSION__';
 
@@ -349,8 +347,8 @@ export class YogaServer<
       options?.cors !== false && useCORS(options?.cors),
       options?.graphiql !== false &&
         useGraphiQL({
-          getGraphQLEndpoint: () => this.graphqlEndpoint,
-          getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
+          getGraphQLEndpoint: () => this._graphqlEndpoint,
+          getGraphQLEndpointURLPattern: () => this._graphqlEndpointURLPattern,
           options: options?.graphiql,
           render: options?.renderGraphiQL,
           logger: this.logger,
@@ -393,7 +391,7 @@ export class YogaServer<
       useCheckGraphQLQueryParams(options?.extraParamNames),
       useUnhandledRoute({
         getGraphQLEndpoint: () => this.graphqlEndpoint,
-        getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
+        getGraphQLEndpointURLPattern: () => this._graphqlEndpointURLPattern,
         showLandingPage: options?.landingPage !== false,
         landingPageRenderer:
           typeof options?.landingPage === 'function' ? options.landingPage : undefined,
@@ -463,16 +461,13 @@ export class YogaServer<
     }
   }
 
-  private getUrlPatternForGraphQLEndpoint() {
-    if (this._graphqlEndpointURLPattern?.graphqlEndpoint !== this.graphqlEndpoint) {
-      this._graphqlEndpointURLPattern = {
-        graphqlEndpoint: this.graphqlEndpoint,
-        urlPattern: new this.fetchAPI.URLPattern({
-          pathname: this.graphqlEndpoint,
-        }),
-      };
-    }
-    return this._graphqlEndpointURLPattern.urlPattern;
+  get graphqlEndpoint() {
+    return this._graphqlEndpoint;
+  }
+
+  set graphqlEndpoint(endpoint: string) {
+    this._graphqlEndpoint = endpoint;
+    this._graphqlEndpointURLPattern = new this.fetchAPI.URLPattern({ pathname: endpoint });
   }
 
   handleParams: ParamsHandler<TServerContext> = ({ request, context, params }) => {

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -350,6 +350,7 @@ export class YogaServer<
       options?.graphiql !== false &&
         useGraphiQL({
           getGraphQLEndpoint: () => this.graphqlEndpoint,
+          getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
           options: options?.graphiql,
           render: options?.renderGraphiQL,
           logger: this.logger,
@@ -462,7 +463,7 @@ export class YogaServer<
     }
   }
 
-  getUrlPatternForGraphQLEndpoint() {
+  private getUrlPatternForGraphQLEndpoint() {
     if (this._graphqlEndpointURLPattern?.graphqlEndpoint !== this.graphqlEndpoint) {
       this._graphqlEndpointURLPattern = {
         graphqlEndpoint: this.graphqlEndpoint,

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -247,8 +247,7 @@ export class YogaServer<
 
   // @ts-expect-error - This is set by `this.graphqlEndpoint` setter in the constructor, but TypeScript doesn't recognize it.
   private _graphqlEndpoint: string;
-  // @ts-expect-error - This is set by `this.graphqlEndpoint` setter in the constructor, but TypeScript doesn't recognize it.
-  private _graphqlEndpointURLPattern: URLPattern;
+  private _graphqlEndpointURLPattern: URLPattern | undefined;
 
   readonly version = '__YOGA_VERSION__';
 
@@ -348,7 +347,7 @@ export class YogaServer<
       options?.graphiql !== false &&
         useGraphiQL({
           getGraphQLEndpoint: () => this._graphqlEndpoint,
-          getGraphQLEndpointURLPattern: () => this._graphqlEndpointURLPattern,
+          getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
           options: options?.graphiql,
           render: options?.renderGraphiQL,
           logger: this.logger,
@@ -391,7 +390,7 @@ export class YogaServer<
       useCheckGraphQLQueryParams(options?.extraParamNames),
       useUnhandledRoute({
         getGraphQLEndpoint: () => this.graphqlEndpoint,
-        getGraphQLEndpointURLPattern: () => this._graphqlEndpointURLPattern,
+        getGraphQLEndpointURLPattern: () => this.getUrlPatternForGraphQLEndpoint(),
         showLandingPage: options?.landingPage !== false,
         landingPageRenderer:
           typeof options?.landingPage === 'function' ? options.landingPage : undefined,
@@ -467,7 +466,14 @@ export class YogaServer<
 
   set graphqlEndpoint(endpoint: string) {
     this._graphqlEndpoint = endpoint;
-    this._graphqlEndpointURLPattern = new this.fetchAPI.URLPattern({ pathname: endpoint });
+    this._graphqlEndpointURLPattern = undefined;
+  }
+
+  private getUrlPatternForGraphQLEndpoint() {
+    this._graphqlEndpointURLPattern ??= new this.fetchAPI.URLPattern({
+        pathname: this._graphqlEndpoint,
+      });
+    return this._graphqlEndpointURLPattern;
   }
 
   handleParams: ParamsHandler<TServerContext> = ({ request, context, params }) => {

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -471,8 +471,8 @@ export class YogaServer<
 
   private getUrlPatternForGraphQLEndpoint() {
     this._graphqlEndpointURLPattern ??= new this.fetchAPI.URLPattern({
-        pathname: this._graphqlEndpoint,
-      });
+      pathname: this._graphqlEndpoint,
+    });
     return this._graphqlEndpointURLPattern;
   }
 


### PR DESCRIPTION
Support to change `graphqlEndpoint` after the initialization;

```ts
const yoga = createYoga({
  schema,
  logging: false,
  plugins: [
    {
      onYogaInit({ yoga }) {
        // Inside the plugin
        yoga.graphqlEndpoint = `/(graphql|my-custom-path)`;
      },
    },
  ],
});

// Or after the initialization
yoga.graphqlEndpoint = `/(graphql|my-custom-path)`;
```