### PR TITLE
feat(onRequestParse): short-circuit `Response`

### DIFF
--- a/.changeset/eager-monkeys-play.md
+++ b/.changeset/eager-monkeys-play.md
@@ -1,0 +1,33 @@
+---
+'graphql-yoga': minor
+---
+
+Short-circuit response in `onRequestParse` hook
+
+In the `onRequestParse` hook, if a response is sent using `endResponse`, we should short-circuit the request parsing and return that response immediately. This allows users to handle certain requests entirely within the `onRequestParse` hook without needing to go through the rest of the request processing pipeline.
+
+```ts
+const plugin = {
+  onRequestParse({ endResponse }) {
+    if (/* some condition */) {
+      endResponse(new Response('Short-circuited response'));
+    }
+  },
+};
+```
+
+Or you can also short-circuit the response inside the request parser:
+
+```ts
+const plugin = {
+  onRequestParse({ setRequestParser }) {
+    setRequestParser(req => {
+        if (req.url === '/short-circuit') {
+          return new Response('Short-circuited response');
+        }
+        // Otherwise, return the parsed parameters as usual
+        return parseRequestNormally(req);
+    });
+  },
+};
+```

--- a/packages/graphql-yoga/__tests__/requests.spec.ts
+++ b/packages/graphql-yoga/__tests__/requests.spec.ts
@@ -636,4 +636,52 @@ describe('requests', () => {
     expect(oldBody.errors).toBeUndefined();
     expect(oldBody.data.ping).toBe('pong');
   });
+  it('allows you to short-circuit response inside `onRequestParse` hook', async () => {
+    const shortCircuitResponse = new Response('Short-circuited response', {
+      status: 418,
+    });
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      plugins: [
+        {
+          onRequestParse({ endResponse }) {
+            endResponse(shortCircuitResponse);
+          },
+        },
+      ],
+    });
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ ping }' }),
+    });
+
+    expect(response).toBe(shortCircuitResponse);
+  });
+  it('allows you to short-circuit inside the request parser', async () => {
+    const shortCircuitResponse = new Response('Short-circuited response', {
+      status: 418,
+    });
+    const yoga = createYoga({
+      schema,
+      logging: false,
+      plugins: [
+        {
+          onRequestParse({ setRequestParser }) {
+            setRequestParser(() => {
+              return shortCircuitResponse;
+            });
+          },
+        },
+      ],
+    });
+    const response = await yoga.fetch('http://yoga/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ ping }' }),
+    });
+
+    expect(response).toBe(shortCircuitResponse);
+  });
 });

--- a/packages/graphql-yoga/src/plugins/types.ts
+++ b/packages/graphql-yoga/src/plugins/types.ts
@@ -123,7 +123,7 @@ export type OnRequestParseHook<TServerContext> = (
 
 export type RequestParser = (
   request: Request,
-) => PromiseOrValue<GraphQLParams> | PromiseOrValue<GraphQLParams[]>;
+) => PromiseOrValue<GraphQLParams | GraphQLParams[] | Response>;
 
 export interface OnRequestParseEventPayload<TServerContext> {
   request: Request;
@@ -131,6 +131,8 @@ export interface OnRequestParseEventPayload<TServerContext> {
   requestParser: RequestParser | undefined;
   serverContext: TServerContext & ServerAdapterInitialContext;
   setRequestParser: (parser: RequestParser) => void;
+  fetchAPI: FetchAPI;
+  endResponse: (response: Response) => void;
 }
 
 export type OnRequestParseHookResult = {

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -598,12 +598,12 @@ export class YogaServer<
     serverContext: TServerContext & ServerAdapterInitialContext,
   ): MaybePromise<
     | {
-        parsedParams:
+        requestParserResult:
           | GraphQLParams<Record<string, any>, Record<string, any>>
           | GraphQLParams<Record<string, any>, Record<string, any>>[];
         response?: never;
       }
-    | { parsedParams?: never; response: Response }
+    | { requestParserResult?: never; response: Response }
   > => {
     let url = new Proxy({} as URL, {
       get: (_target, prop, _receiver) => {
@@ -659,25 +659,25 @@ export class YogaServer<
 
         return handleMaybePromise(
           () => requestParser!(request),
-          requestParserResult => {
-            if (isResponse(requestParserResult)) {
+          requestParserFnResult => {
+            if (isResponse(requestParserFnResult)) {
               return {
-                response: requestParserResult,
+                response: requestParserFnResult,
               };
             }
-            const parsedParams = requestParserResult;
+            let requestParserResult = requestParserFnResult;
             return handleMaybePromise(
               () =>
                 iterateAsyncVoid(onRequestParseDoneList, onRequestParseDone =>
                   onRequestParseDone({
-                    requestParserResult: parsedParams,
+                    requestParserResult,
                     setRequestParserResult(newParams: GraphQLParams | GraphQLParams[]) {
                       requestParserResult = newParams;
                     },
                   }),
                 ),
               () => ({
-                parsedParams,
+                requestParserResult,
               }),
             );
           },
@@ -699,7 +699,7 @@ export class YogaServer<
     return unfakePromise(
       fakePromise()
         .then(() => parseRequest(request, serverContext))
-        .then(({ response, parsedParams }) => {
+        .then(({ response, requestParserResult }) => {
           if (response) {
             return response;
           }
@@ -715,9 +715,9 @@ export class YogaServer<
             : this.getResultForParams;
           return handleMaybePromise(
             () =>
-              (Array.isArray(parsedParams)
+              (Array.isArray(requestParserResult)
                 ? Promise.all(
-                    parsedParams.map(params =>
+                    requestParserResult.map(params =>
                       fakePromise()
                         .then(() =>
                           getResultForParams(
@@ -740,7 +740,7 @@ export class YogaServer<
                   )
                 : getResultForParams(
                     {
-                      params: parsedParams,
+                      params: requestParserResult,
                       request,
                     },
                     serverContext,

--- a/packages/graphql-yoga/src/server.ts
+++ b/packages/graphql-yoga/src/server.ts
@@ -82,6 +82,7 @@ import {
   YogaInitialContext,
   YogaMaskedErrorOpts,
 } from './types.js';
+import { isResponse } from './utils/is-response.js';
 import { maskError } from './utils/mask-error.js';
 
 /**
@@ -597,12 +598,12 @@ export class YogaServer<
     serverContext: TServerContext & ServerAdapterInitialContext,
   ): MaybePromise<
     | {
-        requestParserResult:
+        parsedParams:
           | GraphQLParams<Record<string, any>, Record<string, any>>
           | GraphQLParams<Record<string, any>, Record<string, any>>[];
         response?: never;
       }
-    | { requestParserResult?: never; response: Response }
+    | { parsedParams?: never; response: Response }
   > => {
     let url = new Proxy({} as URL, {
       get: (_target, prop, _receiver) => {
@@ -612,13 +613,14 @@ export class YogaServer<
     }) as URL;
 
     let requestParser: RequestParser | undefined;
+    let response: Response | undefined;
     const onRequestParseDoneList: OnRequestParseDoneHook[] = [];
 
     return handleMaybePromise(
       () =>
         iterateAsync(
           this.onRequestParseHooks,
-          onRequestParse =>
+          (onRequestParse, endEarly) =>
             handleMaybePromise(
               () =>
                 onRequestParse({
@@ -629,12 +631,21 @@ export class YogaServer<
                   setRequestParser(parser: RequestParser) {
                     requestParser = parser;
                   },
+                  // Short-circuit the request parsing if a response is sent in `onRequestParse`
+                  endResponse(res) {
+                    response = res;
+                    endEarly();
+                  },
+                  fetchAPI: this.fetchAPI,
                 }),
               requestParseHookResult => requestParseHookResult?.onRequestParseDone,
             ),
           onRequestParseDoneList,
         ),
       () => {
+        if (response) {
+          return { response };
+        }
         this.logger.debug(`Parsing request to extract GraphQL parameters`);
 
         if (!requestParser) {
@@ -649,18 +660,24 @@ export class YogaServer<
         return handleMaybePromise(
           () => requestParser!(request),
           requestParserResult => {
+            if (isResponse(requestParserResult)) {
+              return {
+                response: requestParserResult,
+              };
+            }
+            const parsedParams = requestParserResult;
             return handleMaybePromise(
               () =>
                 iterateAsyncVoid(onRequestParseDoneList, onRequestParseDone =>
                   onRequestParseDone({
-                    requestParserResult,
+                    requestParserResult: parsedParams,
                     setRequestParserResult(newParams: GraphQLParams | GraphQLParams[]) {
                       requestParserResult = newParams;
                     },
                   }),
                 ),
               () => ({
-                requestParserResult,
+                parsedParams,
               }),
             );
           },
@@ -682,7 +699,7 @@ export class YogaServer<
     return unfakePromise(
       fakePromise()
         .then(() => parseRequest(request, serverContext))
-        .then(({ response, requestParserResult }) => {
+        .then(({ response, parsedParams }) => {
           if (response) {
             return response;
           }
@@ -698,9 +715,9 @@ export class YogaServer<
             : this.getResultForParams;
           return handleMaybePromise(
             () =>
-              (Array.isArray(requestParserResult)
+              (Array.isArray(parsedParams)
                 ? Promise.all(
-                    requestParserResult.map(params =>
+                    parsedParams.map(params =>
                       fakePromise()
                         .then(() =>
                           getResultForParams(
@@ -723,7 +740,7 @@ export class YogaServer<
                   )
                 : getResultForParams(
                     {
-                      params: requestParserResult,
+                      params: parsedParams,
                       request,
                     },
                     serverContext,

--- a/packages/graphql-yoga/src/utils/is-response.ts
+++ b/packages/graphql-yoga/src/utils/is-response.ts
@@ -1,0 +1,4 @@
+export function isResponse(value: unknown): value is Response {
+  // @ts-expect-error - we want to check if it is a Response
+  return value?.status && value?.headers;
+}


### PR DESCRIPTION
Short-circuit response in `onRequestParse` hook

In the `onRequestParse` hook, if a response is sent using `endResponse`, we should short-circuit the request parsing and return that response immediately. This allows users to handle certain requests entirely within the `onRequestParse` hook without needing to go through the rest of the request processing pipeline.

```ts
const plugin = {
  onRequestParse({ endResponse }) {
    if (/* some condition */) {
      endResponse(new Response('Short-circuited response'));
    }
  },
};
```

Or you can also short-circuit the response inside the request parser:

```ts
const plugin = {
  onRequestParse({ setRequestParser }) {
    setRequestParser(req => {
        if (req.url === '/short-circuit') {
          return new Response('Short-circuited response');
        }
        // Otherwise, return the parsed parameters as usual
        return parseRequestNormally(req);
    });
  },
};
```